### PR TITLE
Add RDF/XML export plugin

### DIFF
--- a/docs/aicode/codex-report-20250915T173416Z.md
+++ b/docs/aicode/codex-report-20250915T173416Z.md
@@ -1,0 +1,51 @@
+# AI Code Report — 2025-09-15T17:34:16Z
+
+## Objective
+Create a proof-of-concept Draw.io plugin that exposes an RDF/XML export option,
+register it so the editor can load it like built-in plugins, describe how to use
+it, and document the engineering work.
+
+## Repository analysis
+* Located the plugin infrastructure under `src/main/webapp/plugins/` and reviewed
+  existing samples (`svgdata.js`, `tags.js`, `anonymize.js`) to understand how
+  actions are registered and menus are extended.
+* Inspected `App.js` and `app.min.js` to learn how plugins are registered and
+  exposed to the plug-in dialog via `App.pluginRegistry` and
+  `App.publicPlugin`.
+* Confirmed that production builds rely on the minified bundle by reading
+  `index.html`, which meant registry updates had to land in both the source and
+  minified versions.
+
+## Implementation summary
+1. **New plugin file** — Added `src/main/webapp/plugins/rdfexport.js` that
+   registers an `exportRdfXml` action. The plugin:
+   * Builds a new DOM document rooted at `<rdf:RDF>` with both the RDF and
+     `example` namespaces declared.
+   * Clones the editor's `<mxGraphModel>` tree using `createElementNS` so each
+     element becomes an `example:*` node while all attributes/text nodes are
+     preserved.
+   * Wraps the cloned tree inside `<example:Diagram>` tagged with
+     `rdf:about="urn:diagram:{pageId}"` and a human-readable title element.
+   * Hooks into the **File → Export as** menu to surface the new action and uses
+     `editorUi.saveData` to produce a `.rdf` download with MIME type
+     `application/rdf+xml`.
+2. **Registry updates** — Extended `App.pluginRegistry` / `App.publicPlugin` in
+   both `App.js` and `app.min.js` with the `rdf` identifier so the plugin can be
+   loaded via `?p=rdf` and appears in the plugin manager.
+3. **User documentation** — Authored
+   `docs/plugins/rdfexport/README.md` describing how to enable the plugin (URL
+   parameter or plugin dialog) and what the exporter produces.
+4. **Engineering log** — Recorded these steps in this report for future
+   reference.
+
+## Testing
+* No automated test harness exists in this repository (no `package.json` or
+  documented build scripts). The changes are isolated to a plugin and related
+  documentation, so no commands were executed. Manual verification guidance is
+  captured in the README.
+
+## Follow-up ideas
+* Expand the exporter to cover multi-page diagrams and embed richer RDF
+  semantics instead of the current namespace-only clone.
+* Add a round-trip smoke test that ensures the plugin action generates valid XML
+  by parsing it before download when running in development mode.

--- a/docs/aicode/codex-report-20250915T173416Z.md
+++ b/docs/aicode/codex-report-20250915T173416Z.md
@@ -23,7 +23,8 @@ it, and document the engineering work.
      `example` namespaces declared.
    * Clones the editor's `<mxGraphModel>` tree using `createElementNS` so each
      element becomes an `example:*` node while all attributes/text nodes are
-     preserved.
+     preserved, using the element returned by `editorUi.editor.getGraphXml()`
+     directly to avoid dropping the model from the export.
    * Wraps the cloned tree inside `<example:Diagram>` tagged with
      `rdf:about="urn:diagram:{pageId}"` and a human-readable title element.
    * Hooks into the **File → Export as** menu to surface the new action and uses

--- a/docs/plugins/rdfexport/README.md
+++ b/docs/plugins/rdfexport/README.md
@@ -1,0 +1,34 @@
+# RDF/XML Export Plugin
+
+The RDF/XML export plugin adds a proof-of-concept exporter that serializes the
+current diagram to a lightweight RDF/XML document where every Draw.io element is
+copied into the `example` namespace.
+
+## Enabling the plugin
+
+You can load the plugin in any Draw.io build that includes this repository:
+
+* **URL parameter** – append `?p=rdf` (or add `&p=rdf` to an existing query) to
+the editor URL. Reload the editor to load the plugin immediately.
+* **Plugins dialog** – open **Extras → Plugins…**, choose **Add**, enter `rdf`,
+and confirm. The plugin becomes active after reloading the editor.
+
+## Exporting to RDF/XML
+
+Once the plugin is active, a new entry **File → Export as → Export as RDF/XML…**
+appears. Selecting it immediately downloads a `.rdf` file. The file name is
+based on the current diagram name.
+
+## Output characteristics
+
+* The RDF/XML document declares the namespaces `rdf` and `example`.
+* A root `<example:Diagram>` element is created for the current page with a
+  stable `rdf:about` identifier (`urn:diagram:{pageId}`).
+* The existing Draw.io `<mxGraphModel>` tree is cloned under the
+  `<example:Diagram>` node, but every element is recreated in the `example`
+  namespace. Attribute names and values are preserved verbatim.
+* The exporter intentionally avoids using additional RDF tooling so that the
+  plugin remains small and dependency free.
+
+Because this exporter is intentionally blunt, the resulting document is a good
+starting point for experimentation rather than a production-ready serialization.

--- a/docs/plugins/rdfexport/README.md
+++ b/docs/plugins/rdfexport/README.md
@@ -24,9 +24,11 @@ based on the current diagram name.
 * The RDF/XML document declares the namespaces `rdf` and `example`.
 * A root `<example:Diagram>` element is created for the current page with a
   stable `rdf:about` identifier (`urn:diagram:{pageId}`).
-* The existing Draw.io `<mxGraphModel>` tree is cloned under the
-  `<example:Diagram>` node, but every element is recreated in the `example`
-  namespace. Attribute names and values are preserved verbatim.
+* The existing Draw.io `<mxGraphModel>` tree returned by
+  `editorUi.editor.getGraphXml()` is cloned under the `<example:Diagram>` node,
+  ensuring the entire diagram structure is included while recreating each
+  element in the `example` namespace. Attribute names and values are preserved
+  verbatim.
 * The exporter intentionally avoids using additional RDF tooling so that the
   plugin remains small and dependency free.
 

--- a/src/main/webapp/js/diagramly/App.js
+++ b/src/main/webapp/js/diagramly/App.js
@@ -332,7 +332,7 @@ App.pluginRegistry = {'4xAKTrabTpTzahoLthkwPNUn': 'plugins/explore.js',
 	'tr': 'plugins/trello.js', 'f5': 'plugins/rackF5.js',
 	'webcola': 'plugins/webcola/webcola.js', 'rnd': 'plugins/random.js',
 	'page': 'plugins/page.js', 'gd': 'plugins/googledrive.js',
-	'tags': 'plugins/tags.js'};
+	'rdf': 'plugins/rdfexport.js', 'tags': 'plugins/tags.js'};
 
 App.publicPlugin = [
 	'ex',
@@ -350,6 +350,7 @@ App.publicPlugin = [
 	'anon',
 	'webcola',
 //	'rnd', 'page', 'gd',
+	'rdf',
 	'tags'
 ];
 

--- a/src/main/webapp/plugins/rdfexport.js
+++ b/src/main/webapp/plugins/rdfexport.js
@@ -1,0 +1,132 @@
+/**
+ * RDF/XML export plugin.
+ */
+Draw.loadPlugin(function(editorUi)
+{
+        var EXAMPLE_NS = 'http://example.com/ns#';
+        var RDF_NS = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+
+        function cloneWithExampleNamespace(node, doc)
+        {
+                if (node == null)
+                {
+                        return null;
+                }
+
+                if (node.nodeType == mxConstants.NODETYPE_ELEMENT)
+                {
+                        var localName = node.localName || node.nodeName;
+
+                        if (localName.indexOf(':') >= 0)
+                        {
+                                localName = localName.substring(localName.indexOf(':') + 1);
+                        }
+
+                        var element = doc.createElementNS(EXAMPLE_NS, 'example:' + localName);
+
+                        if (node.attributes != null)
+                        {
+                                for (var i = 0; i < node.attributes.length; i++)
+                                {
+                                        var attr = node.attributes[i];
+
+                                        if (attr != null)
+                                        {
+                                                if (attr.prefix != null && attr.prefix.length > 0)
+                                                {
+                                                        element.setAttributeNS(attr.namespaceURI, attr.name, attr.value);
+                                                }
+                                                else
+                                                {
+                                                        element.setAttribute(attr.name, attr.value);
+                                                }
+                                        }
+                                }
+                        }
+
+                        var child = node.firstChild;
+
+                        while (child != null)
+                        {
+                                var childClone = cloneWithExampleNamespace(child, doc);
+
+                                if (childClone != null)
+                                {
+                                        element.appendChild(childClone);
+                                }
+
+                                child = child.nextSibling;
+                        }
+
+                        return element;
+                }
+                else if (node.nodeType == mxConstants.NODETYPE_TEXT)
+                {
+                        return doc.createTextNode(node.nodeValue);
+                }
+                else if (node.nodeType == mxConstants.NODETYPE_CDATA)
+                {
+                        return doc.createCDATASection(node.nodeValue);
+                }
+
+                return null;
+        };
+
+        function createRdfXml(editorUi)
+        {
+                var graphXml = editorUi.editor.getGraphXml();
+                var doc = mxUtils.createXmlDocument();
+                var rdfRoot = doc.createElementNS(RDF_NS, 'rdf:RDF');
+                rdfRoot.setAttribute('xmlns:rdf', RDF_NS);
+                rdfRoot.setAttribute('xmlns:example', EXAMPLE_NS);
+                doc.appendChild(rdfRoot);
+
+                var diagramElement = doc.createElementNS(EXAMPLE_NS, 'example:Diagram');
+                var pageId = (editorUi.currentPage != null && typeof editorUi.currentPage.getId === 'function') ?
+                        editorUi.currentPage.getId() : 'diagram';
+                diagramElement.setAttributeNS(RDF_NS, 'rdf:about', 'urn:diagram:' + pageId);
+                rdfRoot.appendChild(diagramElement);
+
+                var titleElement = doc.createElementNS(EXAMPLE_NS, 'example:Title');
+                titleElement.appendChild(doc.createTextNode(editorUi.getBaseFilename(true)));
+                diagramElement.appendChild(titleElement);
+
+                var modelElement = cloneWithExampleNamespace(graphXml.documentElement, doc);
+
+                if (modelElement != null)
+                {
+                        diagramElement.appendChild(modelElement);
+                }
+
+                return mxUtils.getPrettyXml(doc);
+        };
+
+        mxResources.parse('exportRdfXml=Export as RDF/XML...');
+
+        editorUi.actions.addAction('exportRdfXml', function()
+        {
+                try
+                {
+                        var rdf = createRdfXml(editorUi);
+                        var filename = editorUi.getBaseFilename() + '.rdf';
+                        editorUi.saveData(filename, 'rdf', rdf, 'application/rdf+xml');
+                }
+                catch (e)
+                {
+                        editorUi.handleError(e);
+                }
+        });
+
+        var exportMenu = editorUi.menus.get('exportAs');
+
+        if (exportMenu != null)
+        {
+                var oldFunct = exportMenu.funct;
+
+                exportMenu.funct = function(menu, parent)
+                {
+                        oldFunct.apply(this, arguments);
+                        editorUi.menus.addMenuItems(menu, ['-', 'exportRdfXml'], parent);
+                };
+        }
+});

--- a/src/main/webapp/plugins/rdfexport.js
+++ b/src/main/webapp/plugins/rdfexport.js
@@ -91,7 +91,7 @@ Draw.loadPlugin(function(editorUi)
                 titleElement.appendChild(doc.createTextNode(editorUi.getBaseFilename(true)));
                 diagramElement.appendChild(titleElement);
 
-                var modelElement = cloneWithExampleNamespace(graphXml.documentElement, doc);
+                var modelElement = cloneWithExampleNamespace(graphXml, doc);
 
                 if (modelElement != null)
                 {


### PR DESCRIPTION
## Summary
- add an rdfexport plugin that clones the current mxGraphModel into the example namespace and downloads it as RDF/XML
- register the plugin id in both App.js and the minified bundle so it can be loaded via ?p=rdf or the Plugins dialog
- document usage in a dedicated README and capture the implementation notes in a codex report

## Testing
- not run (no automated test harness present)


------
https://chatgpt.com/codex/tasks/task_e_68c84d0912a4832d90d8491972ebba29