### PR TITLE
Restore RDF export checksum regression coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,16 @@ Contributor Guidelines
 
 Task Status Summary
 
-{placeholder}
+Task 1 – DrawIO Black Box Integration: ✅ Completed on 2025-10-08 by gpt-5-codex
+Task 2 – Extend DrawIO Parser (stdin → rdflib Graph): ⏳ Not started
+Task 3 – Expose and Extend map_schema Functions for Testing and DrawIO Integration: ⏳ Not started
+Task 4 – Browser Execution Pipeline (Pyodide Integration): ⏳ Not started
 
 ⸻
 
 Task 1 – DrawIO Black Box Integration
+
+Status: ✅ Completed on 2025-10-08 by gpt-5-codex
 
 Goal
 Enhance the DrawIO save flow so that, after XML serialization, the serialized XML is passed through a mock black box function that returns an arbitrary string, which is then saved using the existing RDF/XML save logic.

--- a/docs/aicode/gpt-5-codex-report-20251008T180943Z.md
+++ b/docs/aicode/gpt-5-codex-report-20251008T180943Z.md
@@ -1,0 +1,32 @@
+# Task 1 – DrawIO Black Box Integration Report
+
+## Author
+- **Agent:** gpt-5-codex
+- **Date (UTC):** 2025-10-08T18:09:43Z
+
+## Objective
+Implement the initial mock "black box" stage in the DrawIO RDF export workflow so that the serialized diagram XML is routed through the mock transformer before invoking the existing RDF/XML save logic. Maintain backward compatibility and extend the Bun-based test suite to cover the new behavior.
+
+## Work Summary
+1. **Black box scaffolding in the plugin source**
+   - Added exported helper `runMockBlackBox` that prepends/annotates the serialized XML with deterministic metadata (`[BLACKBOX] len=<n>` ... `[/BLACKBOX]`).
+   - Updated the `exportRdfXml` action flow to pass the serialized RDF/XML through the mock black box result before calling `editorUi.saveData`.
+2. **Test coverage enhancements**
+   - Introduced a dedicated unit test that asserts the black box output format and guarantees the original payload is preserved within the annotated string.
+   - Adapted the existing integration/E2E fixture loop to validate that saved exports now match the annotated black box output derived from the legacy golden RDF fixtures.
+   - Ensured the preamble/UI regression test loads the module via the helper and validates the black box helper remains accessible.
+3. **Build artifacts**
+   - Rebuilt `src/main/webapp/plugins/rdfexport.js` via `bun run build` to keep the bundled plugin in sync with the TypeScript source.
+4. **Repository coordination**
+   - Updated `AGENTS.md` task summary/status for Task 1 and noted the completion metadata.
+
+## Testing
+- `bun test` (from `src/main/webapp/plugins/rdfexport`) – verifies unit, integration, and regression coverage for the updated pipeline.
+
+## Follow-up Recommendations
+- Future Pyodide integration work should reuse `runMockBlackBox` as the hook point for bridging to the Python runtime; keep the exported helper stable or offer a wrapper to minimize churn in existing tests.
+- When introducing real transformations, preserve deterministic annotations for testing or expose instrumentation hooks so Bun tests can continue verifying the saved payload without brittle string comparisons.
+
+## 2025-10-08T19:42Z Update
+- Restored the MD5-based fixture verification in the Bun integration loop so every exported payload is compared against the golden RDF fixtures using the historical checksum workflow.
+- Added standalone assertions for the mock black box helper without weakening the regression harness, ensuring the annotated payload remains deterministic while the legacy hash guard stays in place.

--- a/src/main/webapp/plugins/rdfexport.js
+++ b/src/main/webapp/plugins/rdfexport.js
@@ -1,3 +1,13 @@
+// src/mockBlackBox.ts
+var BLACK_BOX_PREFIX = "[BLACKBOX]";
+var BLACK_BOX_SUFFIX = "[/BLACKBOX]";
+function runMockBlackBox(serializedXml) {
+  const lengthLabel = serializedXml.length.toString(10);
+  return `${BLACK_BOX_PREFIX} len=${lengthLabel}
+${serializedXml}
+${BLACK_BOX_SUFFIX}`;
+}
+
 // src/rdfexport.ts
 var CSV_PATH_ATTRIBUTE = "csvPath";
 var BASE_URI_ATTRIBUTE = "baseUri";
@@ -20,14 +30,6 @@ var DEFAULT_ADD_PREFIX_LABEL = "Add Prefix";
 var PREAMBLE_ENTRY_TAG = "userObjectPreambleElement";
 var PREAMBLE_PREFIX_ATTRIBUTE = "rdfPrefix";
 var PREAMBLE_IRI_ATTRIBUTE = "rdfIRI";
-var BLACK_BOX_PREFIX = "[BLACKBOX]";
-var BLACK_BOX_SUFFIX = "[/BLACKBOX]";
-function runMockBlackBox(serializedXml) {
-  const lengthLabel = serializedXml.length.toString(10);
-  return `${BLACK_BOX_PREFIX} len=${lengthLabel}
-${serializedXml}
-${BLACK_BOX_SUFFIX}`;
-}
 var csvPropertyPatched = false;
 var registeredResourceKeys = new Set;
 function registerResource(key, fallback) {
@@ -860,6 +862,3 @@ Draw.loadPlugin(function(editorUi) {
     };
   }
 });
-export {
-  runMockBlackBox
-};

--- a/src/main/webapp/plugins/rdfexport.js
+++ b/src/main/webapp/plugins/rdfexport.js
@@ -20,6 +20,14 @@ var DEFAULT_ADD_PREFIX_LABEL = "Add Prefix";
 var PREAMBLE_ENTRY_TAG = "userObjectPreambleElement";
 var PREAMBLE_PREFIX_ATTRIBUTE = "rdfPrefix";
 var PREAMBLE_IRI_ATTRIBUTE = "rdfIRI";
+var BLACK_BOX_PREFIX = "[BLACKBOX]";
+var BLACK_BOX_SUFFIX = "[/BLACKBOX]";
+function runMockBlackBox(serializedXml) {
+  const lengthLabel = serializedXml.length.toString(10);
+  return `${BLACK_BOX_PREFIX} len=${lengthLabel}
+${serializedXml}
+${BLACK_BOX_SUFFIX}`;
+}
 var csvPropertyPatched = false;
 var registeredResourceKeys = new Set;
 function registerResource(key, fallback) {
@@ -835,9 +843,10 @@ Draw.loadPlugin(function(editorUi) {
   mxResources.parse("exportRdfXml=GBAD: Export as RDF/XML...");
   editorUi.actions.addAction("exportRdfXml", function() {
     try {
-      const rdf = createRdfXml(editorUi);
+      const serializedRdf = createRdfXml(editorUi);
+      const blackBoxPayload = runMockBlackBox(serializedRdf);
       const filename = editorUi.getBaseFilename() + ".rdf";
-      editorUi.saveData(filename, "rdf", rdf, "application/rdf+xml");
+      editorUi.saveData(filename, "rdf", blackBoxPayload, "application/rdf+xml");
     } catch (e) {
       editorUi.handleError(e);
     }
@@ -851,3 +860,6 @@ Draw.loadPlugin(function(editorUi) {
     };
   }
 });
+export {
+  runMockBlackBox
+};

--- a/src/main/webapp/plugins/rdfexport/src/mockBlackBox.ts
+++ b/src/main/webapp/plugins/rdfexport/src/mockBlackBox.ts
@@ -1,0 +1,6 @@
+const BLACK_BOX_PREFIX = "[BLACKBOX]";
+const BLACK_BOX_SUFFIX = "[/BLACKBOX]";
+export function runMockBlackBox(serializedXml: string): string {
+  const lengthLabel = serializedXml.length.toString(10);
+  return `${BLACK_BOX_PREFIX} len=${lengthLabel}\n${serializedXml}\n${BLACK_BOX_SUFFIX}`;
+}

--- a/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
+++ b/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
@@ -134,13 +134,7 @@ const PREAMBLE_ENTRY_TAG = "userObjectPreambleElement";
 const PREAMBLE_PREFIX_ATTRIBUTE = "rdfPrefix";
 const PREAMBLE_IRI_ATTRIBUTE = "rdfIRI";
 
-const BLACK_BOX_PREFIX = "[BLACKBOX]";
-const BLACK_BOX_SUFFIX = "[/BLACKBOX]";
-
-export function runMockBlackBox(serializedXml: string): string {
-  const lengthLabel = serializedXml.length.toString(10);
-  return `${BLACK_BOX_PREFIX} len=${lengthLabel}\n${serializedXml}\n${BLACK_BOX_SUFFIX}`;
-}
+import { runMockBlackBox } from './mockBlackBox';
 
 let csvPropertyPatched = false;
 const registeredResourceKeys = new Set<string>();

--- a/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
+++ b/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
@@ -134,6 +134,14 @@ const PREAMBLE_ENTRY_TAG = "userObjectPreambleElement";
 const PREAMBLE_PREFIX_ATTRIBUTE = "rdfPrefix";
 const PREAMBLE_IRI_ATTRIBUTE = "rdfIRI";
 
+const BLACK_BOX_PREFIX = "[BLACKBOX]";
+const BLACK_BOX_SUFFIX = "[/BLACKBOX]";
+
+export function runMockBlackBox(serializedXml: string): string {
+  const lengthLabel = serializedXml.length.toString(10);
+  return `${BLACK_BOX_PREFIX} len=${lengthLabel}\n${serializedXml}\n${BLACK_BOX_SUFFIX}`;
+}
+
 let csvPropertyPatched = false;
 const registeredResourceKeys = new Set<string>();
 
@@ -1327,9 +1335,15 @@ Draw.loadPlugin(function (editorUi: any): void {
 
   editorUi.actions.addAction("exportRdfXml", function (): void {
     try {
-      const rdf = createRdfXml(editorUi);
+      const serializedRdf = createRdfXml(editorUi);
+      const blackBoxPayload = runMockBlackBox(serializedRdf);
       const filename = editorUi.getBaseFilename() + ".rdf";
-      editorUi.saveData(filename, "rdf", rdf, "application/rdf+xml");
+      editorUi.saveData(
+        filename,
+        "rdf",
+        blackBoxPayload,
+        "application/rdf+xml",
+      );
     } catch (e) {
       editorUi.handleError(e as Error);
     }

--- a/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
+++ b/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
@@ -27,6 +27,7 @@ async function loadPluginModule(): Promise<RdfExportModule> {
   loadedPluginModule = (await import(rdfexportUrl)) as RdfExportModule;
   return loadedPluginModule;
 }
+import { runMockBlackBox } from '../src/mockBlackBox';
 
 type EventHandler = (event: any) => void;
 
@@ -726,7 +727,7 @@ const resourceBundle: Record<string, string> = {};
 test("runMockBlackBox annotates serialized XML", async () => {
   const pluginModule = await loadPluginModule();
   const sample = "<rdf/>";
-  const output = pluginModule.runMockBlackBox(sample);
+  const output = runMockBlackBox(sample);
 
   expect(output.startsWith("[BLACKBOX] len=")).toBe(true);
   expect(output).toContain(sample);
@@ -844,7 +845,7 @@ function runRdfExportTest(fixtureFile: string, sampleFile: string) {
     expect(exportMenuItems).toContainEqual(["-", "exportRdfXml"]);
 
     const referenceRdf = readFileSync(join(fixturesDir, sampleFile), "utf-8");
-    const expected = pluginModule.runMockBlackBox(referenceRdf);
+    const expected = runMockBlackBox(referenceRdf);
 
     const md5 = createHash("md5").update(data).digest("hex");
     const refMd5 = createHash("md5").update(expected).digest("hex");
@@ -1176,7 +1177,7 @@ test(
   }
   expect(model.listenerCount()).toBe(0);
 
-  expect(pluginModule.runMockBlackBox("test").startsWith("[BLACKBOX]"))
+  expect(runMockBlackBox("test").startsWith("[BLACKBOX]"))
     .toBe(true);
   },
 );

--- a/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
+++ b/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
@@ -15,6 +15,19 @@ const fixturesDir = fileURLToPath(new URL("./fixtures", import.meta.url));
 
 const pluginCallbacks: Array<(ui: any) => void> = [];
 
+type RdfExportModule = typeof import("../src/rdfexport");
+
+let loadedPluginModule: RdfExportModule | null = null;
+
+async function loadPluginModule(): Promise<RdfExportModule> {
+  if (loadedPluginModule) {
+    return loadedPluginModule;
+  }
+
+  loadedPluginModule = (await import(rdfexportUrl)) as RdfExportModule;
+  return loadedPluginModule;
+}
+
 type EventHandler = (event: any) => void;
 
 class ElementStub {
@@ -710,6 +723,17 @@ const resourceBundle: Record<string, string> = {};
   },
 };
 
+test("runMockBlackBox annotates serialized XML", async () => {
+  const pluginModule = await loadPluginModule();
+  const sample = "<rdf/>";
+  const output = pluginModule.runMockBlackBox(sample);
+
+  expect(output.startsWith("[BLACKBOX] len=")).toBe(true);
+  expect(output).toContain(sample);
+  expect(output.trim().endsWith("[/BLACKBOX]"))
+    .toBe(true);
+});
+
 test("compiled rdfexport plugin bundle includes CSV property hook", async () => {
   const scriptContents = await Bun.file(compiledPluginUrl).text();
 
@@ -724,9 +748,7 @@ test("compiled rdfexport plugin bundle includes CSV property hook", async () => 
 
 function runRdfExportTest(fixtureFile: string, sampleFile: string) {
   test(`${fixtureFile}: rdfexport plugin exports RDF with expected checksum`, async () => {
-    if (pluginCallbacks.length === 0) {
-      await import(rdfexportUrl);
-    }
+    const pluginModule = await loadPluginModule();
 
     const fixturePath = join(fixturesDir, fixtureFile);
     const xml = await Bun.file(fixturePath).text();
@@ -821,11 +843,16 @@ function runRdfExportTest(fixtureFile: string, sampleFile: string) {
     expect(mimeType).toBe("application/rdf+xml");
     expect(exportMenuItems).toContainEqual(["-", "exportRdfXml"]);
 
+    const referenceRdf = readFileSync(join(fixturesDir, sampleFile), "utf-8");
+    const expected = pluginModule.runMockBlackBox(referenceRdf);
+
     const md5 = createHash("md5").update(data).digest("hex");
-    const refMd5 = createHash("md5")
-      .update(readFileSync(join(fixturesDir, sampleFile)))
-      .digest("hex");
+    const refMd5 = createHash("md5").update(expected).digest("hex");
+
     expect(md5).toBe(refMd5);
+    expect(data).toBe(expected);
+    expect(data.startsWith("[BLACKBOX]"))
+      .toBe(true);
   });
 }
 
@@ -846,9 +873,7 @@ for (const file of readdirSync(fixturesDir)) {
 test(
   "rdfexport plugin exposes preamble controls and diagram properties",
   async () => {
-  if (pluginCallbacks.length === 0) {
-    await import(rdfexportUrl);
-  }
+  const pluginModule = await loadPluginModule();
 
   const { graph, model, rootCell } = createGraphEnvironment({
     csvPath: "initial.csv",
@@ -1150,5 +1175,8 @@ test(
     listener.destroy();
   }
   expect(model.listenerCount()).toBe(0);
+
+  expect(pluginModule.runMockBlackBox("test").startsWith("[BLACKBOX]"))
+    .toBe(true);
   },
 );


### PR DESCRIPTION
## Summary
- add a `runMockBlackBox` helper that annotates serialized XML and invoke it before saving RDF exports
- expand the Bun test suite to load the plugin module, verify the mock black box output, and validate fixture exports against the annotated payloads while retaining the historical MD5 checksum guard
- record the completed work in `AGENTS.md` and document the effort under `docs/aicode`

## Testing
- bun test (from src/main/webapp/plugins/rdfexport)


------
https://chatgpt.com/codex/tasks/task_e_68e6a6cf2720832d893f0dce207bf629