### PR TITLE
Add parser settings dialog and pipeline integration

### DIFF
--- a/src/main/webapp/plugins/rdfexport.js
+++ b/src/main/webapp/plugins/rdfexport.js
@@ -20277,6 +20277,8 @@ from draw_io_parser import (  # type: ignore[attr-defined]  # noqa: E402
 
 DEFAULT_METACHARACTER_SUBSTITUTE = ["url"]
 
+_LAST_PARSER_CONFIG: dict[str, Any] | None = None
+
 GraphSummary = Dict[str, Any]
 
 _GRAPH_STORE: dict[str, DrawioParserGraph] = {}
@@ -20316,6 +20318,133 @@ def _default_parser_config() -> dict[str, Any]:
         "metacharacter_substitute": DEFAULT_METACHARACTER_SUBSTITUTE,
         "capitalisation_scheme": DEFAULT_CAPITALISATION_SCHEME,
     }
+
+
+def _coerce_bool(value: Any, fallback: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+
+    if value is None:
+        return fallback
+
+    return bool(value)
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped if stripped else None
+
+    return str(value)
+
+
+def _coerce_int(value: Any, fallback: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _coerce_float(value: Any, fallback: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _normalise_metacharacters(value: Any) -> list[str]:
+    if value is None:
+        return []
+
+    if isinstance(value, str):
+        return [value] if len(value) > 0 else []
+
+    try:
+        result = []
+        for item in value:
+            if isinstance(item, str) and len(item) > 0:
+                result.append(item)
+        return result
+    except TypeError:
+        return []
+
+
+def _apply_parser_overrides(overrides: dict[str, Any] | None) -> dict[str, Any]:
+    config = _default_parser_config()
+
+    if overrides:
+        if "infer_type_of_literals" in overrides:
+            config["infer_type_of_literals"] = _coerce_bool(
+                overrides["infer_type_of_literals"],
+                config["infer_type_of_literals"],
+            )
+        if "include_preamble" in overrides:
+            config["include_preamble"] = _coerce_bool(
+                overrides["include_preamble"],
+                config["include_preamble"],
+            )
+        if "include_label" in overrides:
+            config["include_label"] = _coerce_bool(
+                overrides["include_label"],
+                config["include_label"],
+            )
+        if "strict_mode" in overrides:
+            config["strict_mode"] = _coerce_bool(
+                overrides["strict_mode"],
+                config["strict_mode"],
+            )
+        if "ontology_iri" in overrides:
+            config["ontology_iri"] = _coerce_optional_str(overrides["ontology_iri"])
+        if "prefix" in overrides:
+            config["prefix"] = _coerce_optional_str(overrides["prefix"])
+        if "prefix_iri" in overrides:
+            config["prefix_iri"] = _coerce_optional_str(overrides["prefix_iri"])
+        if "indentation" in overrides:
+            config["indentation"] = _coerce_int(
+                overrides["indentation"],
+                config["indentation"],
+            )
+        if "max_gap" in overrides:
+            config["max_gap"] = _coerce_float(
+                overrides["max_gap"],
+                config["max_gap"],
+            )
+        if "metacharacter_substitute" in overrides:
+            config["metacharacter_substitute"] = _normalise_metacharacters(
+                overrides["metacharacter_substitute"],
+            )
+        if "capitalisation_scheme" in overrides and isinstance(
+            overrides["capitalisation_scheme"],
+            str,
+        ):
+            config["capitalisation_scheme"] = overrides["capitalisation_scheme"]
+
+    config["metacharacter_substitute"] = _normalise_metacharacters(
+        config["metacharacter_substitute"]
+    )
+
+    global _LAST_PARSER_CONFIG
+    _LAST_PARSER_CONFIG = deepcopy(config)
+    return config
+
+
+def get_last_parser_config() -> dict[str, Any] | None:
+    """Return the most recent parser configuration (for testing/debugging)."""
+
+    if _LAST_PARSER_CONFIG is None:
+        return None
+
+    return deepcopy(_LAST_PARSER_CONFIG)
 
 
 def _store_graph(graph: DrawioParserGraph, payload_hash: str | None = None) -> str:
@@ -20399,19 +20528,28 @@ def get_graph_summary(graph_id: str) -> GraphSummary:
     return _build_summary(graph_id, graph)
 
 
-def parse_drawio_xml(serialized_xml: str) -> tuple[str, DrawioParserGraph]:
+def parse_drawio_xml(
+    serialized_xml: str, parser_config: dict[str, Any] | None = None
+) -> tuple[str, DrawioParserGraph]:
     """Parse DrawIO XML into a DrawioParserGraph and cache it."""
     normalized_xml = _normalize_drawio_xml(serialized_xml)
-    config = _default_parser_config()
+    config = _apply_parser_overrides(parser_config)
+    payload_descriptor = json.dumps(
+        {"xml": normalized_xml, "config": config},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    payload_hash = hashlib.sha256(payload_descriptor.encode("utf-8")).hexdigest()
     graph = _build_graph_from_raw_xml(normalized_xml, config)
-    payload_hash = hashlib.sha256(normalized_xml.encode("utf-8")).hexdigest()
     graph_id = _store_graph(graph, payload_hash)
     return graph_id, graph
 
 
-def parse_drawio_xml_to_json(serialized_xml: str) -> str:
+def parse_drawio_xml_to_json(
+    serialized_xml: str, parser_config: dict[str, Any] | None = None
+) -> str:
     """Parse DrawIO XML and return a JSON payload describing the graph."""
-    graph_id, graph = parse_drawio_xml(serialized_xml)
+    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)
     summary = _build_summary(graph_id, graph)
     return json.dumps(summary, sort_keys=True)
 `;
@@ -20656,14 +20794,16 @@ function mapRawSummary(raw) {
     rawTurtle: decodeRawTurtle(raw.raw_turtle)
   };
 }
-async function invokeDrawioParser(serializedXml) {
+async function invokeDrawioParser(serializedXml, config) {
   await ensurePythonEnvironment();
   const pyodide = await ensurePyodideInstance();
   logInfo(LOG_PREFIX.PIPELINE, `Invoking DrawIO parser via Pyodide (input length ${serializedXml.length})`);
   try {
     const quoted = JSON.stringify(serializedXml);
+    const configJson = JSON.stringify(config ?? null);
     const jsonResult = await pyodide.runPythonAsync(`from pyodide_pipeline.drawio_pipeline import parse_drawio_xml_to_json
-parse_drawio_xml_to_json(${quoted})`);
+import json
+parse_drawio_xml_to_json(${quoted}, json.loads(${JSON.stringify(configJson)}))`);
     const rawSummary = JSON.parse(jsonResult);
     const mapped = mapRawSummary(rawSummary);
     logInfo(LOG_PREFIX.PIPELINE, `DrawIO parser produced graph ${mapped.graphId} with ${mapped.tripleCount} triples`);
@@ -20675,14 +20815,14 @@ parse_drawio_xml_to_json(${quoted})`);
 }
 
 // src/mockBlackBox.ts
-async function parseSerializedXml(serializedXml) {
-  const processed = await invokeDrawioParser(serializedXml);
+async function parseSerializedXml(serializedXml, config) {
+  const processed = await invokeDrawioParser(serializedXml, config);
   logInfo(LOG_PREFIX.BLACKBOX, `Parsed DrawIO graph ${processed.graphId} with ${processed.tripleCount} triples`);
   return processed;
 }
-async function runDrawioPipeline(serializedXml) {
+async function runDrawioPipeline(serializedXml, config) {
   logInfo(LOG_PREFIX.BLACKBOX, `Generating Turtle payload for serialized input (${serializedXml.length} characters)`);
-  const processed = await parseSerializedXml(serializedXml);
+  const processed = await parseSerializedXml(serializedXml, config);
   if (processed.rawTurtle == null || processed.rawTurtle.length === 0) {
     throw new Error("DrawIO parser did not return Turtle serialization");
   }
@@ -20712,6 +20852,297 @@ var DEFAULT_ADD_PREFIX_LABEL = "Add Prefix";
 var PREAMBLE_ENTRY_TAG = "userObjectPreambleElement";
 var PREAMBLE_PREFIX_ATTRIBUTE = "rdfPrefix";
 var PREAMBLE_IRI_ATTRIBUTE = "rdfIRI";
+var PARSER_SETTINGS_ATTRIBUTE_NAME = "rdfParserSettings";
+var PARSER_SETTINGS_STORAGE_VERSION = 1;
+var PARSER_SETTINGS_BUTTON_RESOURCE_KEY = "parserSettings";
+var DEFAULT_PARSER_SETTINGS_BUTTON_LABEL = "Parser Settings...";
+var PARSER_SETTINGS_DIALOG_ATTRIBUTE = "data-rdfexport-parser-settings-dialog";
+var PARSER_SETTINGS_BUTTON_ATTRIBUTE = "data-rdfexport-parser-settings-button";
+var PARSER_SETTINGS_INCLUDE_PREAMBLE_ATTRIBUTE = "data-rdfexport-parser-include-preamble";
+var PARSER_SETTINGS_INCLUDE_LABEL_ATTRIBUTE = "data-rdfexport-parser-include-label";
+var PARSER_SETTINGS_INFER_TYPES_ATTRIBUTE = "data-rdfexport-parser-infer-types";
+var PARSER_SETTINGS_STRICT_MODE_ATTRIBUTE = "data-rdfexport-parser-strict-mode";
+var PARSER_SETTINGS_PREFIX_ATTRIBUTE = "data-rdfexport-parser-prefix";
+var PARSER_SETTINGS_PREFIX_IRI_ATTRIBUTE = "data-rdfexport-parser-prefix-iri";
+var PARSER_SETTINGS_ONTOLOGY_IRI_ATTRIBUTE = "data-rdfexport-parser-ontology-iri";
+var PARSER_SETTINGS_INDENTATION_ATTRIBUTE = "data-rdfexport-parser-indentation";
+var PARSER_SETTINGS_MAX_GAP_ATTRIBUTE = "data-rdfexport-parser-max-gap";
+var PARSER_SETTINGS_CAPITALISATION_ATTRIBUTE = "data-rdfexport-parser-capitalisation";
+var PARSER_SETTINGS_STRATEGY_ATTRIBUTE = "data-rdfexport-parser-metachar-strategy";
+var PARSER_SETTINGS_METACHAR_LIST_ATTRIBUTE = "data-rdfexport-parser-metachar-list";
+var PARSER_SETTINGS_METACHAR_ENTRY_ATTRIBUTE = "data-rdfexport-parser-metachar-entry";
+var PARSER_SETTINGS_METACHAR_CHAR_ATTRIBUTE = "data-rdfexport-parser-metachar-char";
+var PARSER_SETTINGS_METACHAR_REPLACEMENT_ATTRIBUTE = "data-rdfexport-parser-metachar-replacement";
+var PARSER_SETTINGS_METACHAR_REMOVE_ATTRIBUTE = "data-rdfexport-parser-metachar-remove";
+var PARSER_SETTINGS_METACHAR_ADD_ATTRIBUTE = "data-rdfexport-parser-metachar-add";
+var PARSER_SETTINGS_APPLY_ATTRIBUTE = "data-rdfexport-parser-apply";
+var PARSER_SETTINGS_CANCEL_ATTRIBUTE = "data-rdfexport-parser-cancel";
+var DRAWIO_PARSER_DEFAULT_INDENTATION = 2;
+var DRAWIO_PARSER_DEFAULT_MAX_GAP = 10;
+var DRAWIO_PARSER_DEFAULT_CAPITALISATION = "upper-camel";
+var DRAWIO_PARSER_DEFAULT_METACHARACTER_STRATEGY = "url";
+var METACHARACTER_OPTIONS = [
+  { value: " ", label: "Space ( )" },
+  { value: "(", label: "(" },
+  { value: ")", label: ")" },
+  { value: "[", label: "[" },
+  { value: "]", label: "]" },
+  { value: "{", label: "{" },
+  { value: "}", label: "}" },
+  { value: "/", label: "/" },
+  { value: ",", label: "," },
+  { value: ":", label: ":" },
+  { value: ".", label: "." },
+  { value: "'", label: "'" },
+  { value: '"', label: '"' },
+  { value: " ", label: "Non-breaking space" },
+  { value: "#", label: "#" }
+];
+var CAPITALISATION_SCHEME_OPTIONS = [
+  { value: "upper-camel", label: "Upper camel case" },
+  { value: "lower-camel", label: "Lower camel case" },
+  { value: "flat", label: "Flat (lowercase)" },
+  { value: "none", label: "Leave unchanged" }
+];
+var METACHARACTER_STRATEGY_OPTIONS = [
+  {
+    value: "url",
+    label: "Replace unspecified metacharacters with URL entities"
+  },
+  {
+    value: "remove",
+    label: "Remove unspecified metacharacters"
+  },
+  {
+    value: "custom",
+    label: "Use only custom substitutions"
+  }
+];
+function createDefaultParserSettings() {
+  return {
+    includePreamble: true,
+    inferTypeOfLiterals: true,
+    includeLabel: true,
+    strictMode: false,
+    indentation: DRAWIO_PARSER_DEFAULT_INDENTATION,
+    maxGap: DRAWIO_PARSER_DEFAULT_MAX_GAP,
+    ontologyIri: null,
+    prefix: null,
+    prefixIri: null,
+    capitalisationScheme: DRAWIO_PARSER_DEFAULT_CAPITALISATION,
+    metacharacterStrategy: DRAWIO_PARSER_DEFAULT_METACHARACTER_STRATEGY,
+    metacharacterEntries: []
+  };
+}
+function normalizeBoolean(value, fallback) {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "string") {
+    const lowered = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(lowered)) {
+      return true;
+    }
+    if (["false", "0", "no", "off"].includes(lowered)) {
+      return false;
+    }
+  }
+  if (value == null) {
+    return fallback;
+  }
+  return Boolean(value);
+}
+function normalizeNullableString(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+function normalizeIndentation(value, fallback) {
+  if (typeof value === "string" && value.trim().length === 0) {
+    return Math.max(0, Math.round(fallback));
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return Math.max(0, Math.round(numeric));
+  }
+  return Math.max(0, Math.round(fallback));
+}
+function normalizeMaxGap(value, fallback) {
+  if (typeof value === "string" && value.trim().length === 0) {
+    return Math.max(0, fallback);
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return Math.max(0, numeric);
+  }
+  return Math.max(0, fallback);
+}
+function normalizeCapitalisationScheme(value, fallback) {
+  if (value === "lower-camel" || value === "flat" || value === "none") {
+    return value;
+  }
+  if (value === "upper-camel") {
+    return "upper-camel";
+  }
+  return fallback;
+}
+function normalizeMetacharacterStrategy(value, fallback) {
+  if (value === "remove" || value === "custom" || value === "url") {
+    return value;
+  }
+  return fallback;
+}
+function normalizeMetacharacterEntries(entries) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  const normalized = [];
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const character = typeof entry.character === "string" ? entry.character : "";
+    if (character.length === 0) {
+      continue;
+    }
+    const replacement = typeof entry.replacement === "string" ? entry.replacement : "";
+    normalized.push({ character, replacement });
+  }
+  return normalized;
+}
+function normaliseParserSettings(partial) {
+  const defaults = createDefaultParserSettings();
+  return {
+    includePreamble: normalizeBoolean(partial?.includePreamble, defaults.includePreamble),
+    inferTypeOfLiterals: normalizeBoolean(partial?.inferTypeOfLiterals, defaults.inferTypeOfLiterals),
+    includeLabel: normalizeBoolean(partial?.includeLabel, defaults.includeLabel),
+    strictMode: normalizeBoolean(partial?.strictMode, defaults.strictMode),
+    indentation: normalizeIndentation(partial?.indentation, defaults.indentation),
+    maxGap: normalizeMaxGap(partial?.maxGap, defaults.maxGap),
+    ontologyIri: partial?.ontologyIri != null ? normalizeNullableString(partial.ontologyIri) : null,
+    prefix: partial?.prefix != null ? normalizeNullableString(partial.prefix) : null,
+    prefixIri: partial?.prefixIri != null ? normalizeNullableString(partial.prefixIri) : null,
+    capitalisationScheme: normalizeCapitalisationScheme(partial?.capitalisationScheme, defaults.capitalisationScheme),
+    metacharacterStrategy: normalizeMetacharacterStrategy(partial?.metacharacterStrategy, defaults.metacharacterStrategy),
+    metacharacterEntries: normalizeMetacharacterEntries(partial?.metacharacterEntries)
+  };
+}
+function parseStoredParserSettings(raw) {
+  if (!raw) {
+    return createDefaultParserSettings();
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      if (typeof parsed.settings === "object" && parsed.settings !== null) {
+        return normaliseParserSettings(parsed.settings);
+      }
+      return normaliseParserSettings(parsed);
+    }
+  } catch (error) {}
+  return createDefaultParserSettings();
+}
+function serializeParserSettings(settings) {
+  const normalized = normaliseParserSettings(settings);
+  const storage = {
+    version: PARSER_SETTINGS_STORAGE_VERSION,
+    settings: normalized
+  };
+  return JSON.stringify(storage);
+}
+var DEFAULT_SERIALIZED_PARSER_SETTINGS = serializeParserSettings(createDefaultParserSettings());
+function buildParserConfigPayloadFromSettings(settings) {
+  const normalized = normaliseParserSettings(settings);
+  const substitutes = [];
+  if (normalized.metacharacterStrategy === "url") {
+    substitutes.push("url");
+  } else if (normalized.metacharacterStrategy === "remove") {
+    substitutes.push("remove");
+  }
+  for (const entry of normalized.metacharacterEntries) {
+    substitutes.push(`${entry.character}=${entry.replacement ?? ""}`);
+  }
+  return {
+    infer_type_of_literals: normalized.inferTypeOfLiterals,
+    include_preamble: normalized.includePreamble,
+    ontology_iri: normalizeNullableString(normalized.ontologyIri),
+    prefix: normalizeNullableString(normalized.prefix),
+    prefix_iri: normalizeNullableString(normalized.prefixIri),
+    indentation: normalized.indentation,
+    include_label: normalized.includeLabel,
+    max_gap: normalized.maxGap,
+    strict_mode: normalized.strictMode,
+    metacharacter_substitute: substitutes,
+    capitalisation_scheme: normalized.capitalisationScheme
+  };
+}
+function extractValueElement(model, rootCell) {
+  if (typeof model.getValue === "function") {
+    const value = model.getValue(rootCell);
+    if (value && typeof value.getAttribute === "function") {
+      return value;
+    }
+  }
+  const fallback = rootCell.value;
+  if (fallback && typeof fallback.getAttribute === "function") {
+    return fallback;
+  }
+  return null;
+}
+function readParserSettingsFromGraphInstance(graph, model, rootCell) {
+  let rawValue = null;
+  if (typeof graph.getAttributeForCell === "function") {
+    const attributeValue = graph.getAttributeForCell(rootCell, PARSER_SETTINGS_ATTRIBUTE_NAME, null);
+    rawValue = typeof attributeValue === "string" ? attributeValue : null;
+  }
+  if (!rawValue || rawValue.length === 0) {
+    const valueElement = extractValueElement(model, rootCell);
+    if (valueElement) {
+      const attribute = valueElement.getAttribute(PARSER_SETTINGS_ATTRIBUTE_NAME);
+      rawValue = attribute != null && attribute.length > 0 ? attribute : null;
+    }
+  }
+  return parseStoredParserSettings(rawValue);
+}
+function writeParserSettingsToGraphInstance(graph, model, rootCell, settings) {
+  const serialized = serializeParserSettings(settings);
+  const valueToStore = serialized === DEFAULT_SERIALIZED_PARSER_SETTINGS ? null : serialized;
+  model.beginUpdate?.();
+  try {
+    if (typeof graph.setAttributeForCell === "function") {
+      graph.setAttributeForCell(rootCell, PARSER_SETTINGS_ATTRIBUTE_NAME, valueToStore);
+    } else {
+      const valueElement = extractValueElement(model, rootCell);
+      if (valueElement) {
+        if (valueToStore != null) {
+          valueElement.setAttribute(PARSER_SETTINGS_ATTRIBUTE_NAME, valueToStore);
+        } else if (typeof valueElement.removeAttribute === "function") {
+          valueElement.removeAttribute(PARSER_SETTINGS_ATTRIBUTE_NAME);
+        }
+        model.markDirty?.();
+      }
+    }
+  } finally {
+    model.endUpdate?.();
+  }
+}
+function buildParserConfigPayloadFromGraph(graph) {
+  if (!graph || typeof graph.getModel !== "function") {
+    return buildParserConfigPayloadFromSettings(createDefaultParserSettings());
+  }
+  const model = graph.getModel();
+  if (!model || typeof model.getRoot !== "function") {
+    return buildParserConfigPayloadFromSettings(createDefaultParserSettings());
+  }
+  const rootCell = model.getRoot();
+  if (!rootCell) {
+    return buildParserConfigPayloadFromSettings(createDefaultParserSettings());
+  }
+  const settings = readParserSettingsFromGraphInstance(graph, model, rootCell);
+  return buildParserConfigPayloadFromSettings(settings);
+}
 var csvPropertyPatched = false;
 var registeredResourceKeys = new Set;
 function registerResource(key, fallback) {
@@ -21022,10 +21453,46 @@ function installCsvPathProperty() {
     preambleButton.setAttribute("data-rdfexport-preamble-button", "true");
     preambleButton.style.marginTop = "8px";
     preambleButton.style.width = "210px";
-    preambleButton.style.display = "inline-block";
+    preambleButton.style.display = "block";
     preambleButton.style.textAlign = "center";
     preambleButton.className = preambleButton.className || "geButton";
     preambleSection.appendChild(preambleButton);
+    const openParserSettingsDialog = () => {
+      if (!ui) {
+        return;
+      }
+      const rootCell = getRootCell();
+      if (!rootCell) {
+        return;
+      }
+      const dialog = createParserSettingsDialog(ui, graph, model, rootCell);
+      if (!dialog) {
+        return;
+      }
+      ui.showDialog?.(dialog.container, 520, 520, true, true, null, false);
+      dialog.init?.();
+    };
+    const parserSettingsLabel = resolveLabel(PARSER_SETTINGS_BUTTON_RESOURCE_KEY, DEFAULT_PARSER_SETTINGS_BUTTON_LABEL);
+    const parserSettingsButton = (() => {
+      if (typeof mxUtils.button === "function") {
+        return mxUtils.button(parserSettingsLabel, () => {
+          openParserSettingsDialog();
+        });
+      }
+      const button = document.createElement("button");
+      button.textContent = parserSettingsLabel;
+      button.addEventListener("click", () => {
+        openParserSettingsDialog();
+      });
+      return button;
+    })();
+    parserSettingsButton.setAttribute(PARSER_SETTINGS_BUTTON_ATTRIBUTE, "true");
+    parserSettingsButton.style.marginTop = "6px";
+    parserSettingsButton.style.width = "210px";
+    parserSettingsButton.style.display = "block";
+    parserSettingsButton.style.textAlign = "center";
+    parserSettingsButton.className = parserSettingsButton.className || "geButton";
+    preambleSection.appendChild(parserSettingsButton);
     const panelContainer = this.container ?? null;
     const findFormatSectionAncestor = (node) => {
       let current = node;
@@ -21161,6 +21628,346 @@ function buildValueWithPreamble(baseValue, entries) {
     valueElement.appendChild(preambleElement);
   }
   return valueElement;
+}
+function createParserSettingsDialog(editorUi, graph, model, rootCell) {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  const settings = readParserSettingsFromGraphInstance(graph, model, rootCell);
+  const container = document.createElement("div");
+  container.setAttribute(PARSER_SETTINGS_DIALOG_ATTRIBUTE, "true");
+  container.style.position = "relative";
+  container.style.width = "100%";
+  container.style.height = "100%";
+  const scrollArea = document.createElement("div");
+  scrollArea.style.position = "absolute";
+  scrollArea.style.top = "30px";
+  scrollArea.style.left = "30px";
+  scrollArea.style.right = "30px";
+  scrollArea.style.bottom = "80px";
+  scrollArea.style.overflowY = "auto";
+  scrollArea.style.display = "flex";
+  scrollArea.style.flexDirection = "column";
+  scrollArea.style.gap = "14px";
+  container.appendChild(scrollArea);
+  const createSection = (title) => {
+    const section = document.createElement("div");
+    section.style.display = "flex";
+    section.style.flexDirection = "column";
+    section.style.gap = "8px";
+    const heading = document.createElement("div");
+    heading.textContent = title;
+    heading.style.fontWeight = "bold";
+    heading.style.fontSize = "13px";
+    section.appendChild(heading);
+    return section;
+  };
+  const createCheckboxRow = (label, initial, dataAttribute) => {
+    const row = document.createElement("label");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.gap = "8px";
+    row.style.cursor = "pointer";
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = initial;
+    checkbox.defaultChecked = initial;
+    checkbox.setAttribute(dataAttribute, "true");
+    row.appendChild(checkbox);
+    const text = document.createElement("span");
+    text.textContent = label;
+    text.style.flex = "1 1 auto";
+    row.appendChild(text);
+    return { container: row, input: checkbox };
+  };
+  const createLabeledInput = (section, label, initial, dataAttribute, options) => {
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "flex";
+    wrapper.style.flexDirection = "column";
+    wrapper.style.gap = "4px";
+    const labelElement = document.createElement("label");
+    labelElement.textContent = label;
+    labelElement.style.fontSize = "12px";
+    labelElement.style.fontWeight = "500";
+    wrapper.appendChild(labelElement);
+    const input = document.createElement("input");
+    input.type = options?.type ?? "text";
+    if (options?.step) {
+      input.step = options.step;
+    }
+    input.value = initial ?? "";
+    input.setAttribute(dataAttribute, "true");
+    input.style.height = "26px";
+    input.style.padding = "4px 6px";
+    input.style.border = "1px solid var(--geInputBorderColor, #d5d5d5)";
+    input.style.borderRadius = "2px";
+    input.style.boxSizing = "border-box";
+    input.style.fontSize = "12px";
+    input.autocomplete = "off";
+    const inputId = `rdfexport-parser-${dataAttribute}-${Math.random().toString(36).slice(2)}`;
+    input.id = inputId;
+    labelElement.htmlFor = inputId;
+    wrapper.appendChild(input);
+    section.appendChild(wrapper);
+    return input;
+  };
+  const createSelect = (section, label, options, initial, dataAttribute) => {
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "flex";
+    wrapper.style.flexDirection = "column";
+    wrapper.style.gap = "4px";
+    const labelElement = document.createElement("label");
+    labelElement.textContent = label;
+    labelElement.style.fontSize = "12px";
+    labelElement.style.fontWeight = "500";
+    wrapper.appendChild(labelElement);
+    const select = document.createElement("select");
+    select.setAttribute(dataAttribute, "true");
+    select.style.height = "28px";
+    select.style.padding = "4px 6px";
+    select.style.border = "1px solid var(--geInputBorderColor, #d5d5d5)";
+    select.style.borderRadius = "2px";
+    select.style.fontSize = "12px";
+    for (const option of options) {
+      const element = document.createElement("option");
+      element.value = option.value;
+      element.textContent = option.label;
+      select.appendChild(element);
+    }
+    if (!options.some((option) => option.value === initial)) {
+      select.value = options[0]?.value ?? "";
+    } else {
+      select.value = initial;
+    }
+    const selectId = `rdfexport-parser-select-${Math.random().toString(36).slice(2)}`;
+    select.id = selectId;
+    labelElement.htmlFor = selectId;
+    wrapper.appendChild(select);
+    section.appendChild(wrapper);
+    return select;
+  };
+  const generalSection = createSection("General behaviour");
+  scrollArea.appendChild(generalSection);
+  const includePreambleRow = createCheckboxRow("Include preamble block in output", settings.includePreamble, PARSER_SETTINGS_INCLUDE_PREAMBLE_ATTRIBUTE);
+  generalSection.appendChild(includePreambleRow.container);
+  const includePreambleCheckbox = includePreambleRow.input;
+  const includeLabelRow = createCheckboxRow("Include rdfs:label annotations", settings.includeLabel, PARSER_SETTINGS_INCLUDE_LABEL_ATTRIBUTE);
+  generalSection.appendChild(includeLabelRow.container);
+  const includeLabelCheckbox = includeLabelRow.input;
+  const inferTypesRow = createCheckboxRow("Infer literal datatypes", settings.inferTypeOfLiterals, PARSER_SETTINGS_INFER_TYPES_ATTRIBUTE);
+  generalSection.appendChild(inferTypesRow.container);
+  const inferTypesCheckbox = inferTypesRow.input;
+  const strictModeRow = createCheckboxRow("Enable strict arrow parsing", settings.strictMode, PARSER_SETTINGS_STRICT_MODE_ATTRIBUTE);
+  generalSection.appendChild(strictModeRow.container);
+  const strictModeCheckbox = strictModeRow.input;
+  const identifiersSection = createSection("Identifiers");
+  scrollArea.appendChild(identifiersSection);
+  const prefixInput = createLabeledInput(identifiersSection, "Generated individual prefix", settings.prefix, PARSER_SETTINGS_PREFIX_ATTRIBUTE);
+  const prefixIriInput = createLabeledInput(identifiersSection, "Prefix IRI", settings.prefixIri, PARSER_SETTINGS_PREFIX_IRI_ATTRIBUTE);
+  const ontologyIriInput = createLabeledInput(identifiersSection, "Ontology IRI", settings.ontologyIri, PARSER_SETTINGS_ONTOLOGY_IRI_ATTRIBUTE);
+  const formattingSection = createSection("Formatting");
+  scrollArea.appendChild(formattingSection);
+  const indentationInput = createLabeledInput(formattingSection, "Indentation (spaces)", String(settings.indentation), PARSER_SETTINGS_INDENTATION_ATTRIBUTE, { type: "number" });
+  indentationInput.min = "0";
+  const maxGapInput = createLabeledInput(formattingSection, "Maximum gap for loose arrows", String(settings.maxGap), PARSER_SETTINGS_MAX_GAP_ATTRIBUTE, { type: "number", step: "0.1" });
+  maxGapInput.min = "0";
+  const capitalisationSelect = createSelect(formattingSection, "Capitalisation scheme", CAPITALISATION_SCHEME_OPTIONS, settings.capitalisationScheme, PARSER_SETTINGS_CAPITALISATION_ATTRIBUTE);
+  const metacharSection = createSection("Metacharacter substitution");
+  scrollArea.appendChild(metacharSection);
+  const strategySelect = createSelect(metacharSection, "Default handling", METACHARACTER_STRATEGY_OPTIONS, settings.metacharacterStrategy, PARSER_SETTINGS_STRATEGY_ATTRIBUTE);
+  const entriesList = document.createElement("div");
+  entriesList.style.display = "flex";
+  entriesList.style.flexDirection = "column";
+  entriesList.style.gap = "6px";
+  entriesList.setAttribute(PARSER_SETTINGS_METACHAR_LIST_ATTRIBUTE, "true");
+  metacharSection.appendChild(entriesList);
+  const entries = [];
+  const addEntry = (character, replacement) => {
+    const row = document.createElement("div");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.gap = "8px";
+    row.setAttribute(PARSER_SETTINGS_METACHAR_ENTRY_ATTRIBUTE, "true");
+    const charSelect = document.createElement("select");
+    charSelect.style.flex = "0 0 140px";
+    charSelect.style.height = "28px";
+    charSelect.style.padding = "4px 6px";
+    charSelect.style.border = "1px solid var(--geInputBorderColor, #d5d5d5)";
+    charSelect.style.borderRadius = "2px";
+    charSelect.style.fontSize = "12px";
+    charSelect.setAttribute(PARSER_SETTINGS_METACHAR_CHAR_ATTRIBUTE, "true");
+    const ensureOption = (value, label) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = label;
+      charSelect.appendChild(option);
+    };
+    for (const option of METACHARACTER_OPTIONS) {
+      ensureOption(option.value, option.label);
+    }
+    if (!METACHARACTER_OPTIONS.some((option) => option.value === character)) {
+      const fallbackLabel = character === " " ? "Space ( )" : character === " " ? "Non-breaking space" : character;
+      ensureOption(character, fallbackLabel);
+    }
+    charSelect.value = character;
+    const replacementInput = document.createElement("input");
+    replacementInput.type = "text";
+    replacementInput.value = replacement;
+    replacementInput.style.flex = "1 1 auto";
+    replacementInput.style.height = "26px";
+    replacementInput.style.padding = "4px 6px";
+    replacementInput.style.border = "1px solid var(--geInputBorderColor, #d5d5d5)";
+    replacementInput.style.borderRadius = "2px";
+    replacementInput.style.fontSize = "12px";
+    replacementInput.setAttribute(PARSER_SETTINGS_METACHAR_REPLACEMENT_ATTRIBUTE, "true");
+    let state;
+    const removeEntry = () => {
+      const index = entries.indexOf(state);
+      if (index >= 0) {
+        entries.splice(index, 1);
+      }
+      if (row.parentNode) {
+        row.parentNode.removeChild(row);
+      }
+    };
+    const removeButton = (() => {
+      if (typeof mxUtils.button === "function") {
+        return mxUtils.button("Remove", () => {
+          removeEntry();
+        });
+      }
+      const button = document.createElement("button");
+      button.textContent = "Remove";
+      button.addEventListener("click", () => {
+        removeEntry();
+      });
+      return button;
+    })();
+    removeButton.setAttribute(PARSER_SETTINGS_METACHAR_REMOVE_ATTRIBUTE, "true");
+    removeButton.className = removeButton.className || "geButton";
+    state = {
+      container: row,
+      select: charSelect,
+      replacement: replacementInput
+    };
+    row.appendChild(charSelect);
+    row.appendChild(replacementInput);
+    row.appendChild(removeButton);
+    entriesList.appendChild(row);
+    entries.push(state);
+  };
+  if (settings.metacharacterEntries.length > 0) {
+    for (const entry of settings.metacharacterEntries) {
+      addEntry(entry.character, entry.replacement);
+    }
+  }
+  const addButtonContainer = document.createElement("div");
+  addButtonContainer.style.display = "flex";
+  addButtonContainer.style.justifyContent = "flex-end";
+  const addButton = (() => {
+    if (typeof mxUtils.button === "function") {
+      return mxUtils.button("Add substitution", () => {
+        addEntry(" ", "");
+      });
+    }
+    const button = document.createElement("button");
+    button.textContent = "Add substitution";
+    button.addEventListener("click", () => {
+      addEntry(" ", "");
+    });
+    return button;
+  })();
+  addButton.setAttribute(PARSER_SETTINGS_METACHAR_ADD_ATTRIBUTE, "true");
+  addButton.className = addButton.className || "geButton";
+  addButtonContainer.appendChild(addButton);
+  metacharSection.appendChild(addButtonContainer);
+  const buttons = document.createElement("div");
+  buttons.style.position = "absolute";
+  buttons.style.left = "30px";
+  buttons.style.right = "30px";
+  buttons.style.bottom = "30px";
+  buttons.style.height = "40px";
+  buttons.style.display = "flex";
+  buttons.style.alignItems = "center";
+  buttons.style.justifyContent = "flex-end";
+  buttons.style.gap = "10px";
+  container.appendChild(buttons);
+  const cancelLabel = resolveLabel("cancel", "Cancel");
+  const cancelButton = (() => {
+    if (typeof mxUtils.button === "function") {
+      return mxUtils.button(cancelLabel, () => {
+        editorUi.hideDialog?.();
+      });
+    }
+    const button = document.createElement("button");
+    button.textContent = cancelLabel;
+    button.addEventListener("click", () => {
+      editorUi.hideDialog?.();
+    });
+    return button;
+  })();
+  cancelButton.setAttribute(PARSER_SETTINGS_CANCEL_ATTRIBUTE, "true");
+  cancelButton.className = cancelButton.className || "geButton";
+  buttons.appendChild(cancelButton);
+  const applyLabel = resolveLabel("apply", "Apply");
+  const handleApply = () => {
+    const indentationRaw = indentationInput.value.trim();
+    const maxGapRaw = maxGapInput.value.trim();
+    const partialSettings = {
+      includePreamble: includePreambleCheckbox.checked,
+      includeLabel: includeLabelCheckbox.checked,
+      inferTypeOfLiterals: inferTypesCheckbox.checked,
+      strictMode: strictModeCheckbox.checked,
+      prefix: prefixInput.value,
+      prefixIri: prefixIriInput.value,
+      ontologyIri: ontologyIriInput.value,
+      capitalisationScheme: capitalisationSelect.value,
+      metacharacterStrategy: strategySelect.value,
+      metacharacterEntries: entries.map((entry) => ({
+        character: entry.select.value,
+        replacement: entry.replacement.value
+      }))
+    };
+    if (indentationRaw.length > 0) {
+      partialSettings.indentation = Number(indentationRaw);
+    }
+    if (maxGapRaw.length > 0) {
+      partialSettings.maxGap = Number(maxGapRaw);
+    }
+    const updatedSettings = normaliseParserSettings(partialSettings);
+    writeParserSettingsToGraphInstance(graph, model, rootCell, updatedSettings);
+    editorUi.hideDialog?.();
+  };
+  const applyButton = (() => {
+    if (typeof mxUtils.button === "function") {
+      return mxUtils.button(applyLabel, () => {
+        handleApply();
+      });
+    }
+    const button = document.createElement("button");
+    button.textContent = applyLabel;
+    button.addEventListener("click", () => {
+      handleApply();
+    });
+    return button;
+  })();
+  applyButton.setAttribute(PARSER_SETTINGS_APPLY_ATTRIBUTE, "true");
+  const applyElement = applyButton;
+  if (applyElement.className) {
+    if (!/\bgePrimaryBtn\b/.test(applyElement.className)) {
+      applyElement.className += " gePrimaryBtn";
+    }
+  } else {
+    applyElement.className = "geButton gePrimaryBtn";
+  }
+  buttons.appendChild(applyButton);
+  const dialog = {
+    container,
+    init() {
+      prefixInput.focus?.();
+    }
+  };
+  return dialog;
 }
 function createPreambleDialog(editorUi, model, rootCell, labels) {
   if (typeof document === "undefined") {
@@ -21426,7 +22233,8 @@ Draw.loadPlugin(function(editorUi) {
     try {
       const serializedXml = serializeDiagramXml(editorUi);
       logInfo(LOG_PREFIX.PIPELINE, `Generated DrawIO XML payload (${serializedXml.length} characters)`);
-      const blackBoxPayload = await runDrawioPipeline(serializedXml);
+      const parserConfig = buildParserConfigPayloadFromGraph(editorUi?.editor?.graph ?? null);
+      const blackBoxPayload = await runDrawioPipeline(serializedXml, parserConfig);
       const filename = editorUi.getBaseFilename() + ".ttl";
       logInfo(LOG_PREFIX.PIPELINE, `Saving export payload to ${filename}`);
       editorUi.saveData(filename, "turtle", blackBoxPayload, "text/turtle");

--- a/src/main/webapp/plugins/rdfexport/pyodide_pipeline/drawio_pipeline.py
+++ b/src/main/webapp/plugins/rdfexport/pyodide_pipeline/drawio_pipeline.py
@@ -25,6 +25,8 @@ from draw_io_parser import (  # type: ignore[attr-defined]  # noqa: E402
 
 DEFAULT_METACHARACTER_SUBSTITUTE = ["url"]
 
+_LAST_PARSER_CONFIG: dict[str, Any] | None = None
+
 GraphSummary = Dict[str, Any]
 
 _GRAPH_STORE: dict[str, DrawioParserGraph] = {}
@@ -64,6 +66,133 @@ def _default_parser_config() -> dict[str, Any]:
         "metacharacter_substitute": DEFAULT_METACHARACTER_SUBSTITUTE,
         "capitalisation_scheme": DEFAULT_CAPITALISATION_SCHEME,
     }
+
+
+def _coerce_bool(value: Any, fallback: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+
+    if value is None:
+        return fallback
+
+    return bool(value)
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped if stripped else None
+
+    return str(value)
+
+
+def _coerce_int(value: Any, fallback: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _coerce_float(value: Any, fallback: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _normalise_metacharacters(value: Any) -> list[str]:
+    if value is None:
+        return []
+
+    if isinstance(value, str):
+        return [value] if len(value) > 0 else []
+
+    try:
+        result = []
+        for item in value:
+            if isinstance(item, str) and len(item) > 0:
+                result.append(item)
+        return result
+    except TypeError:
+        return []
+
+
+def _apply_parser_overrides(overrides: dict[str, Any] | None) -> dict[str, Any]:
+    config = _default_parser_config()
+
+    if overrides:
+        if "infer_type_of_literals" in overrides:
+            config["infer_type_of_literals"] = _coerce_bool(
+                overrides["infer_type_of_literals"],
+                config["infer_type_of_literals"],
+            )
+        if "include_preamble" in overrides:
+            config["include_preamble"] = _coerce_bool(
+                overrides["include_preamble"],
+                config["include_preamble"],
+            )
+        if "include_label" in overrides:
+            config["include_label"] = _coerce_bool(
+                overrides["include_label"],
+                config["include_label"],
+            )
+        if "strict_mode" in overrides:
+            config["strict_mode"] = _coerce_bool(
+                overrides["strict_mode"],
+                config["strict_mode"],
+            )
+        if "ontology_iri" in overrides:
+            config["ontology_iri"] = _coerce_optional_str(overrides["ontology_iri"])
+        if "prefix" in overrides:
+            config["prefix"] = _coerce_optional_str(overrides["prefix"])
+        if "prefix_iri" in overrides:
+            config["prefix_iri"] = _coerce_optional_str(overrides["prefix_iri"])
+        if "indentation" in overrides:
+            config["indentation"] = _coerce_int(
+                overrides["indentation"],
+                config["indentation"],
+            )
+        if "max_gap" in overrides:
+            config["max_gap"] = _coerce_float(
+                overrides["max_gap"],
+                config["max_gap"],
+            )
+        if "metacharacter_substitute" in overrides:
+            config["metacharacter_substitute"] = _normalise_metacharacters(
+                overrides["metacharacter_substitute"],
+            )
+        if "capitalisation_scheme" in overrides and isinstance(
+            overrides["capitalisation_scheme"],
+            str,
+        ):
+            config["capitalisation_scheme"] = overrides["capitalisation_scheme"]
+
+    config["metacharacter_substitute"] = _normalise_metacharacters(
+        config["metacharacter_substitute"]
+    )
+
+    global _LAST_PARSER_CONFIG
+    _LAST_PARSER_CONFIG = deepcopy(config)
+    return config
+
+
+def get_last_parser_config() -> dict[str, Any] | None:
+    """Return the most recent parser configuration (for testing/debugging)."""
+
+    if _LAST_PARSER_CONFIG is None:
+        return None
+
+    return deepcopy(_LAST_PARSER_CONFIG)
 
 
 def _store_graph(graph: DrawioParserGraph, payload_hash: str | None = None) -> str:
@@ -147,18 +276,27 @@ def get_graph_summary(graph_id: str) -> GraphSummary:
     return _build_summary(graph_id, graph)
 
 
-def parse_drawio_xml(serialized_xml: str) -> tuple[str, DrawioParserGraph]:
+def parse_drawio_xml(
+    serialized_xml: str, parser_config: dict[str, Any] | None = None
+) -> tuple[str, DrawioParserGraph]:
     """Parse DrawIO XML into a DrawioParserGraph and cache it."""
     normalized_xml = _normalize_drawio_xml(serialized_xml)
-    config = _default_parser_config()
+    config = _apply_parser_overrides(parser_config)
+    payload_descriptor = json.dumps(
+        {"xml": normalized_xml, "config": config},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    payload_hash = hashlib.sha256(payload_descriptor.encode("utf-8")).hexdigest()
     graph = _build_graph_from_raw_xml(normalized_xml, config)
-    payload_hash = hashlib.sha256(normalized_xml.encode("utf-8")).hexdigest()
     graph_id = _store_graph(graph, payload_hash)
     return graph_id, graph
 
 
-def parse_drawio_xml_to_json(serialized_xml: str) -> str:
+def parse_drawio_xml_to_json(
+    serialized_xml: str, parser_config: dict[str, Any] | None = None
+) -> str:
     """Parse DrawIO XML and return a JSON payload describing the graph."""
-    graph_id, graph = parse_drawio_xml(serialized_xml)
+    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)
     summary = _build_summary(graph_id, graph)
     return json.dumps(summary, sort_keys=True)

--- a/src/main/webapp/plugins/rdfexport/src/mockBlackBox.ts
+++ b/src/main/webapp/plugins/rdfexport/src/mockBlackBox.ts
@@ -2,6 +2,7 @@ import { LOG_PREFIX, logError, logInfo } from "./logging";
 import {
   invokeDrawioParser,
   type DrawioParserResult,
+  type DrawioParserConfigPayload,
   debugPyodide,
 } from "./pyodideRuntime";
 
@@ -14,8 +15,9 @@ function formatParserResult(result: DrawioParserResult): string {
 
 async function parseSerializedXml(
   serializedXml: string,
+  config?: DrawioParserConfigPayload | null,
 ): Promise<DrawioParserResult> {
-  const processed = await invokeDrawioParser(serializedXml);
+  const processed = await invokeDrawioParser(serializedXml, config);
   logInfo(
     LOG_PREFIX.BLACKBOX,
     `Parsed DrawIO graph ${processed.graphId} with ${processed.tripleCount} triples`,
@@ -23,14 +25,17 @@ async function parseSerializedXml(
   return processed;
 }
 
-export async function runMockBlackBox(serializedXml: string): Promise<string> {
+export async function runMockBlackBox(
+  serializedXml: string,
+  config?: DrawioParserConfigPayload | null,
+): Promise<string> {
   logInfo(
     LOG_PREFIX.BLACKBOX,
     `Received serialized payload (${serializedXml.length} characters)`,
   );
 
   try {
-    const processed = await parseSerializedXml(serializedXml);
+    const processed = await parseSerializedXml(serializedXml, config);
     const summary = formatParserResult(processed);
     const output = `${BLACK_BOX_PREFIX} len=${serializedXml.length}\n${summary}\n${BLACK_BOX_SUFFIX}`;
     logInfo(LOG_PREFIX.BLACKBOX, "Black box processing completed");
@@ -43,13 +48,14 @@ export async function runMockBlackBox(serializedXml: string): Promise<string> {
 
 export async function runDrawioPipeline(
   serializedXml: string,
+  config?: DrawioParserConfigPayload | null,
 ): Promise<string> {
   logInfo(
     LOG_PREFIX.BLACKBOX,
     `Generating Turtle payload for serialized input (${serializedXml.length} characters)`,
   );
 
-  const processed = await parseSerializedXml(serializedXml);
+  const processed = await parseSerializedXml(serializedXml, config);
 
   if (processed.rawTurtle == null || processed.rawTurtle.length === 0) {
     throw new Error("DrawIO parser did not return Turtle serialization");
@@ -63,4 +69,7 @@ export async function runDrawioPipeline(
 }
 
 export { debugPyodide };
-export type { DrawioParserResult } from "./pyodideRuntime";
+export type {
+  DrawioParserResult,
+  DrawioParserConfigPayload,
+} from "./pyodideRuntime";

--- a/src/main/webapp/plugins/rdfexport/src/pyodideRuntime.ts
+++ b/src/main/webapp/plugins/rdfexport/src/pyodideRuntime.ts
@@ -15,6 +15,20 @@ export interface DrawioParserResult {
   rawTurtle: string | null;
 }
 
+export interface DrawioParserConfigPayload {
+  infer_type_of_literals: boolean;
+  include_preamble: boolean;
+  ontology_iri: string | null;
+  prefix: string | null;
+  prefix_iri: string | null;
+  indentation: number;
+  include_label: boolean;
+  max_gap: number;
+  strict_mode: boolean;
+  metacharacter_substitute: string[];
+  capitalisation_scheme: string;
+}
+
 type RawGraphSummary = {
   graph_id: string;
   triple_count: number;
@@ -373,6 +387,7 @@ function mapRawSummary(raw: RawGraphSummary): DrawioParserResult {
 
 export async function invokeDrawioParser(
   serializedXml: string,
+  config?: DrawioParserConfigPayload | null,
 ): Promise<DrawioParserResult> {
   await ensurePythonEnvironment();
   const pyodide = await ensurePyodideInstance();
@@ -384,8 +399,9 @@ export async function invokeDrawioParser(
 
   try {
     const quoted = JSON.stringify(serializedXml);
+    const configJson = JSON.stringify(config ?? null);
     const jsonResult = (await pyodide.runPythonAsync(
-      `from pyodide_pipeline.drawio_pipeline import parse_drawio_xml_to_json\nparse_drawio_xml_to_json(${quoted})`,
+      `from pyodide_pipeline.drawio_pipeline import parse_drawio_xml_to_json\nimport json\nparse_drawio_xml_to_json(${quoted}, json.loads(${JSON.stringify(configJson)}))`,
     )) as string;
 
     const rawSummary = JSON.parse(jsonResult) as RawGraphSummary;

--- a/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
+++ b/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
@@ -1093,7 +1093,7 @@ function installCsvPathProperty(): void {
     preambleButton.setAttribute("data-rdfexport-preamble-button", "true");
     preambleButton.style.marginTop = "8px";
     preambleButton.style.width = "210px";
-    preambleButton.style.display = "inline-block";
+    preambleButton.style.display = "block";
     preambleButton.style.textAlign = "center";
     (preambleButton as HTMLElement).className =
       (preambleButton as HTMLElement).className || "geButton";
@@ -1141,7 +1141,7 @@ function installCsvPathProperty(): void {
     parserSettingsButton.setAttribute(PARSER_SETTINGS_BUTTON_ATTRIBUTE, "true");
     parserSettingsButton.style.marginTop = "6px";
     parserSettingsButton.style.width = "210px";
-    parserSettingsButton.style.display = "inline-block";
+    parserSettingsButton.style.display = "block";
     parserSettingsButton.style.textAlign = "center";
     (parserSettingsButton as HTMLElement).className =
       (parserSettingsButton as HTMLElement).className || "geButton";

--- a/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
+++ b/src/main/webapp/plugins/rdfexport/src/rdfexport.ts
@@ -138,7 +138,483 @@ const PREAMBLE_ENTRY_TAG = "userObjectPreambleElement";
 const PREAMBLE_PREFIX_ATTRIBUTE = "rdfPrefix";
 const PREAMBLE_IRI_ATTRIBUTE = "rdfIRI";
 
-import { runDrawioPipeline } from "./mockBlackBox";
+const PARSER_SETTINGS_ATTRIBUTE_NAME = "rdfParserSettings";
+const PARSER_SETTINGS_STORAGE_VERSION = 1;
+const PARSER_SETTINGS_BUTTON_RESOURCE_KEY = "parserSettings";
+const DEFAULT_PARSER_SETTINGS_BUTTON_LABEL = "Parser Settings...";
+const PARSER_SETTINGS_DIALOG_ATTRIBUTE =
+  "data-rdfexport-parser-settings-dialog";
+const PARSER_SETTINGS_BUTTON_ATTRIBUTE =
+  "data-rdfexport-parser-settings-button";
+const PARSER_SETTINGS_INCLUDE_PREAMBLE_ATTRIBUTE =
+  "data-rdfexport-parser-include-preamble";
+const PARSER_SETTINGS_INCLUDE_LABEL_ATTRIBUTE =
+  "data-rdfexport-parser-include-label";
+const PARSER_SETTINGS_INFER_TYPES_ATTRIBUTE =
+  "data-rdfexport-parser-infer-types";
+const PARSER_SETTINGS_STRICT_MODE_ATTRIBUTE =
+  "data-rdfexport-parser-strict-mode";
+const PARSER_SETTINGS_PREFIX_ATTRIBUTE = "data-rdfexport-parser-prefix";
+const PARSER_SETTINGS_PREFIX_IRI_ATTRIBUTE = "data-rdfexport-parser-prefix-iri";
+const PARSER_SETTINGS_ONTOLOGY_IRI_ATTRIBUTE =
+  "data-rdfexport-parser-ontology-iri";
+const PARSER_SETTINGS_INDENTATION_ATTRIBUTE =
+  "data-rdfexport-parser-indentation";
+const PARSER_SETTINGS_MAX_GAP_ATTRIBUTE = "data-rdfexport-parser-max-gap";
+const PARSER_SETTINGS_CAPITALISATION_ATTRIBUTE =
+  "data-rdfexport-parser-capitalisation";
+const PARSER_SETTINGS_STRATEGY_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-strategy";
+const PARSER_SETTINGS_METACHAR_LIST_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-list";
+const PARSER_SETTINGS_METACHAR_ENTRY_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-entry";
+const PARSER_SETTINGS_METACHAR_CHAR_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-char";
+const PARSER_SETTINGS_METACHAR_REPLACEMENT_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-replacement";
+const PARSER_SETTINGS_METACHAR_REMOVE_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-remove";
+const PARSER_SETTINGS_METACHAR_ADD_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-add";
+const PARSER_SETTINGS_APPLY_ATTRIBUTE = "data-rdfexport-parser-apply";
+const PARSER_SETTINGS_CANCEL_ATTRIBUTE = "data-rdfexport-parser-cancel";
+
+const DRAWIO_PARSER_DEFAULT_INDENTATION = 2;
+const DRAWIO_PARSER_DEFAULT_MAX_GAP = 10;
+type CapitalisationScheme = "upper-camel" | "lower-camel" | "flat" | "none";
+const DRAWIO_PARSER_DEFAULT_CAPITALISATION: CapitalisationScheme =
+  "upper-camel";
+type MetacharacterStrategy = "url" | "remove" | "custom";
+const DRAWIO_PARSER_DEFAULT_METACHARACTER_STRATEGY: MetacharacterStrategy =
+  "url";
+
+const METACHARACTER_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: " ", label: "Space ( )" },
+  { value: "(", label: "(" },
+  { value: ")", label: ")" },
+  { value: "[", label: "[" },
+  { value: "]", label: "]" },
+  { value: "{", label: "{" },
+  { value: "}", label: "}" },
+  { value: "/", label: "/" },
+  { value: ",", label: "," },
+  { value: ":", label: ":" },
+  { value: ".", label: "." },
+  { value: "'", label: "'" },
+  { value: '"', label: '"' },
+  { value: "\u00a0", label: "Non-breaking space" },
+  { value: "#", label: "#" },
+];
+
+const CAPITALISATION_SCHEME_OPTIONS: Array<{
+  value: CapitalisationScheme;
+  label: string;
+}> = [
+  { value: "upper-camel", label: "Upper camel case" },
+  { value: "lower-camel", label: "Lower camel case" },
+  { value: "flat", label: "Flat (lowercase)" },
+  { value: "none", label: "Leave unchanged" },
+];
+
+const METACHARACTER_STRATEGY_OPTIONS: Array<{
+  value: MetacharacterStrategy;
+  label: string;
+}> = [
+  {
+    value: "url",
+    label: "Replace unspecified metacharacters with URL entities",
+  },
+  {
+    value: "remove",
+    label: "Remove unspecified metacharacters",
+  },
+  {
+    value: "custom",
+    label: "Use only custom substitutions",
+  },
+];
+
+interface ParserSettingsEntry {
+  character: string;
+  replacement: string;
+}
+
+interface ParserSettings {
+  includePreamble: boolean;
+  inferTypeOfLiterals: boolean;
+  includeLabel: boolean;
+  strictMode: boolean;
+  indentation: number;
+  maxGap: number;
+  ontologyIri: string | null;
+  prefix: string | null;
+  prefixIri: string | null;
+  capitalisationScheme: CapitalisationScheme;
+  metacharacterStrategy: MetacharacterStrategy;
+  metacharacterEntries: ParserSettingsEntry[];
+}
+
+interface StoredParserSettings {
+  version: number;
+  settings: ParserSettings;
+}
+
+function createDefaultParserSettings(): ParserSettings {
+  return {
+    includePreamble: true,
+    inferTypeOfLiterals: true,
+    includeLabel: true,
+    strictMode: false,
+    indentation: DRAWIO_PARSER_DEFAULT_INDENTATION,
+    maxGap: DRAWIO_PARSER_DEFAULT_MAX_GAP,
+    ontologyIri: null,
+    prefix: null,
+    prefixIri: null,
+    capitalisationScheme: DRAWIO_PARSER_DEFAULT_CAPITALISATION,
+    metacharacterStrategy: DRAWIO_PARSER_DEFAULT_METACHARACTER_STRATEGY,
+    metacharacterEntries: [],
+  };
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const lowered = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(lowered)) {
+      return true;
+    }
+    if (["false", "0", "no", "off"].includes(lowered)) {
+      return false;
+    }
+  }
+
+  if (value == null) {
+    return fallback;
+  }
+
+  return Boolean(value);
+}
+
+function normalizeNullableString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeIndentation(value: unknown, fallback: number): number {
+  if (typeof value === "string" && value.trim().length === 0) {
+    return Math.max(0, Math.round(fallback));
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return Math.max(0, Math.round(numeric));
+  }
+  return Math.max(0, Math.round(fallback));
+}
+
+function normalizeMaxGap(value: unknown, fallback: number): number {
+  if (typeof value === "string" && value.trim().length === 0) {
+    return Math.max(0, fallback);
+  }
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return Math.max(0, numeric);
+  }
+  return Math.max(0, fallback);
+}
+
+function normalizeCapitalisationScheme(
+  value: unknown,
+  fallback: CapitalisationScheme,
+): CapitalisationScheme {
+  if (value === "lower-camel" || value === "flat" || value === "none") {
+    return value;
+  }
+  if (value === "upper-camel") {
+    return "upper-camel";
+  }
+  return fallback;
+}
+
+function normalizeMetacharacterStrategy(
+  value: unknown,
+  fallback: MetacharacterStrategy,
+): MetacharacterStrategy {
+  if (value === "remove" || value === "custom" || value === "url") {
+    return value;
+  }
+  return fallback;
+}
+
+function normalizeMetacharacterEntries(
+  entries: unknown,
+): ParserSettingsEntry[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  const normalized: ParserSettingsEntry[] = [];
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+
+    const character =
+      typeof (entry as ParserSettingsEntry).character === "string"
+        ? (entry as ParserSettingsEntry).character
+        : "";
+
+    if (character.length === 0) {
+      continue;
+    }
+
+    const replacement =
+      typeof (entry as ParserSettingsEntry).replacement === "string"
+        ? (entry as ParserSettingsEntry).replacement
+        : "";
+
+    normalized.push({ character, replacement });
+  }
+
+  return normalized;
+}
+
+function normaliseParserSettings(
+  partial: Partial<ParserSettings> | null | undefined,
+): ParserSettings {
+  const defaults = createDefaultParserSettings();
+
+  return {
+    includePreamble: normalizeBoolean(
+      partial?.includePreamble,
+      defaults.includePreamble,
+    ),
+    inferTypeOfLiterals: normalizeBoolean(
+      partial?.inferTypeOfLiterals,
+      defaults.inferTypeOfLiterals,
+    ),
+    includeLabel: normalizeBoolean(
+      partial?.includeLabel,
+      defaults.includeLabel,
+    ),
+    strictMode: normalizeBoolean(partial?.strictMode, defaults.strictMode),
+    indentation: normalizeIndentation(
+      partial?.indentation,
+      defaults.indentation,
+    ),
+    maxGap: normalizeMaxGap(partial?.maxGap, defaults.maxGap),
+    ontologyIri:
+      partial?.ontologyIri != null
+        ? normalizeNullableString(partial.ontologyIri)
+        : null,
+    prefix:
+      partial?.prefix != null ? normalizeNullableString(partial.prefix) : null,
+    prefixIri:
+      partial?.prefixIri != null
+        ? normalizeNullableString(partial.prefixIri)
+        : null,
+    capitalisationScheme: normalizeCapitalisationScheme(
+      partial?.capitalisationScheme,
+      defaults.capitalisationScheme,
+    ),
+    metacharacterStrategy: normalizeMetacharacterStrategy(
+      partial?.metacharacterStrategy,
+      defaults.metacharacterStrategy,
+    ),
+    metacharacterEntries: normalizeMetacharacterEntries(
+      partial?.metacharacterEntries,
+    ),
+  };
+}
+
+function parseStoredParserSettings(raw: string | null): ParserSettings {
+  if (!raw) {
+    return createDefaultParserSettings();
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as StoredParserSettings | ParserSettings;
+    if (parsed && typeof parsed === "object") {
+      if (
+        typeof (parsed as StoredParserSettings).settings === "object" &&
+        (parsed as StoredParserSettings).settings !== null
+      ) {
+        return normaliseParserSettings(
+          (parsed as StoredParserSettings).settings,
+        );
+      }
+
+      return normaliseParserSettings(parsed as ParserSettings);
+    }
+  } catch (error) {
+    // ignore malformed stored state and fall back to defaults
+  }
+
+  return createDefaultParserSettings();
+}
+
+function serializeParserSettings(settings: ParserSettings): string {
+  const normalized = normaliseParserSettings(settings);
+  const storage: StoredParserSettings = {
+    version: PARSER_SETTINGS_STORAGE_VERSION,
+    settings: normalized,
+  };
+  return JSON.stringify(storage);
+}
+
+const DEFAULT_SERIALIZED_PARSER_SETTINGS = serializeParserSettings(
+  createDefaultParserSettings(),
+);
+
+function buildParserConfigPayloadFromSettings(
+  settings: ParserSettings,
+): DrawioParserConfigPayload {
+  const normalized = normaliseParserSettings(settings);
+  const substitutes: string[] = [];
+
+  if (normalized.metacharacterStrategy === "url") {
+    substitutes.push("url");
+  } else if (normalized.metacharacterStrategy === "remove") {
+    substitutes.push("remove");
+  }
+
+  for (const entry of normalized.metacharacterEntries) {
+    substitutes.push(`${entry.character}=${entry.replacement ?? ""}`);
+  }
+
+  return {
+    infer_type_of_literals: normalized.inferTypeOfLiterals,
+    include_preamble: normalized.includePreamble,
+    ontology_iri: normalizeNullableString(normalized.ontologyIri),
+    prefix: normalizeNullableString(normalized.prefix),
+    prefix_iri: normalizeNullableString(normalized.prefixIri),
+    indentation: normalized.indentation,
+    include_label: normalized.includeLabel,
+    max_gap: normalized.maxGap,
+    strict_mode: normalized.strictMode,
+    metacharacter_substitute: substitutes,
+    capitalisation_scheme: normalized.capitalisationScheme,
+  };
+}
+
+function extractValueElement(
+  model: MxGraphModel,
+  rootCell: any,
+): Element | null {
+  if (typeof model.getValue === "function") {
+    const value = model.getValue(rootCell);
+    if (value && typeof (value as Element).getAttribute === "function") {
+      return value as Element;
+    }
+  }
+
+  const fallback = (rootCell as { value?: any }).value;
+  if (fallback && typeof (fallback as Element).getAttribute === "function") {
+    return fallback as Element;
+  }
+
+  return null;
+}
+
+function readParserSettingsFromGraphInstance(
+  graph: MxGraph,
+  model: MxGraphModel,
+  rootCell: any,
+): ParserSettings {
+  let rawValue: string | null = null;
+
+  if (typeof graph.getAttributeForCell === "function") {
+    const attributeValue = graph.getAttributeForCell(
+      rootCell,
+      PARSER_SETTINGS_ATTRIBUTE_NAME,
+      null,
+    );
+    rawValue = typeof attributeValue === "string" ? attributeValue : null;
+  }
+
+  if (!rawValue || rawValue.length === 0) {
+    const valueElement = extractValueElement(model, rootCell);
+    if (valueElement) {
+      const attribute = valueElement.getAttribute(
+        PARSER_SETTINGS_ATTRIBUTE_NAME,
+      );
+      rawValue = attribute != null && attribute.length > 0 ? attribute : null;
+    }
+  }
+
+  return parseStoredParserSettings(rawValue);
+}
+
+function writeParserSettingsToGraphInstance(
+  graph: MxGraph,
+  model: MxGraphModel,
+  rootCell: any,
+  settings: ParserSettings,
+): void {
+  const serialized = serializeParserSettings(settings);
+  const valueToStore =
+    serialized === DEFAULT_SERIALIZED_PARSER_SETTINGS ? null : serialized;
+
+  model.beginUpdate?.();
+  try {
+    if (typeof graph.setAttributeForCell === "function") {
+      graph.setAttributeForCell(
+        rootCell,
+        PARSER_SETTINGS_ATTRIBUTE_NAME,
+        valueToStore,
+      );
+    } else {
+      const valueElement = extractValueElement(model, rootCell);
+      if (valueElement) {
+        if (valueToStore != null) {
+          valueElement.setAttribute(
+            PARSER_SETTINGS_ATTRIBUTE_NAME,
+            valueToStore,
+          );
+        } else if (typeof valueElement.removeAttribute === "function") {
+          valueElement.removeAttribute(PARSER_SETTINGS_ATTRIBUTE_NAME);
+        }
+        (model as { markDirty?: () => void }).markDirty?.();
+      }
+    }
+  } finally {
+    model.endUpdate?.();
+  }
+}
+
+function buildParserConfigPayloadFromGraph(
+  graph: MxGraph | undefined | null,
+): DrawioParserConfigPayload {
+  if (!graph || typeof graph.getModel !== "function") {
+    return buildParserConfigPayloadFromSettings(createDefaultParserSettings());
+  }
+
+  const model = graph.getModel();
+  if (!model || typeof model.getRoot !== "function") {
+    return buildParserConfigPayloadFromSettings(createDefaultParserSettings());
+  }
+
+  const rootCell = model.getRoot();
+  if (!rootCell) {
+    return buildParserConfigPayloadFromSettings(createDefaultParserSettings());
+  }
+
+  const settings = readParserSettingsFromGraphInstance(graph, model, rootCell);
+  return buildParserConfigPayloadFromSettings(settings);
+}
+
+import {
+  runDrawioPipeline,
+  type DrawioParserConfigPayload,
+} from "./mockBlackBox";
 import { LOG_PREFIX, logError, logInfo } from "./logging";
 
 let csvPropertyPatched = false;
@@ -623,6 +1099,54 @@ function installCsvPathProperty(): void {
       (preambleButton as HTMLElement).className || "geButton";
     preambleSection.appendChild(preambleButton);
 
+    const openParserSettingsDialog = (): void => {
+      if (!ui) {
+        return;
+      }
+
+      const rootCell = getRootCell();
+      if (!rootCell) {
+        return;
+      }
+
+      const dialog = createParserSettingsDialog(ui, graph, model, rootCell);
+      if (!dialog) {
+        return;
+      }
+
+      ui.showDialog?.(dialog.container, 520, 520, true, true, null, false);
+      dialog.init?.();
+    };
+
+    const parserSettingsLabel = resolveLabel(
+      PARSER_SETTINGS_BUTTON_RESOURCE_KEY,
+      DEFAULT_PARSER_SETTINGS_BUTTON_LABEL,
+    );
+
+    const parserSettingsButton = ((): HTMLElement => {
+      if (typeof mxUtils.button === "function") {
+        return mxUtils.button(parserSettingsLabel, () => {
+          openParserSettingsDialog();
+        });
+      }
+
+      const button = document.createElement("button");
+      button.textContent = parserSettingsLabel;
+      button.addEventListener("click", () => {
+        openParserSettingsDialog();
+      });
+      return button;
+    })();
+
+    parserSettingsButton.setAttribute(PARSER_SETTINGS_BUTTON_ATTRIBUTE, "true");
+    parserSettingsButton.style.marginTop = "6px";
+    parserSettingsButton.style.width = "210px";
+    parserSettingsButton.style.display = "inline-block";
+    parserSettingsButton.style.textAlign = "center";
+    (parserSettingsButton as HTMLElement).className =
+      (parserSettingsButton as HTMLElement).className || "geButton";
+    preambleSection.appendChild(parserSettingsButton);
+
     const panelContainer:
       | (HTMLElement & {
           insertBefore?: (node: Node, child: Node | null) => Node;
@@ -874,6 +1398,515 @@ function buildValueWithPreamble(
   }
 
   return valueElement;
+}
+
+function createParserSettingsDialog(
+  editorUi: EditorUi,
+  graph: MxGraph,
+  model: MxGraphModel,
+  rootCell: any,
+): { container: HTMLElement; init(): void } | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+
+  const settings = readParserSettingsFromGraphInstance(graph, model, rootCell);
+
+  const container = document.createElement("div");
+  container.setAttribute(PARSER_SETTINGS_DIALOG_ATTRIBUTE, "true");
+  container.style.position = "relative";
+  container.style.width = "100%";
+  container.style.height = "100%";
+
+  const scrollArea = document.createElement("div");
+  scrollArea.style.position = "absolute";
+  scrollArea.style.top = "30px";
+  scrollArea.style.left = "30px";
+  scrollArea.style.right = "30px";
+  scrollArea.style.bottom = "80px";
+  scrollArea.style.overflowY = "auto";
+  scrollArea.style.display = "flex";
+  scrollArea.style.flexDirection = "column";
+  scrollArea.style.gap = "14px";
+  container.appendChild(scrollArea);
+
+  const createSection = (title: string): HTMLElement => {
+    const section = document.createElement("div");
+    section.style.display = "flex";
+    section.style.flexDirection = "column";
+    section.style.gap = "8px";
+
+    const heading = document.createElement("div");
+    heading.textContent = title;
+    heading.style.fontWeight = "bold";
+    heading.style.fontSize = "13px";
+    section.appendChild(heading);
+
+    return section;
+  };
+
+  const createCheckboxRow = (
+    label: string,
+    initial: boolean,
+    dataAttribute: string,
+  ): { container: HTMLElement; input: HTMLInputElement } => {
+    const row = document.createElement("label");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.gap = "8px";
+    row.style.cursor = "pointer";
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = initial;
+    checkbox.defaultChecked = initial;
+    checkbox.setAttribute(dataAttribute, "true");
+    row.appendChild(checkbox);
+
+    const text = document.createElement("span");
+    text.textContent = label;
+    text.style.flex = "1 1 auto";
+    row.appendChild(text);
+
+    return { container: row, input: checkbox };
+  };
+
+  const createLabeledInput = (
+    section: HTMLElement,
+    label: string,
+    initial: string | null,
+    dataAttribute: string,
+    options?: { type?: string; step?: string },
+  ): HTMLInputElement => {
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "flex";
+    wrapper.style.flexDirection = "column";
+    wrapper.style.gap = "4px";
+
+    const labelElement = document.createElement("label");
+    labelElement.textContent = label;
+    labelElement.style.fontSize = "12px";
+    labelElement.style.fontWeight = "500";
+    wrapper.appendChild(labelElement);
+
+    const input = document.createElement("input");
+    input.type = options?.type ?? "text";
+    if (options?.step) {
+      input.step = options.step;
+    }
+    input.value = initial ?? "";
+    input.setAttribute(dataAttribute, "true");
+    input.style.height = "26px";
+    input.style.padding = "4px 6px";
+    input.style.border = "1px solid var(--geInputBorderColor, #d5d5d5)";
+    input.style.borderRadius = "2px";
+    input.style.boxSizing = "border-box";
+    input.style.fontSize = "12px";
+    input.autocomplete = "off";
+
+    const inputId = `rdfexport-parser-${dataAttribute}-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    input.id = inputId;
+    labelElement.htmlFor = inputId;
+
+    wrapper.appendChild(input);
+    section.appendChild(wrapper);
+    return input;
+  };
+
+  const createSelect = <T extends string>(
+    section: HTMLElement,
+    label: string,
+    options: Array<{ value: T; label: string }>,
+    initial: T,
+    dataAttribute: string,
+  ): HTMLSelectElement => {
+    const wrapper = document.createElement("div");
+    wrapper.style.display = "flex";
+    wrapper.style.flexDirection = "column";
+    wrapper.style.gap = "4px";
+
+    const labelElement = document.createElement("label");
+    labelElement.textContent = label;
+    labelElement.style.fontSize = "12px";
+    labelElement.style.fontWeight = "500";
+    wrapper.appendChild(labelElement);
+
+    const select = document.createElement("select");
+    select.setAttribute(dataAttribute, "true");
+    select.style.height = "28px";
+    select.style.padding = "4px 6px";
+    select.style.border = "1px solid var(--geInputBorderColor, #d5d5d5)";
+    select.style.borderRadius = "2px";
+    select.style.fontSize = "12px";
+
+    for (const option of options) {
+      const element = document.createElement("option");
+      element.value = option.value;
+      element.textContent = option.label;
+      select.appendChild(element);
+    }
+
+    if (!options.some((option) => option.value === initial)) {
+      select.value = options[0]?.value ?? "";
+    } else {
+      select.value = initial;
+    }
+
+    const selectId = `rdfexport-parser-select-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+    select.id = selectId;
+    labelElement.htmlFor = selectId;
+
+    wrapper.appendChild(select);
+    section.appendChild(wrapper);
+    return select;
+  };
+
+  const generalSection = createSection("General behaviour");
+  scrollArea.appendChild(generalSection);
+
+  const includePreambleRow = createCheckboxRow(
+    "Include preamble block in output",
+    settings.includePreamble,
+    PARSER_SETTINGS_INCLUDE_PREAMBLE_ATTRIBUTE,
+  );
+  generalSection.appendChild(includePreambleRow.container);
+  const includePreambleCheckbox = includePreambleRow.input;
+
+  const includeLabelRow = createCheckboxRow(
+    "Include rdfs:label annotations",
+    settings.includeLabel,
+    PARSER_SETTINGS_INCLUDE_LABEL_ATTRIBUTE,
+  );
+  generalSection.appendChild(includeLabelRow.container);
+  const includeLabelCheckbox = includeLabelRow.input;
+
+  const inferTypesRow = createCheckboxRow(
+    "Infer literal datatypes",
+    settings.inferTypeOfLiterals,
+    PARSER_SETTINGS_INFER_TYPES_ATTRIBUTE,
+  );
+  generalSection.appendChild(inferTypesRow.container);
+  const inferTypesCheckbox = inferTypesRow.input;
+
+  const strictModeRow = createCheckboxRow(
+    "Enable strict arrow parsing",
+    settings.strictMode,
+    PARSER_SETTINGS_STRICT_MODE_ATTRIBUTE,
+  );
+  generalSection.appendChild(strictModeRow.container);
+  const strictModeCheckbox = strictModeRow.input;
+
+  const identifiersSection = createSection("Identifiers");
+  scrollArea.appendChild(identifiersSection);
+
+  const prefixInput = createLabeledInput(
+    identifiersSection,
+    "Generated individual prefix",
+    settings.prefix,
+    PARSER_SETTINGS_PREFIX_ATTRIBUTE,
+  );
+
+  const prefixIriInput = createLabeledInput(
+    identifiersSection,
+    "Prefix IRI",
+    settings.prefixIri,
+    PARSER_SETTINGS_PREFIX_IRI_ATTRIBUTE,
+  );
+
+  const ontologyIriInput = createLabeledInput(
+    identifiersSection,
+    "Ontology IRI",
+    settings.ontologyIri,
+    PARSER_SETTINGS_ONTOLOGY_IRI_ATTRIBUTE,
+  );
+
+  const formattingSection = createSection("Formatting");
+  scrollArea.appendChild(formattingSection);
+
+  const indentationInput = createLabeledInput(
+    formattingSection,
+    "Indentation (spaces)",
+    String(settings.indentation),
+    PARSER_SETTINGS_INDENTATION_ATTRIBUTE,
+    { type: "number" },
+  );
+  indentationInput.min = "0";
+
+  const maxGapInput = createLabeledInput(
+    formattingSection,
+    "Maximum gap for loose arrows",
+    String(settings.maxGap),
+    PARSER_SETTINGS_MAX_GAP_ATTRIBUTE,
+    { type: "number", step: "0.1" },
+  );
+  maxGapInput.min = "0";
+
+  const capitalisationSelect = createSelect(
+    formattingSection,
+    "Capitalisation scheme",
+    CAPITALISATION_SCHEME_OPTIONS,
+    settings.capitalisationScheme,
+    PARSER_SETTINGS_CAPITALISATION_ATTRIBUTE,
+  );
+
+  const metacharSection = createSection("Metacharacter substitution");
+  scrollArea.appendChild(metacharSection);
+
+  const strategySelect = createSelect(
+    metacharSection,
+    "Default handling",
+    METACHARACTER_STRATEGY_OPTIONS,
+    settings.metacharacterStrategy,
+    PARSER_SETTINGS_STRATEGY_ATTRIBUTE,
+  );
+
+  type MetacharEntryState = {
+    container: HTMLElement;
+    select: HTMLSelectElement;
+    replacement: HTMLInputElement;
+  };
+
+  const entriesList = document.createElement("div");
+  entriesList.style.display = "flex";
+  entriesList.style.flexDirection = "column";
+  entriesList.style.gap = "6px";
+  entriesList.setAttribute(PARSER_SETTINGS_METACHAR_LIST_ATTRIBUTE, "true");
+  metacharSection.appendChild(entriesList);
+
+  const entries: MetacharEntryState[] = [];
+
+  const addEntry = (character: string, replacement: string) => {
+    const row = document.createElement("div");
+    row.style.display = "flex";
+    row.style.alignItems = "center";
+    row.style.gap = "8px";
+    row.setAttribute(PARSER_SETTINGS_METACHAR_ENTRY_ATTRIBUTE, "true");
+
+    const charSelect = document.createElement("select");
+    charSelect.style.flex = "0 0 140px";
+    charSelect.style.height = "28px";
+    charSelect.style.padding = "4px 6px";
+    charSelect.style.border = "1px solid var(--geInputBorderColor, #d5d5d5)";
+    charSelect.style.borderRadius = "2px";
+    charSelect.style.fontSize = "12px";
+    charSelect.setAttribute(PARSER_SETTINGS_METACHAR_CHAR_ATTRIBUTE, "true");
+
+    const ensureOption = (value: string, label: string) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = label;
+      charSelect.appendChild(option);
+    };
+
+    for (const option of METACHARACTER_OPTIONS) {
+      ensureOption(option.value, option.label);
+    }
+
+    if (!METACHARACTER_OPTIONS.some((option) => option.value === character)) {
+      const fallbackLabel =
+        character === " "
+          ? "Space ( )"
+          : character === "\u00a0"
+            ? "Non-breaking space"
+            : character;
+      ensureOption(character, fallbackLabel);
+    }
+
+    charSelect.value = character;
+
+    const replacementInput = document.createElement("input");
+    replacementInput.type = "text";
+    replacementInput.value = replacement;
+    replacementInput.style.flex = "1 1 auto";
+    replacementInput.style.height = "26px";
+    replacementInput.style.padding = "4px 6px";
+    replacementInput.style.border =
+      "1px solid var(--geInputBorderColor, #d5d5d5)";
+    replacementInput.style.borderRadius = "2px";
+    replacementInput.style.fontSize = "12px";
+    replacementInput.setAttribute(
+      PARSER_SETTINGS_METACHAR_REPLACEMENT_ATTRIBUTE,
+      "true",
+    );
+
+    let state: MetacharEntryState;
+
+    const removeEntry = () => {
+      const index = entries.indexOf(state);
+      if (index >= 0) {
+        entries.splice(index, 1);
+      }
+      if (row.parentNode) {
+        row.parentNode.removeChild(row);
+      }
+    };
+
+    const removeButton = ((): HTMLElement => {
+      if (typeof mxUtils.button === "function") {
+        return mxUtils.button("Remove", () => {
+          removeEntry();
+        });
+      }
+      const button = document.createElement("button");
+      button.textContent = "Remove";
+      button.addEventListener("click", () => {
+        removeEntry();
+      });
+      return button;
+    })();
+    removeButton.setAttribute(
+      PARSER_SETTINGS_METACHAR_REMOVE_ATTRIBUTE,
+      "true",
+    );
+    removeButton.className =
+      (removeButton as HTMLElement).className || "geButton";
+
+    state = {
+      container: row,
+      select: charSelect,
+      replacement: replacementInput,
+    };
+
+    row.appendChild(charSelect);
+    row.appendChild(replacementInput);
+    row.appendChild(removeButton);
+    entriesList.appendChild(row);
+    entries.push(state);
+  };
+
+  if (settings.metacharacterEntries.length > 0) {
+    for (const entry of settings.metacharacterEntries) {
+      addEntry(entry.character, entry.replacement);
+    }
+  }
+
+  const addButtonContainer = document.createElement("div");
+  addButtonContainer.style.display = "flex";
+  addButtonContainer.style.justifyContent = "flex-end";
+
+  const addButton = ((): HTMLElement => {
+    if (typeof mxUtils.button === "function") {
+      return mxUtils.button("Add substitution", () => {
+        addEntry(" ", "");
+      });
+    }
+    const button = document.createElement("button");
+    button.textContent = "Add substitution";
+    button.addEventListener("click", () => {
+      addEntry(" ", "");
+    });
+    return button;
+  })();
+
+  addButton.setAttribute(PARSER_SETTINGS_METACHAR_ADD_ATTRIBUTE, "true");
+  addButton.className = (addButton as HTMLElement).className || "geButton";
+  addButtonContainer.appendChild(addButton);
+  metacharSection.appendChild(addButtonContainer);
+
+  const buttons = document.createElement("div");
+  buttons.style.position = "absolute";
+  buttons.style.left = "30px";
+  buttons.style.right = "30px";
+  buttons.style.bottom = "30px";
+  buttons.style.height = "40px";
+  buttons.style.display = "flex";
+  buttons.style.alignItems = "center";
+  buttons.style.justifyContent = "flex-end";
+  buttons.style.gap = "10px";
+  container.appendChild(buttons);
+
+  const cancelLabel = resolveLabel("cancel", "Cancel");
+  const cancelButton = ((): HTMLElement => {
+    if (typeof mxUtils.button === "function") {
+      return mxUtils.button(cancelLabel, () => {
+        editorUi.hideDialog?.();
+      });
+    }
+    const button = document.createElement("button");
+    button.textContent = cancelLabel;
+    button.addEventListener("click", () => {
+      editorUi.hideDialog?.();
+    });
+    return button;
+  })();
+  cancelButton.setAttribute(PARSER_SETTINGS_CANCEL_ATTRIBUTE, "true");
+  cancelButton.className =
+    (cancelButton as HTMLElement).className || "geButton";
+  buttons.appendChild(cancelButton);
+
+  const applyLabel = resolveLabel("apply", "Apply");
+
+  const handleApply = () => {
+    const indentationRaw = indentationInput.value.trim();
+    const maxGapRaw = maxGapInput.value.trim();
+
+    const partialSettings: Partial<ParserSettings> = {
+      includePreamble: includePreambleCheckbox.checked,
+      includeLabel: includeLabelCheckbox.checked,
+      inferTypeOfLiterals: inferTypesCheckbox.checked,
+      strictMode: strictModeCheckbox.checked,
+      prefix: prefixInput.value,
+      prefixIri: prefixIriInput.value,
+      ontologyIri: ontologyIriInput.value,
+      capitalisationScheme: capitalisationSelect.value as CapitalisationScheme,
+      metacharacterStrategy: strategySelect.value as MetacharacterStrategy,
+      metacharacterEntries: entries.map((entry) => ({
+        character: entry.select.value,
+        replacement: entry.replacement.value,
+      })),
+    };
+
+    if (indentationRaw.length > 0) {
+      partialSettings.indentation = Number(indentationRaw);
+    }
+
+    if (maxGapRaw.length > 0) {
+      partialSettings.maxGap = Number(maxGapRaw);
+    }
+
+    const updatedSettings = normaliseParserSettings(partialSettings);
+
+    writeParserSettingsToGraphInstance(graph, model, rootCell, updatedSettings);
+    editorUi.hideDialog?.();
+  };
+
+  const applyButton = ((): HTMLElement => {
+    if (typeof mxUtils.button === "function") {
+      return mxUtils.button(applyLabel, () => {
+        handleApply();
+      });
+    }
+    const button = document.createElement("button");
+    button.textContent = applyLabel;
+    button.addEventListener("click", () => {
+      handleApply();
+    });
+    return button;
+  })();
+
+  applyButton.setAttribute(PARSER_SETTINGS_APPLY_ATTRIBUTE, "true");
+  const applyElement = applyButton as HTMLElement;
+  if (applyElement.className) {
+    if (!/\bgePrimaryBtn\b/.test(applyElement.className)) {
+      applyElement.className += " gePrimaryBtn";
+    }
+  } else {
+    applyElement.className = "geButton gePrimaryBtn";
+  }
+  buttons.appendChild(applyButton);
+
+  const dialog = {
+    container,
+    init() {
+      prefixInput.focus?.();
+    },
+  };
+
+  return dialog;
 }
 
 function createPreambleDialog(
@@ -1211,7 +2244,13 @@ Draw.loadPlugin(function (editorUi: any): void {
         `Generated DrawIO XML payload (${serializedXml.length} characters)`,
       );
 
-      const blackBoxPayload = await runDrawioPipeline(serializedXml);
+      const parserConfig = buildParserConfigPayloadFromGraph(
+        editorUi?.editor?.graph ?? null,
+      );
+      const blackBoxPayload = await runDrawioPipeline(
+        serializedXml,
+        parserConfig,
+      );
       const filename = editorUi.getBaseFilename() + ".ttl";
 
       logInfo(LOG_PREFIX.PIPELINE, `Saving export payload to ${filename}`);

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,4 +1,5 @@
-Script started on 2025-10-15 02:39:14+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
+Script started on Wed Oct 15 04:19:28 2025
+Command: bun run test
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 Attempting to regenerate baselines from 1 commit(s)...
 Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
@@ -37,13 +38,16 @@ Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
      An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
 
 🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
-[1m===================================================== test session starts ======================================================[0m
-platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0 -- /root/.pyenv/versions/3.12.10/bin/python
+[1m====================================== test session starts =======================================[0m
+platform darwin -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0 -- /Users/anonymous/miniconda3/bin/python
 cachedir: .pytest_cache
-rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
+rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
+plugins: langsmith-0.3.41, docker-3.1.2, anyio-4.9.0
+[1mcollecting ... [0m[1mcollected 29 items                                                                               [0m
 
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  3%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m [  6%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [ 10%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 13%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[32m [ 17%][0m
@@ -67,16 +71,28 @@ webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[32m [ 79%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[32m [ 82%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 86%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 89%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 93%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m [ 96%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m [100%][0m
 
-[32m====================================================== [32m[1m29 passed[0m[32m in 6.30s[0m[32m ======================================================[0m
-platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
+[32m======================================= [32m[1m29 passed[0m[32m in 1.02s[0m[32m =======================================[0m
+[1m====================================== test session starts =======================================[0m
+platform darwin -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
+rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
+plugins: langsmith-0.3.41, docker-3.1.2, anyio-4.9.0
+[1mcollecting ... [0m[1mcollected 33 items                                                                               [0m
 
+legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                          [ 87%][0m
+legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                 [100%][0m
 
-[32m====================================================== [32m[1m33 passed[0m[32m in 6.29s[0m[32m ======================================================[0m
+[32m======================================= [32m[1m33 passed[0m[32m in 1.05s[0m[32m =======================================[0m
+[0m[1mbun test [0m[2mv1.2.21 (7c45ed97)[0m
 [0m
 tests/rdfexport.test.ts:
 [BLACKBOX] Received serialized payload (36445 characters)
+[PIPELINE] Initializing Pyodide runtime from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
 [PIPELINE] Pyodide runtime ready
 [PIPELINE] Preparing Pyodide Python environment
 [PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
@@ -88,348 +104,439 @@ tests/rdfexport.test.ts:
 [PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
 [BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
 [BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[0m[33m9477.53ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[2.88ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m270.78ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (23529 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-1 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (3738 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-2 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (3738 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m533.06ms[0m[2m][0m
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] DrawIO parser produced graph graph-3 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (5497 characters)
-[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m554.56ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (39382 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-5 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-6 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m437.01ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (40849 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-7 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (5715 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-8 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (5715 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m368.97ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[PIPELINE] DrawIO parser produced graph graph-9 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (5458 characters)
-[PIPELINE] DrawIO parser produced graph graph-10 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (5458 characters)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m313.13ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (37601 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-11 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (4345 characters)
-[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-12 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (4345 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m297.69ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m1342.85ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[0.64ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m19.22ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (54115 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-13 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (6195 characters)
-[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-14 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (6195 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m367.52ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] DrawIO parser produced graph graph-15 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (6307 characters)
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m303.30ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37282 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-17 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (4369 characters)
-[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-18 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (4369 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m255.00ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (58331 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-19 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (9207 characters)
-[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-20 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (9207 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m357.63ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (30806 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-21 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (4952 characters)
-[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
-[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-22 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (4952 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m201.65ms[0m[2m][0m
-[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[PIPELINE] Generated DrawIO XML payload (34878 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-23 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (5761 characters)
-[PIPELINE] Saving export payload to AA37 Department of Health.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-24 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (5761 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m231.16ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (95196 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-25 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (9826 characters)
-[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-26 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (9826 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m543.02ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-27 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (5721 characters)
-[PIPELINE] DrawIO parser produced graph graph-28 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-28 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-28 (5721 characters)
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m256.64ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (39312 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-29 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-29 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-29 (5053 characters)
-[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-30 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-30 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-30 (5053 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m240.38ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (73820 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-31 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-31 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-31 (9086 characters)
-[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-32 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-32 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-32 (9086 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m439.07ms[0m[2m][0m
 [PIPELINE] Generated DrawIO XML payload (61812 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-33 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-33 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-33 (7040 characters)
+[PIPELINE] DrawIO parser produced graph graph-1 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (7040 characters)
 [PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
 [PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-34 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (7040 characters)
+[PIPELINE] DrawIO parser produced graph graph-2 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (7040 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m444.78ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m140.15ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (44244 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
+[PIPELINE] DrawIO parser produced graph graph-3 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5497 characters)
+[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
+[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m74.51ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (23393 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-35 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (3002 characters)
+[PIPELINE] DrawIO parser produced graph graph-5 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (3002 characters)
 [PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
 [PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-36 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (3002 characters)
+[PIPELINE] DrawIO parser produced graph graph-6 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (3002 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m163.94ms[0m[2m][0m
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m39.43ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (49927 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-37 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-37 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-37 (6443 characters)
-[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-38 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-38 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-38 (6443 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
+[PIPELINE] Generated DrawIO XML payload (23529 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-7 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (3738 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-8 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (3738 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m299.23ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m42.71ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (39382 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-9 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (4590 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-10 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (4590 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m58.57ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (44778 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
+[PIPELINE] DrawIO parser produced graph graph-11 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (5458 characters)
+[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
+[PIPELINE] DrawIO parser produced graph graph-12 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (5458 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m63.36ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (39312 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-13 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (5053 characters)
+[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-14 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (5053 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m54.43ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (73820 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-15 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (9086 characters)
+[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-16 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (9086 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m100.92ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (80864 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-39 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-39 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-39 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-17 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (11220 characters)
 [PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
 [BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-40 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-40 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-40 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-18 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (11220 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m505.16ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m123.46ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (37601 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-19 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (4345 characters)
+[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-20 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (4345 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m59.93ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (95196 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-21 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (9826 characters)
+[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-22 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (9826 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m122.25ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (54115 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
+[PIPELINE] DrawIO parser produced graph graph-23 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (6195 characters)
+[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
+[PIPELINE] DrawIO parser produced graph graph-24 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (6195 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m69.23ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (58331 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
+[PIPELINE] DrawIO parser produced graph graph-25 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (9207 characters)
+[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
+[PIPELINE] DrawIO parser produced graph graph-26 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (9207 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m75.70ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (34878 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-27 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (5761 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-28 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (5761 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m49.49ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (49927 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
+[PIPELINE] DrawIO parser produced graph graph-29 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (6443 characters)
+[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
+[PIPELINE] DrawIO parser produced graph graph-30 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (6443 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m84.30ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (32192 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-41 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-41 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-41 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-31 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (3931 characters)
 [PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
 [PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-42 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-42 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-42 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-32 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (3931 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m191.68ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m66.54ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m47.21ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (40849 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
+[PIPELINE] DrawIO parser produced graph graph-33 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (5715 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
+[PIPELINE] DrawIO parser produced graph graph-34 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (5715 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m57.40ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (48145 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
+[PIPELINE] DrawIO parser produced graph graph-35 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (5721 characters)
+[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
+[PIPELINE] DrawIO parser produced graph graph-36 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (5721 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m65.50ms[0m[2m][0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (30806 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
+[PIPELINE] DrawIO parser produced graph graph-37 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (4952 characters)
+[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
+[PIPELINE] DrawIO parser produced graph graph-38 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (4952 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m43.59ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (37282 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-39 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (4369 characters)
+[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-40 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (4369 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m50.31ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (42005 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
+[PIPELINE] DrawIO parser produced graph graph-41 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (6307 characters)
+[PIPELINE] Saving export payload to F 47-11-1 Elizabeth Simcoe loose sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
+[PIPELINE] DrawIO parser produced graph graph-42 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (6307 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m54.01ms[0m[2m][0m
+[BLACKBOX] Received serialized payload (36445 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
+[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
+[BLACKBOX] Black box processing completed
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m13.46ms[0m[2m][0m
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (36445 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (36445 characters)
@@ -439,113 +546,8 @@ tests/rdfexport.test.ts:
 [BLACKBOX] Returning Turtle payload for graph graph-43 (4714 characters)
 [PIPELINE] Saving export payload to diagram.ttl
 [PIPELINE] Export pipeline completed for diagram.ttl
-[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m53.04ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m19.38ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[0m[32m 27 pass[0m
- 491 expect() calls
-Ran 31 tests across 1 files. [0m[2m[[1m17.40s[0m[2m][0m
-Script done on 2025-10-15 02:39:48+00:00 [COMMAND_EXIT_CODE="0"]
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-17 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (5715 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m57.01ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (48145 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-18 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5721 characters)
-[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-18 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5721 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m62.48ms[0m[2m][0m
-[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (30806 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-19 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (4952 characters)
-[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
-[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-19 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (4952 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m41.02ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37282 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-20 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (4369 characters)
-[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-20 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (4369 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m49.93ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (42005 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
-[PIPELINE] DrawIO parser produced graph graph-21 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (6307 characters)
-[PIPELINE] Saving export payload to F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
-[PIPELINE] DrawIO parser produced graph graph-21 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (6307 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m51.68ms[0m[2m][0m
-[BLACKBOX] Received serialized payload (36445 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
-[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
-[BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m13.28ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[4.01ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m12.14ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[3.84ms[0m[2m][0m
 
 [0m[2m4 tests skipped:[0m
 [0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
@@ -553,11 +555,11 @@ Script done on 2025-10-15 02:39:48+00:00 [COMMAND_EXIT_CODE="0"]
 [0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
 [0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
 
-[0m[32m 26 pass[0m
+[0m[32m 27 pass[0m
  [0m[33m4 skip[0m
 [0m[2m 0 fail[0m
- 452 expect() calls
-Ran 30 tests across 1 file. [0m[2m[[1m2.86s[0m[2m][0m
+ 493 expect() calls
+Ran 31 tests across 1 file. [0m[2m[[1m2.90s[0m[2m][0m
 
 Command exit status: 0
-Script done on Tue Oct 14 03:16:12 2025
+Script done on Wed Oct 15 04:19:34 2025

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,4 +1,4 @@
-Script started on 2025-10-15 00:50:43+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
+Script started on 2025-10-15 02:39:14+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 Attempting to regenerate baselines from 1 commit(s)...
 Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
@@ -38,405 +38,415 @@ Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
 
 🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
 [1m===================================================== test session starts ======================================================[0m
-platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
+platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0 -- /root/.pyenv/versions/3.12.10/bin/python
 cachedir: .pytest_cache
 rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 29 items                                                                                                             [0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m   [  6%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 89%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 93%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m       [ 96%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m         [100%][0m
-[32m====================================================== [32m[1m29 passed[0m[32m in 4.89s[0m[32m ======================================================[0m
-[1m===================================================== test session starts ======================================================[0m
-platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
-rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
-[1mcollecting ... [0m[1mcollected 33 items                                                                                                             [0m
-legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                        [ 87%][0m
-legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                               [100%][0m
-[32m====================================================== [32m[1m33 passed[0m[32m in 4.47s[0m[32m ======================================================[0m
-[0m[1mbun test [0m[2mv1.2.14 (6a363a38)[0m
-[PIPELINE] Initializing Pyodide runtime from /workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m6324.66ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[[1m13.72ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m209.39ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (48145 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-1 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (5721 characters)
-[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-1 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (5721 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m615.30ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (95196 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-2 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (9826 characters)
-[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-2 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (9826 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m724.50ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (30806 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-3 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (4952 characters)
-[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
-[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-3 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (4952 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
+
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  3%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [ 10%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 13%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[32m [ 17%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[32m [ 20%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[32m [ 24%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[32m [ 27%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[32m [ 31%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[32m [ 34%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[32m [ 37%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[32m [ 41%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[32m [ 44%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[32m [ 48%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[32m [ 51%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[32m [ 55%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[32m [ 58%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[32m [ 62%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[32m [ 65%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[32m [ 68%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[32m [ 72%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[32m [ 75%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[32m [ 79%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[32m [ 82%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 86%][0m
+
+[32m====================================================== [32m[1m29 passed[0m[32m in 6.30s[0m[32m ======================================================[0m
+platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
+configfile: pyproject.toml
+
+
+[32m====================================================== [32m[1m33 passed[0m[32m in 6.29s[0m[32m ======================================================[0m
+[0m
+tests/rdfexport.test.ts:
+[BLACKBOX] Received serialized payload (36445 characters)
+[PIPELINE] Pyodide runtime ready
+[PIPELINE] Preparing Pyodide Python environment
+[PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
+[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/__init__.py
+[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/drawio_pipeline.py
+[PIPELINE] Syncing Python wheel to virtual FS: /app/wheels/rdflib-7.2.1-py3-none-any.whl
+[PIPELINE] Pyodide Python environment ready
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
+[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
+[BLACKBOX] Black box processing completed
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[0m[33m9477.53ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[2.88ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m270.78ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (23529 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-1 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (3738 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-2 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (3738 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m189.79ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m533.06ms[0m[2m][0m
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37282 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-4 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (4369 characters)
-[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-4 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (4369 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m214.67ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-3 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5497 characters)
+[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m554.56ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (39382 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-5 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (4590 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-6 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (4590 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m437.01ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (40849 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
+[PIPELINE] DrawIO parser produced graph graph-7 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (5715 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
+[PIPELINE] DrawIO parser produced graph graph-8 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (5715 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m368.97ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[PIPELINE] DrawIO parser produced graph graph-9 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (5458 characters)
+[PIPELINE] DrawIO parser produced graph graph-10 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (5458 characters)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m313.13ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (37601 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-11 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (4345 characters)
+[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-12 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (4345 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m297.69ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (54115 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-5 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (6195 characters)
+[PIPELINE] DrawIO parser produced graph graph-13 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (6195 characters)
 [PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
 [PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-5 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (6195 characters)
+[PIPELINE] DrawIO parser produced graph graph-14 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (6195 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m279.48ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-6 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (3738 characters)
-[PIPELINE] DrawIO parser produced graph graph-6 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (3738 characters)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m170.44ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (49927 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-7 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (6443 characters)
-[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-7 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (6443 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m293.24ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (44244 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-8 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (5497 characters)
-[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-8 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (5497 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m264.29ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m466.80ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m367.52ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] DrawIO parser produced graph graph-15 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (6307 characters)
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m303.30ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (37282 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-17 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (4369 characters)
+[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-18 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (4369 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m255.00ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (58331 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-10 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-19 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (9207 characters)
 [PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
 [PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-10 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-20 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (9207 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m266.78ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m357.63ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (30806 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
+[PIPELINE] DrawIO parser produced graph graph-21 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (4952 characters)
+[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
+[PIPELINE] DrawIO parser produced graph graph-22 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (4952 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m201.65ms[0m[2m][0m
 [0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (34878 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-23 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (5761 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-24 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (5761 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m231.16ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (95196 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-25 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (9826 characters)
+[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-26 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (9826 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m543.02ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-27 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (5721 characters)
+[PIPELINE] DrawIO parser produced graph graph-28 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (5721 characters)
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m256.64ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (39312 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-29 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (5053 characters)
+[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-30 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (5053 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m240.38ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (73820 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-31 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (9086 characters)
+[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-32 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (9086 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m439.07ms[0m[2m][0m
 [PIPELINE] Generated DrawIO XML payload (61812 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-11 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (7040 characters)
+[PIPELINE] DrawIO parser produced graph graph-33 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (7040 characters)
 [PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
 [PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-11 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (7040 characters)
+[PIPELINE] DrawIO parser produced graph graph-34 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (7040 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m265.02ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m444.78ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (23393 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-12 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (3002 characters)
+[PIPELINE] DrawIO parser produced graph graph-35 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (3002 characters)
 [PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
 [PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-12 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (3002 characters)
+[PIPELINE] DrawIO parser produced graph graph-36 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (3002 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m116.57ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39312 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-13 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (5053 characters)
-[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-13 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (5053 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m180.84ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44778 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-14 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-14 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (5458 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m200.12ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (73820 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-15 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (9086 characters)
-[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-15 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (9086 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m400.36ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (42005 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
-[PIPELINE] DrawIO parser produced graph graph-16 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (6307 characters)
-[PIPELINE] Saving export payload to F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
-[PIPELINE] DrawIO parser produced graph graph-16 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (6307 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m183.80ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (39382 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-17 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-17 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m179.05ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-18 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5761 characters)
-[PIPELINE] DrawIO parser produced graph graph-18 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5761 characters)
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m160.91ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-19 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (3931 characters)
-[PIPELINE] DrawIO parser produced graph graph-19 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (3931 characters)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m148.58ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37601 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-20 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (4345 characters)
-[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-20 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (4345 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m172.34ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-21 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (5715 characters)
-[PIPELINE] DrawIO parser produced graph graph-21 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (5715 characters)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m176.61ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m45.27ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m20.58ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-Ran 30 tests across 1 files. [0m[2m[[1m12.45s[0m[2m][0m
-Script done on 2025-10-15 00:51:06+00:00 [COMMAND_EXIT_CODE="0"]
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m163.94ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (49927 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-15 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (6443 characters)
+[PIPELINE] DrawIO parser produced graph graph-37 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (6443 characters)
 [PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-15 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (6443 characters)
+[PIPELINE] DrawIO parser produced graph graph-38 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (6443 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m66.54ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m299.23ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (80864 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
+[PIPELINE] DrawIO parser produced graph graph-39 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (11220 characters)
+[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
+[PIPELINE] DrawIO parser produced graph graph-40 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (11220 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m505.16ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (32192 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-16 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-41 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (3931 characters)
 [PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
 [PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-16 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-42 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (3931 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m62.52ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m191.68ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m66.54ms[0m[2m][0m
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (40849 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-17 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (5715 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
+[PIPELINE] Generated DrawIO XML payload (36445 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (36445 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
+[PIPELINE] DrawIO parser produced graph graph-43 with 54 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 54 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (4714 characters)
+[PIPELINE] Saving export payload to diagram.ttl
+[PIPELINE] Export pipeline completed for diagram.ttl
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m53.04ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m19.38ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[0m[32m 27 pass[0m
+ 491 expect() calls
+Ran 31 tests across 1 files. [0m[2m[[1m17.40s[0m[2m][0m
+Script done on 2025-10-15 02:39:48+00:00 [COMMAND_EXIT_CODE="0"]
 [PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
 [BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)

--- a/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
+++ b/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
@@ -435,6 +435,41 @@ const PREAMBLE_ENTRY_TAG = "userObjectPreambleElement";
 const PREAMBLE_SECTION_ATTRIBUTE = "data-rdfexport-preamble-section";
 const PREAMBLE_PREFIX_ATTRIBUTE = "rdfPrefix";
 const PREAMBLE_IRI_ATTRIBUTE = "rdfIRI";
+const PARSER_SETTINGS_CELL_ATTRIBUTE = "rdfParserSettings";
+const PARSER_SETTINGS_BUTTON_ATTRIBUTE =
+  "data-rdfexport-parser-settings-button";
+const PARSER_SETTINGS_DIALOG_ATTRIBUTE =
+  "data-rdfexport-parser-settings-dialog";
+const PARSER_SETTINGS_INCLUDE_PREAMBLE_ATTRIBUTE =
+  "data-rdfexport-parser-include-preamble";
+const PARSER_SETTINGS_INCLUDE_LABEL_ATTRIBUTE =
+  "data-rdfexport-parser-include-label";
+const PARSER_SETTINGS_INFER_TYPES_ATTRIBUTE =
+  "data-rdfexport-parser-infer-types";
+const PARSER_SETTINGS_STRICT_MODE_ATTRIBUTE =
+  "data-rdfexport-parser-strict-mode";
+const PARSER_SETTINGS_PREFIX_ATTRIBUTE = "data-rdfexport-parser-prefix";
+const PARSER_SETTINGS_PREFIX_IRI_ATTRIBUTE = "data-rdfexport-parser-prefix-iri";
+const PARSER_SETTINGS_ONTOLOGY_IRI_ATTRIBUTE =
+  "data-rdfexport-parser-ontology-iri";
+const PARSER_SETTINGS_INDENTATION_ATTRIBUTE =
+  "data-rdfexport-parser-indentation";
+const PARSER_SETTINGS_MAX_GAP_ATTRIBUTE = "data-rdfexport-parser-max-gap";
+const PARSER_SETTINGS_CAPITALISATION_ATTRIBUTE =
+  "data-rdfexport-parser-capitalisation";
+const PARSER_SETTINGS_STRATEGY_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-strategy";
+const PARSER_SETTINGS_METACHAR_LIST_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-list";
+const PARSER_SETTINGS_METACHAR_ENTRY_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-entry";
+const PARSER_SETTINGS_METACHAR_CHAR_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-char";
+const PARSER_SETTINGS_METACHAR_REPLACEMENT_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-replacement";
+const PARSER_SETTINGS_METACHAR_ADD_ATTRIBUTE =
+  "data-rdfexport-parser-metachar-add";
+const PARSER_SETTINGS_APPLY_ATTRIBUTE = "data-rdfexport-parser-apply";
 
 interface GraphEnvironmentOptions {
   csvPath?: string;
@@ -1453,6 +1488,281 @@ test("rdfexport plugin exposes preamble controls and diagram properties", async 
   const previewXml = await Bun.file(previewFixturePath).text();
   const preview = await runMockBlackBox(previewXml);
   expect(preview.startsWith("[BLACKBOX]")).toBe(true);
+});
+
+test("parser settings dialog updates stored configuration and pipeline", async () => {
+  await loadPluginModule();
+
+  const fixturePath = join(fixturesDir, "AA37 Department of Health.drawio");
+  const sampleXml = await Bun.file(fixturePath).text();
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(sampleXml, "application/xml");
+  const graphXmlElement = xmlDoc.documentElement;
+
+  const { graph, model, rootCell } = createGraphEnvironment();
+
+  const actions: Record<string, () => void | Promise<void>> = {};
+  const savedExports: Array<{ filename: string; data: string }> = [];
+  let lastDialogContainer: ElementStub | null = null;
+  let hideDialogCalls = 0;
+
+  const editorUi = {
+    editor: {
+      getGraphXml: () => graphXmlElement,
+      graph,
+    },
+    currentPage: null,
+    actions: {
+      addAction(name: string, fn: () => void | Promise<void>) {
+        actions[name] = fn;
+      },
+    },
+    menus: {
+      get: () => null,
+      addMenuItems: () => {},
+    },
+    getBaseFilename: () => "diagram",
+    saveData(filename: string, _format: string, data: string) {
+      savedExports.push({ filename, data });
+    },
+    handleError(err: Error) {
+      throw err;
+    },
+    showDialog(container: ElementStub) {
+      lastDialogContainer = container;
+    },
+    hideDialog() {
+      hideDialogCalls += 1;
+      lastDialogContainer = null;
+    },
+  };
+
+  for (const callback of pluginCallbacks) {
+    callback(editorUi);
+  }
+
+  const panelRoot = document.createElement("div");
+  const existingViewSection = document.createElement("div");
+  existingViewSection.className = "geFormatSection";
+  panelRoot.appendChild(existingViewSection);
+
+  const panelContext = {
+    editorUi,
+    listeners: [] as Array<{ destroy(): void }>,
+    container: panelRoot,
+  };
+
+  const container = document.createElement("div");
+  const addOptions = (DiagramFormatPanel as any).prototype.addOptions;
+  const returned = addOptions.call(panelContext, container);
+  panelRoot.appendChild(returned ?? container);
+
+  const preambleSection = findChildByAttribute(
+    panelRoot,
+    PREAMBLE_SECTION_ATTRIBUTE,
+    "true",
+  );
+  expect(preambleSection).toBeDefined();
+  if (!preambleSection) {
+    throw new Error("Preamble section missing");
+  }
+
+  const preambleButton = findChildByAttribute(
+    preambleSection,
+    "data-rdfexport-preamble-button",
+    "true",
+  );
+  const parserSettingsButton = findChildByAttribute(
+    preambleSection,
+    PARSER_SETTINGS_BUTTON_ATTRIBUTE,
+    "true",
+  );
+
+  expect(parserSettingsButton).toBeDefined();
+  if (!parserSettingsButton) {
+    throw new Error("Parser settings button was not rendered");
+  }
+
+  const preambleIndex = preambleSection.children.indexOf(preambleButton);
+  const settingsIndex = preambleSection.children.indexOf(parserSettingsButton);
+  expect(settingsIndex).toBeGreaterThan(preambleIndex);
+
+  parserSettingsButton.click();
+  expect(lastDialogContainer).toBeDefined();
+  const dialogContainer = lastDialogContainer;
+  if (!dialogContainer) {
+    throw new Error("Parser settings dialog did not open");
+  }
+  expect(dialogContainer.getAttribute(PARSER_SETTINGS_DIALOG_ATTRIBUTE)).toBe(
+    "true",
+  );
+
+  const includePreambleInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_INCLUDE_PREAMBLE_ATTRIBUTE,
+    "true",
+  ) as ElementStub & { checked: boolean };
+  const includeLabelInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_INCLUDE_LABEL_ATTRIBUTE,
+    "true",
+  ) as ElementStub & { checked: boolean };
+  const inferTypesInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_INFER_TYPES_ATTRIBUTE,
+    "true",
+  ) as ElementStub & { checked: boolean };
+  const strictModeInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_STRICT_MODE_ATTRIBUTE,
+    "true",
+  ) as ElementStub & { checked: boolean };
+
+  expect(includePreambleInput.checked).toBe(true);
+  expect(includeLabelInput.checked).toBe(true);
+  expect(inferTypesInput.checked).toBe(true);
+  expect(strictModeInput.checked).toBe(false);
+
+  includePreambleInput.checked = false;
+  includeLabelInput.checked = false;
+  inferTypesInput.checked = false;
+  strictModeInput.checked = true;
+
+  const prefixInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_PREFIX_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+  const prefixIriInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_PREFIX_IRI_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+  const ontologyIriInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_ONTOLOGY_IRI_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+  const indentationInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_INDENTATION_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+  const maxGapInput = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_MAX_GAP_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+  const capitalisationSelect = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_CAPITALISATION_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+  const strategySelect = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_STRATEGY_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+
+  prefixInput.value = "ex";
+  prefixIriInput.value = "http://example.com/ns#";
+  ontologyIriInput.value = "http://example.com/ontology";
+  indentationInput.value = "4";
+  maxGapInput.value = "42.5";
+  capitalisationSelect.value = "flat";
+  strategySelect.value = "remove";
+
+  const addButton = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_METACHAR_ADD_ATTRIBUTE,
+    "true",
+  );
+  expect(addButton).toBeDefined();
+  addButton?.click();
+
+  const entryRow = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_METACHAR_ENTRY_ATTRIBUTE,
+    "true",
+  );
+  expect(entryRow).toBeDefined();
+  if (!entryRow) {
+    throw new Error("Metacharacter entry row was not created");
+  }
+
+  const entryCharSelect = findChildByAttribute(
+    entryRow,
+    PARSER_SETTINGS_METACHAR_CHAR_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+  const entryReplacementInput = findChildByAttribute(
+    entryRow,
+    PARSER_SETTINGS_METACHAR_REPLACEMENT_ATTRIBUTE,
+    "true",
+  ) as ElementStub;
+
+  entryCharSelect.value = "(";
+  entryReplacementInput.value = "square";
+
+  const applyButton = findChildByAttribute(
+    dialogContainer,
+    PARSER_SETTINGS_APPLY_ATTRIBUTE,
+    "true",
+  );
+  expect(applyButton).toBeDefined();
+  applyButton?.click();
+
+  expect(hideDialogCalls).toBe(1);
+
+  const storedSettingsRaw = graph.getAttributeForCell(
+    rootCell,
+    PARSER_SETTINGS_CELL_ATTRIBUTE,
+    null,
+  );
+  expect(typeof storedSettingsRaw).toBe("string");
+  const storedSettings = JSON.parse(storedSettingsRaw as string) as {
+    version: number;
+    settings: any;
+  };
+  expect(storedSettings.version).toBe(1);
+  const stored = storedSettings.settings;
+  expect(stored.includePreamble).toBe(false);
+  expect(stored.includeLabel).toBe(false);
+  expect(stored.inferTypeOfLiterals).toBe(false);
+  expect(stored.strictMode).toBe(true);
+  expect(stored.indentation).toBe(4);
+  expect(stored.maxGap).toBeCloseTo(42.5);
+  expect(stored.prefix).toBe("ex");
+  expect(stored.prefixIri).toBe("http://example.com/ns#");
+  expect(stored.ontologyIri).toBe("http://example.com/ontology");
+  expect(stored.capitalisationScheme).toBe("flat");
+  expect(stored.metacharacterStrategy).toBe("remove");
+  expect(stored.metacharacterEntries).toEqual([
+    { character: "(", replacement: "square" },
+  ]);
+
+  const exportAction = actions.exportRdfXml;
+  expect(exportAction).toBeDefined();
+  await exportAction?.();
+
+  expect(savedExports).toHaveLength(1);
+  expect(savedExports[0]?.filename).toBe("diagram.ttl");
+
+  const configJson = (await debugPyodide(
+    "import json\nfrom pyodide_pipeline.drawio_pipeline import get_last_parser_config\njson.dumps(get_last_parser_config())",
+  )) as string;
+  const config = JSON.parse(configJson) as Record<string, any>;
+  expect(config.include_preamble).toBe(false);
+  expect(config.include_label).toBe(false);
+  expect(config.infer_type_of_literals).toBe(false);
+  expect(config.strict_mode).toBe(true);
+  expect(config.indentation).toBe(4);
+  expect(config.max_gap).toBeCloseTo(42.5);
+  expect(config.prefix).toBe("ex");
+  expect(config.prefix_iri).toBe("http://example.com/ns#");
+  expect(config.ontology_iri).toBe("http://example.com/ontology");
+  expect(config.capitalisation_scheme).toBe("flat");
+  expect(config.metacharacter_substitute).toEqual(["remove", "(=square"]);
 });
 
 test("patchDrawioWithMetadata reproduces AA37 metadata artifact", () => {


### PR DESCRIPTION
## Summary
- add a parser settings dialog that stores overrides in diagram metadata and exposes a new toolbar button
- serialize the stored settings into a Drawio parser config payload and thread it through the Pyodide bridge to Python
- extend the Python pipeline with config coercion, caching, and hash-aware graph storage while adding Bun coverage for the end-to-end flow

## Testing
- bun run check
- bun run test
- bun run test:log:linux

------
https://chatgpt.com/codex/tasks/task_e_68eeff4da400832da901edacebdfc753