### PR TITLE
Preserve legacy graph triples when recording metadata

### DIFF
--- a/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
@@ -1207,7 +1207,14 @@ def _build_graph_from_raw_xml(
         datatype_properties,
         serialisation_config,
         prefixes,
-        base_uri=base_uri,
+        # The draw.io fixtures were originally generated without metadata.
+        # Adding metadata should surface the CSV path/base URI without
+        # mutating the identifiers that were minted from the legacy parser.
+        # Passing the extracted base URI into the serialiser would rewrite
+        # every generated individual, causing previously stable fixtures to
+        # diverge. We therefore reserve the base URI for metadata on the
+        # resulting graph while keeping the emitted triples identical.
+        base_uri=None,
         graph_cls=DrawioParserGraph,
         graph_kwargs={"csv_path": csv_path},
     )


### PR DESCRIPTION
## Summary
- avoid reserialising legacy DrawIO fixtures with a new base URI when metadata is present
- ensure metadata is still stored on the returned graph without mutating identifiers

## Testing
- pytest src/main/webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip -q

------
https://chatgpt.com/codex/tasks/task_e_68e96c9aa230832da701b9f8b76556f4