### PR TITLE
Handle DrawIO metadata patch idempotently

### DIFF
--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_node_detector.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_node_detector.py
@@ -1,0 +1,64 @@
+"""Overrides for detecting DrawIO metadata relevant to RML exports."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Tuple
+from xml.etree.ElementTree import Element, fromstring
+
+from meta_builder.drawio_meta_builder import override
+
+
+def _coerce_bool(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+
+    return bool(lowered)
+
+
+@override(phase="pre", type="xml", role="metadata")
+def _extract_drawio_metadata(
+    raw_xml: str,
+) -> Tuple[Dict[str, str], Optional[str], Optional[str], Optional[Element]]:
+    """Extract metadata from the DrawIO document including the RML toggle."""
+    try:
+        root = fromstring(raw_xml)
+    except Exception:  # pragma: no cover - guard around XML parsing
+        return {}, None, None, None
+
+    metadata_node = root.find(".//mxGraphModel/root/UserObject[@id='0']")
+    if metadata_node is None:
+        setattr(root, "_rdfexport_metadata", {"rml_enabled": False})
+        return {}, None, None, root
+
+    csv_path_raw = metadata_node.attrib.get("csvPath", "")
+    base_uri_raw = metadata_node.attrib.get("baseUri", "")
+    rml_enabled_raw = metadata_node.attrib.get("rmlEnabled")
+
+    csv_path = csv_path_raw.strip() or None
+    base_uri = base_uri_raw.strip() or None
+    rml_enabled = _coerce_bool(rml_enabled_raw)
+
+    prefixes: Dict[str, str] = {}
+    for preamble in metadata_node.findall("userObjectPreambleElement"):
+        prefix = (preamble.attrib.get("rdfPrefix") or "").strip()
+        iri = (preamble.attrib.get("rdfIRI") or "").strip()
+        if prefix and iri:
+            prefixes[prefix] = iri
+
+    metadata = {
+        "rml_enabled": rml_enabled,
+        "csv_path": csv_path,
+        "base_uri": base_uri,
+    }
+    setattr(root, "_rdfexport_metadata", metadata)
+
+    return prefixes, base_uri, csv_path, root
+
+
+__all__ = ["_extract_drawio_metadata"]

--- a/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
+++ b/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts
@@ -4,7 +4,10 @@ import { DOMParser } from "@xmldom/xmldom";
 import { readFileSync, readdirSync, existsSync } from "fs";
 import type { BunPlugin } from "bun";
 import { join, extname, basename, normalize, dirname, resolve } from "path";
-import { patchDrawioWithMetadata } from "./utils/patchDrawioWithMetadata";
+import {
+  patchDrawioWithMetadata,
+  type DrawioMetadataPatchOptions,
+} from "./utils/patchDrawioWithMetadata";
 import { LOG_PREFIX, logInfo } from "../src/logging";
 
 const rdfexportUrl = fileURLToPath(
@@ -1887,4 +1890,86 @@ test("patchDrawioWithMetadata reproduces AA37 metadata artifact", () => {
   expect(patchedSnapshot.metadata).toEqual(expectedSnapshot.metadata);
   expect(patchedSnapshot.mxfile).toEqual(baseSnapshot.mxfile);
   expect(patchedSnapshot.graphModel).toEqual(baseSnapshot.graphModel);
+});
+
+test("patchDrawioWithMetadata updates existing metadata block", () => {
+  const metadataFixturePath = join(
+    fixturesDir,
+    "AA37 Department of Health-with-metadata.drawio",
+  );
+  const metadataContent = readFileSync(metadataFixturePath, "utf8");
+
+  const options = {
+    label: "Updated AA37 metadata",
+    csvPath: "/tmp/aa37.csv",
+    baseUri: "http://example.org/aa37/",
+    preamble: [
+      {
+        rdfPrefix: "updated",
+        rdfIRI: "http://example.org/aa37/vocab#",
+      },
+      {
+        rdfPrefix: "data",
+        rdfIRI: "http://example.org/aa37/data/",
+      },
+    ],
+  } satisfies DrawioMetadataPatchOptions;
+
+  const updatedContent = patchDrawioWithMetadata(metadataContent, options);
+
+  const parser = new DOMParser({
+    errorHandler: {
+      error(message: string) {
+        throw new Error(message);
+      },
+    },
+  });
+
+  const updatedDoc = parser.parseFromString(updatedContent, "application/xml");
+  if (updatedDoc.getElementsByTagName("parsererror").length > 0) {
+    throw new Error("Failed to parse patched DrawIO XML");
+  }
+
+  const metadataNode = updatedDoc
+    .getElementsByTagName("mxGraphModel")
+    .item(0)
+    ?.getElementsByTagName("root")
+    .item(0)
+    ?.getElementsByTagName("UserObject")
+    .item(0);
+
+  expect(metadataNode).not.toBeNull();
+  expect(metadataNode?.getAttribute("label")).toBe(options.label);
+  expect(metadataNode?.getAttribute("csvPath")).toBe(options.csvPath);
+  expect(metadataNode?.getAttribute("baseUri")).toBe(options.baseUri);
+  expect(metadataNode?.getAttribute("id")).toBe("0");
+
+  const preambleNodes = metadataNode?.getElementsByTagName(
+    "userObjectPreambleElement",
+  );
+  const actualPreamble = preambleNodes
+    ? Array.from({ length: preambleNodes.length }, (_, index) => {
+        const element = preambleNodes.item(index);
+        if (!element) {
+          throw new Error("Unexpected null preamble element");
+        }
+        return {
+          rdfPrefix: element.getAttribute("rdfPrefix"),
+          rdfIRI: element.getAttribute("rdfIRI"),
+        };
+      })
+    : [];
+
+  expect(actualPreamble).toEqual(
+    options.preamble.map((entry) => ({
+      rdfPrefix: entry.rdfPrefix,
+      rdfIRI: entry.rdfIRI,
+    })),
+  );
+
+  const mxCells = metadataNode?.getElementsByTagName("mxCell");
+  expect(mxCells?.length).toBe(1);
+
+  const repeatedContent = patchDrawioWithMetadata(updatedContent, options);
+  expect(repeatedContent).toBe(updatedContent);
 });

--- a/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts
+++ b/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts
@@ -72,32 +72,67 @@ export function patchDrawioWithMetadata(
   );
 
   const rootChildren = collectChildElements(rootElement);
-  const existingUserObject = rootChildren.find(
-    (child) => child.tagName === "UserObject",
+  const existingMetadataNode = rootChildren.find(
+    (child) =>
+      child.tagName === "UserObject" && child.getAttribute("id") === "0",
   );
-
-  if (existingUserObject) {
-    throw new Error(
-      "Drawio document already contains a <UserObject> root metadata node",
-    );
-  }
 
   const rootCell = rootChildren.find(
     (child) => child.tagName === "mxCell" && child.getAttribute("id") === "0",
   );
-  assertElement(
-    rootCell ?? null,
-    'Unable to locate root <mxCell id="0"> element to patch',
-  );
 
-  const outerWhitespace = rootCell.previousSibling?.nodeValue ?? "\n        ";
-  const innerWhitespace = `${outerWhitespace}  `;
+  if (!existingMetadataNode) {
+    assertElement(
+      rootCell ?? null,
+      'Unable to locate root <mxCell id="0"> element to patch',
+    );
+  }
 
-  const metadataNode = document.createElement("UserObject");
+  const outerWhitespace = existingMetadataNode
+    ? (() => {
+        const lastChild = existingMetadataNode.lastChild;
+        if (lastChild && lastChild.nodeType === lastChild.TEXT_NODE) {
+          return lastChild.nodeValue ?? "\n        ";
+        }
+        return "\n        ";
+      })()
+    : (rootCell?.previousSibling?.nodeValue ?? "\n        ");
+
+  const innerWhitespace = existingMetadataNode
+    ? (() => {
+        for (
+          let index = 0;
+          index < existingMetadataNode.childNodes.length;
+          index += 1
+        ) {
+          const child = existingMetadataNode.childNodes.item(index);
+          if (child.nodeType === child.TEXT_NODE) {
+            return child.nodeValue ?? `${outerWhitespace}  `;
+          }
+        }
+        return `${outerWhitespace}  `;
+      })()
+    : `${outerWhitespace}  `;
+
+  const metadataNode =
+    existingMetadataNode ?? document.createElement("UserObject");
   metadataNode.setAttribute("label", options.label ?? "");
   metadataNode.setAttribute("csvPath", options.csvPath);
   metadataNode.setAttribute("baseUri", options.baseUri);
   metadataNode.setAttribute("id", "0");
+
+  const preservedMxCell = existingMetadataNode
+    ? (() => {
+        const candidate = existingMetadataNode
+          .getElementsByTagName("mxCell")
+          .item(0);
+        return candidate ? (candidate.cloneNode(true) as Element) : null;
+      })()
+    : null;
+
+  while (metadataNode.firstChild) {
+    metadataNode.removeChild(metadataNode.firstChild);
+  }
 
   metadataNode.appendChild(createWhitespaceNode(document, innerWhitespace));
 
@@ -109,11 +144,17 @@ export function patchDrawioWithMetadata(
     metadataNode.appendChild(createWhitespaceNode(document, innerWhitespace));
   }
 
-  const mxCellNode = document.createElement("mxCell");
+  const mxCellNode = preservedMxCell ?? document.createElement("mxCell");
   metadataNode.appendChild(mxCellNode);
   metadataNode.appendChild(createWhitespaceNode(document, outerWhitespace));
 
-  rootElement.replaceChild(metadataNode, rootCell);
+  if (!existingMetadataNode) {
+    assertElement(
+      rootCell ?? null,
+      'Unable to locate root <mxCell id="0"> element to patch',
+    );
+    rootElement.replaceChild(metadataNode, rootCell);
+  }
 
   const serializer = new XMLSerializer();
   return serializer.serializeToString(document);


### PR DESCRIPTION
## Summary
- allow `patchDrawioWithMetadata` to update existing root metadata nodes and preserve prior mxCell children when reapplying metadata
- add a regression test that patches an already-annotated AA37 diagram and verifies attributes, preamble entries, and idempotency
- fix the new RML metadata override header so linting accepts its placement of the module docstring and future import

## Testing
- bun run check
- bun run test *(fails: `bun run build:py` exits with lint errors for unresolved names in generated legacy parser)*

------
https://chatgpt.com/codex/tasks/task_e_68f446454f78832db9e1b704658e469f