### PR TITLE
Fix DrawIO parser literal detection for malformed CURIEs

### DIFF
--- a/src/main/webapp/plugins/rdfexport/CHANGELOG.md
+++ b/src/main/webapp/plugins/rdfexport/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - 2025-10-20 – Ensured the rdfexport legacy test harness activates the project virtual environment before running Python tooling and skipped auto-metadata fixtures when regenerating metadata patch tests so baseline regeneration succeeds alongside the updated DrawIO assets.
 - 2025-10-21 – Prevented DrawIO literals that resemble CURIEs from bypassing rdflib validation so malformed prefixes (for example `picoL:`) now raise errors instead of becoming string values.
+- 2025-10-22 – Hardened DrawIO rdf:type detection so swimlane child cells are always treated as attempted individuals, rejecting missing-prefix or colon-only CURIEs and extending the AA37 severely mocked fixture and pytest suite to cover these failures.
 
 ## [2025-10-17] - Historical Review (Pavel Zhelnov contributions)
 ### Added

--- a/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251020-062324.md
+++ b/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251020-062324.md
@@ -1,0 +1,26 @@
+# Malformed CURIE Detection Enhancements – Worklog (2025-10-20)
+
+## Overview
+- Tightened `DrawIOXMLTree._extract_individual_and_arrow_and_literal_cells` override so literal detection requires the absence of a containing mxCell.
+- Ensured malformed rdf:type values (missing prefix separator, empty prefix, or empty reference) now reliably raise `NotInKnownException` instead of being treated as literals.
+- Verified regenerated parser surfaces the override and retains absolute-IRI handling in downstream serialization.
+- Confirmed extended AA37 mock fixture exercises colon-only, dangling prefix, and missing prefix scenarios.
+
+## Key Changes
+1. `legacy/overrides/curie_validator.py`
+   - Track the immediate parent id for each mxCell and classify literal candidates only when they lack a parent box (`parent` of `1`).
+   - Preserve the new malformed rdf:type checks (missing separator, empty prefix, empty reference, unknown prefix) with detailed error reporting.
+2. `legacy/draw_io_parser.py`
+   - Regenerated from overrides to capture the literal classification tweaks.
+3. Tests/Fixtures
+   - Reran pytest suite targeting patched parser behaviours (`legacy/tests/test_patched_parser.py`).
+   - Exercised Bun-integrated regression pipeline via `bun run test` and `bun run test:log:linux` (log captured under `tests/demo_logs/test.log`).
+
+## Testing Summary
+- `bun run check`
+- `pytest legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants -vv`
+- `pytest legacy/tests/test_curie_validator.py -q`
+- Full `bun run test`
+- `bun run test:log:linux` (log archived)
+
+All checks succeeded; malformed rdf:type variants now raise as intended.

--- a/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field, InitVar
 from datetime import datetime
 from html.parser import HTMLParser
 from sys import exit as sys_exit, stdin
-from typing import Generator, Iterator, Optional, Dict, Any, Type
+from typing import Generator, Iterator, Optional, Any
 from copy import deepcopy
 from xml.etree.ElementTree import Element, fromstring, tostring
 import urllib.parse
@@ -15,6 +15,7 @@ import traceback
 import os
 from rdflib import Graph, URIRef, Literal, Namespace
 from rdflib.namespace import RDF, RDFS, OWL, XSD
+
 
 class pipeline:
     class pre:
@@ -113,6 +114,7 @@ class pipeline:
 
 # ===== pre.xml.metadata =====
 
+
 class xml_metadata_pre:
     # BEGIN _extract_drawio_metadata
     def _extract_drawio_metadata(
@@ -173,11 +175,13 @@ class xml_metadata_pre:
 
 # ===== pre.xml.data =====
 
+
 class xml_data_pre:
     pass
 
 
 # ===== pre.xml.control =====
+
 
 class xml_control_pre:
     pass
@@ -185,9 +189,10 @@ class xml_control_pre:
 
 # ===== pre.internal.metadata =====
 
+
 class internal_metadata_pre:
     # BEGIN DEFAULT_CAPITALISATION_SCHEME
-    DEFAULT_CAPITALISATION_SCHEME = 'upper-camel'
+    DEFAULT_CAPITALISATION_SCHEME = "upper-camel"
 
     # END DEFAULT_CAPITALISATION_SCHEME
     # BEGIN DEFAULT_INDENTATION
@@ -199,7 +204,22 @@ class internal_metadata_pre:
 
     # END DEFAULT_MAX_GAP
     # BEGIN OWL_METACHARACTERS
-    OWL_METACHARACTERS = ['(', ')', '[', ']', '{', '}', '/', ',', ':', '.', "'", '"', '\xa0', '#']
+    OWL_METACHARACTERS = [
+        "(",
+        ")",
+        "[",
+        "]",
+        "{",
+        "}",
+        "/",
+        ",",
+        ":",
+        ".",
+        "'",
+        '"',
+        "\xa0",
+        "#",
+    ]
 
     # END OWL_METACHARACTERS
     # BEGIN Blocks
@@ -311,11 +331,13 @@ class internal_metadata_pre:
 
 # ===== pre.internal.data =====
 
+
 class internal_data_pre:
     pass
 
 
 # ===== pre.internal.control =====
+
 
 class internal_control_pre:
     # BEGIN _arguments_parser
@@ -495,11 +517,13 @@ class internal_control_pre:
 
 # ===== pre.rdf.metadata =====
 
+
 class rdf_metadata_pre:
     pass
 
 
 # ===== pre.rdf.data =====
+
 
 class rdf_data_pre:
     # BEGIN _handle_spaces
@@ -560,7 +584,9 @@ class rdf_data_pre:
                     "-m/--metacharacter-substitute and -c/--capitalisation-scheme "
                     "options to define how to handle spaces"
                 )
-            identifier = _handle_spaces(identifier, space_substitute, capitalisation_scheme)
+            identifier = _handle_spaces(
+                identifier, space_substitute, capitalisation_scheme
+            )
         elif capitalisation_scheme in ["lower-camel", "flat"]:
             identifier = identifier[0].lower() + identifier[1:]
         for metacharacter in OWL_METACHARACTERS:
@@ -573,6 +599,7 @@ class rdf_data_pre:
 
 
 # ===== pre.rdf.control =====
+
 
 class rdf_control_pre:
     # BEGIN _parse_capitalisation_scheme
@@ -590,11 +617,13 @@ class rdf_control_pre:
 
 # ===== core.xml.metadata =====
 
+
 class xml_metadata_core:
     pass
 
 
 # ===== core.xml.data =====
+
 
 class xml_data_core:
     # BEGIN NothingToParseException
@@ -744,32 +773,35 @@ class xml_data_core:
         'individuals_and_arrows' can then be called to complete the parsing and
         return the obtained Individual and Arrow instances as a generator
         """
+
         draw_io_xml_tree: Element = field(init=False)
         literal_node_html_parser: NodeHTMLParser = field(init=False)
-        individual_cells: list[tuple[Element, Individual, Dimensions]] = field(init=False)
+        individual_cells: list[tuple[Element, Individual, Dimensions]] = field(
+            init=False
+        )
         arrow_cells: list[ArrowData] = field(init=False)
         literal_cells: list[tuple[Element, Dimensions]] = field(init=False)
         raw_xml: InitVar[str]
         prefixes: InitVar[dict]
 
         def __post_init__(self, raw_xml, prefixes):
-            object.__setattr__(self, 'prefixes', prefixes)
-            object.__setattr__(self, 'literal_node_html_parser', NodeHTMLParser())
-            object.__setattr__(self, 'draw_io_xml_tree', fromstring(raw_xml))
-            object.__setattr__(self, 'individual_cells', [])
-            object.__setattr__(self, 'arrow_cells', [])
-            object.__setattr__(self, 'literal_cells', [])
+            object.__setattr__(self, "prefixes", prefixes)
+            object.__setattr__(self, "literal_node_html_parser", NodeHTMLParser())
+            object.__setattr__(self, "draw_io_xml_tree", fromstring(raw_xml))
+            object.__setattr__(self, "individual_cells", [])
+            object.__setattr__(self, "arrow_cells", [])
+            object.__setattr__(self, "literal_cells", [])
             self._extract_individual_and_arrow_and_literal_cells(prefixes)
 
         def _cell_with_id(self, _id: str) -> Element:
             cell = self.draw_io_xml_tree.find(f".//*[@id='{_id}']")
             if cell is None:
-                raise ValueError(f'No cell with id: {_id}')
+                raise ValueError(f"No cell with id: {_id}")
             return cell
 
         def _value_of(self, cell: Element) -> str:
             try:
-                value = cell.attrib['value'].strip()
+                value = cell.attrib["value"].strip()
             except KeyError as key_error:
                 raise _NoValueException from key_error
             self.literal_node_html_parser.clear()
@@ -778,15 +810,19 @@ class xml_data_core:
 
         def _parent_of(self, cell: Element) -> Element:
             try:
-                parent_id = cell.attrib['parent']
+                parent_id = cell.attrib["parent"]
             except KeyError as key_error:
-                raise ParseException(f"Could not parse XML tree: found an 'mxCell' element with the following id which has value beginning with 'rico:' but with no parent: {cell.attrib['id']}") from key_error
+                raise ParseException(
+                    f"Could not parse XML tree: found an 'mxCell' element with the following id which has value beginning with 'rico:' but with no parent: {cell.attrib['id']}"
+                ) from key_error
             return self._cell_with_id(parent_id)
 
         def _child_of(self, parent_id: str) -> Generator[Element, None, None]:
             yield from self.draw_io_xml_tree.findall(f".//*[@parent='{parent_id}']")
 
-        def _start_or_end(self, cell: Element, as_attribute: str | None) -> tuple[XCoordinate, YCoordinate] | None:
+        def _start_or_end(
+            self, cell: Element, as_attribute: str | None
+        ) -> tuple[XCoordinate, YCoordinate] | None:
             """
             The cell can be part of a group (have another 'parent' than that of the
             top-level graph), in which case the immediate x and y coordinates will
@@ -795,54 +831,69 @@ class xml_data_core:
             """
             geometry = DrawIOXMLTree._geometry(cell)
             if as_attribute is None:
-                return self._x_and_y_in_geometry(geometry, cell.attrib['id'])
+                return self._x_and_y_in_geometry(geometry, cell.attrib["id"])
             if len(geometry) == 0:
-                raise ParseException(f"Expecting the mxGeometry element of the cell with the following id to have sub-elements, but has no sub-elements at all: {cell.attrib['id']}")
+                raise ParseException(
+                    f"Expecting the mxGeometry element of the cell with the following id to have sub-elements, but has no sub-elements at all: {cell.attrib['id']}"
+                )
             for element in geometry:
-                if element.tag != 'mxPoint' or not self._has_correct_as_attribute(element, as_attribute, cell.attrib['id']):
+                if element.tag != "mxPoint" or not self._has_correct_as_attribute(
+                    element, as_attribute, cell.attrib["id"]
+                ):
                     continue
                 try:
-                    x = float(element.attrib['x'])
+                    x = float(element.attrib["x"])
                 except KeyError as key_error:
                     if self._is_locked(cell, as_attribute):
                         return None
-                    raise ParseException(f"Encountered an mxPoint element of the cell with the following id without an 'x' attribute: {cell.attrib['id']}") from key_error
+                    raise ParseException(
+                        f"Encountered an mxPoint element of the cell with the following id without an 'x' attribute: {cell.attrib['id']}"
+                    ) from key_error
                 try:
-                    y = float(element.attrib['y'])
+                    y = float(element.attrib["y"])
                 except KeyError as key_error:
                     if self._is_locked(cell, as_attribute):
                         return None
-                    raise ParseException(f"Encountered an mxPoint element of the cell with the following id without a 'y' attribute: {cell.attrib['id']}") from key_error
-                parent_id = cell.attrib['parent']
-                if parent_id == '1':
+                    raise ParseException(
+                        f"Encountered an mxPoint element of the cell with the following id without a 'y' attribute: {cell.attrib['id']}"
+                    ) from key_error
+                parent_id = cell.attrib["parent"]
+                if parent_id == "1":
                     return (x, y)
                 parent_coordinates = self._start_or_end(self._parent_of(cell), None)
                 if parent_coordinates is None:
                     raise ValueError
                 parent_x, parent_y = parent_coordinates
                 return (x + parent_x, y + parent_y)
-            raise ParseException(f"Expecting the mxGeometry element of the cell with the following id to have an mxPoint sub-element with 'as' attribute having value 'sourcePoint', but it does not: {cell.attrib['id']}")
+            raise ParseException(
+                f"Expecting the mxGeometry element of the cell with the following id to have an mxPoint sub-element with 'as' attribute having value 'sourcePoint', but it does not: {cell.attrib['id']}"
+            )
 
         def _arrow_start(self, arrow_cell: Element) -> ArrowStart | None:
-            return self._start_or_end(arrow_cell, 'sourcePoint')
+            return self._start_or_end(arrow_cell, "sourcePoint")
 
         def _arrow_end(self, arrow_cell: Element) -> ArrowEnd | None:
-            return self._start_or_end(arrow_cell, 'targetPoint')
+            return self._start_or_end(arrow_cell, "targetPoint")
 
         def _arrow_label(self, arrow_cell: Element) -> str:
-            for cell in self._child_of(arrow_cell.attrib['id']):
+            for cell in self._child_of(arrow_cell.attrib["id"]):
                 try:
-                    style = cell.attrib['style']
+                    style = cell.attrib["style"]
                 except KeyError:
                     continue
-                if 'edgeLabel' in style:
+                if "edgeLabel" in style:
                     return self._value_of(cell)
             raise _NoValueException
 
         def _add_arrow_if_find_label(self, cell: Element) -> None:
             try:
                 label = self._arrow_label(cell)
-                arrow_data = (cell, self._arrow_start(cell), self._arrow_end(cell), label)
+                arrow_data = (
+                    cell,
+                    self._arrow_start(cell),
+                    self._arrow_end(cell),
+                    label,
+                )
                 self.arrow_cells.append(arrow_data)
             except _NoValueException:
                 pass
@@ -854,8 +905,10 @@ class xml_data_core:
             except IndexError as key_error:
                 raise NothingToParseException from key_error
             for cell in self.draw_io_xml_tree[0][0][0]:
-                if cell.tag != 'mxCell':
-                    raise ParseException(f"Could not parse XML tree: expecting an element with tag 'mxCell', but had tag '{cell.tag}'")
+                if cell.tag != "mxCell":
+                    raise ParseException(
+                        f"Could not parse XML tree: expecting an element with tag 'mxCell', but had tag '{cell.tag}'"
+                    )
                 try:
                     cell_value = self._value_of(cell)
                 except _NoValueException:
@@ -863,7 +916,7 @@ class xml_data_core:
                 if not cell_value:
                     self._add_arrow_if_find_label(cell)
                     continue
-                if cell_value.split(':')[0] not in self.prefixes.keys():
+                if cell_value.split(":")[0] not in self.prefixes.keys():
                     if self._is_possible_literal(cell):
                         self.literal_cells.append((cell, self._dimensions(cell)))
                     continue
@@ -872,7 +925,12 @@ class xml_data_core:
                     individual_identifier = self._value_of(parent)
                 except _NoValueException:
                     try:
-                        arrow_data = (cell, self._arrow_start(cell), self._arrow_end(cell), cell.attrib['value'])
+                        arrow_data = (
+                            cell,
+                            self._arrow_start(cell),
+                            self._arrow_end(cell),
+                            cell.attrib["value"],
+                        )
                         self.arrow_cells.append(arrow_data)
                     except _NoValueException:
                         pass
@@ -880,13 +938,17 @@ class xml_data_core:
                 if not individual_identifier:
                     continue
                 for prefix in self.prefixes.keys():
-                    for ric_class in cell_value.split(f'{prefix}:')[1:]:
-                        ric_class = f'{prefix}:' + ric_class.strip()
+                    for ric_class in cell_value.split(f"{prefix}:")[1:]:
+                        ric_class = f"{prefix}:" + ric_class.strip()
                         _verify_is_ric_class(ric_class, self.prefixes)
                         individual = Individual(individual_identifier, ric_class)
-                        self.individual_cells.append((cell, individual, self._dimensions(parent)))
+                        self.individual_cells.append(
+                            (cell, individual, self._dimensions(parent))
+                        )
 
-        def _cell_close_to(self, arrow_endpoint: ArrowStart | ArrowEnd, max_gap: float) -> Element:
+        def _cell_close_to(
+            self, arrow_endpoint: ArrowStart | ArrowEnd, max_gap: float
+        ) -> Element:
             for cell, _, dimensions in self.individual_cells:
                 if self._close_enough(arrow_endpoint, dimensions, max_gap):
                     return cell
@@ -902,50 +964,68 @@ class xml_data_core:
             return False
 
         def _cell_is_literal(self, candidate: Element) -> bool:
-            return any((literal_cell is candidate for literal_cell, _ in self.literal_cells))
+            return any(
+                (literal_cell is candidate for literal_cell, _ in self.literal_cells)
+            )
 
-        def _source_or_target(self, source_or_target_cell: Element, must_be_individual: bool) -> str:
+        def _source_or_target(
+            self, source_or_target_cell: Element, must_be_individual: bool
+        ) -> str:
             try:
                 value = self._value_of(source_or_target_cell)
             except KeyError as key_error:
                 raise _NoValueException from key_error
-            if value.split(':')[0] in self.prefixes.keys():
+            if value.split(":")[0] in self.prefixes.keys():
                 return self._value_of(self._parent_of(source_or_target_cell))
             if must_be_individual and (not self._defines_individual(value)):
                 raise _SourceNotIndividualException
             return value
 
-        def _arrow(self, arrow_data: ArrowData, strict_mode: bool, max_gap: float) -> Arrow:
+        def _arrow(
+            self, arrow_data: ArrowData, strict_mode: bool, max_gap: float
+        ) -> Arrow:
             arrow_cell, arrow_start, arrow_end, arrow_label = arrow_data
             try:
-                source_cell = self._cell_with_id(arrow_cell.attrib['source'])
+                source_cell = self._cell_with_id(arrow_cell.attrib["source"])
             except KeyError as key_error:
                 if strict_mode or arrow_start is None:
-                    raise NoSourceException(f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its source was not able to be determined") from key_error
+                    raise NoSourceException(
+                        f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its source was not able to be determined"
+                    ) from key_error
                 try:
                     source_cell = self._cell_close_to(arrow_start, max_gap)
                 except _NoCellCloseEnoughException as not_close_enough_exception:
-                    raise NoSourceException(f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its source was not able to be determined") from not_close_enough_exception
+                    raise NoSourceException(
+                        f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its source was not able to be determined"
+                    ) from not_close_enough_exception
             try:
                 source = self._source_or_target(source_cell, True)
             except _SourceNotIndividualException as exception:
-                raise ArrowWithoutIndividualAsSourceException(f"The arrow with id {arrow_cell.attrib['id']} and label {arrow_label} has a source which appears not to be a node defining a RiC-O individual") from exception
+                raise ArrowWithoutIndividualAsSourceException(
+                    f"The arrow with id {arrow_cell.attrib['id']} and label {arrow_label} has a source which appears not to be a node defining a RiC-O individual"
+                ) from exception
             try:
-                target_cell = self._cell_with_id(arrow_cell.attrib['target'])
+                target_cell = self._cell_with_id(arrow_cell.attrib["target"])
             except KeyError as key_error:
                 if strict_mode or arrow_end is None:
-                    raise NoSourceException(f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its target was not able to be determined") from key_error
+                    raise NoSourceException(
+                        f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its target was not able to be determined"
+                    ) from key_error
                 try:
                     target_cell = self._cell_close_to(arrow_end, max_gap)
                 except _NoCellCloseEnoughException as not_close_enough_exception:
-                    raise NoSourceException(f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its target was not able to be determined") from not_close_enough_exception
+                    raise NoSourceException(
+                        f"The mxCell element with label '{arrow_label}' and id {arrow_cell.attrib['id']} seems to be an arrow, but its target was not able to be determined"
+                    ) from not_close_enough_exception
             target = self._source_or_target(target_cell, False)
             is_datatype = self._cell_is_literal(target_cell)
             if not is_datatype and (not self._defines_individual(target)):
                 is_datatype = True
             return Arrow(str(arrow_label.strip()), source, target, is_datatype)
 
-        def individuals_and_arrows(self, strict_mode: bool, max_gap: float) -> Generator[Individual | Arrow, None, None]:
+        def individuals_and_arrows(
+            self, strict_mode: bool, max_gap: float
+        ) -> Generator[Individual | Arrow, None, None]:
             """
             Returns as a generator all Individual and Arrow instances obtained
             when parsing the nodes and arrows of the draw.io XML graph fed into the
@@ -955,6 +1035,7 @@ class xml_data_core:
                 yield individual
             for arrow_data in self.arrow_cells:
                 yield self._arrow(arrow_data, strict_mode, max_gap)
+
     # END DrawIOXMLTree
     # BEGIN DrawIOXMLTree._cell_with_id
     def _cell_with_id(self, _id: str) -> Element:
@@ -1202,6 +1283,7 @@ class xml_data_core:
 
     # END DrawIOXMLTree._add_arrow_if_find_label
     # BEGIN DrawIOXMLTree._extract_individual_and_arrow_and_literal_cells
+    # override from curie_validator.py
     def _extract_individual_and_arrow_and_literal_cells(self, prefixes) -> None:
         try:
             if len(self.draw_io_xml_tree[0][0][0]) == 0:
@@ -1211,8 +1293,7 @@ class xml_data_core:
         for cell in self.draw_io_xml_tree[0][0][0]:
             if cell.tag != "mxCell":
                 raise ParseException(
-                    "Could not parse XML tree: expecting an element with tag "
-                    f"'mxCell', but had tag '{cell.tag}'"
+                    f"Could not parse XML tree: expecting an element with tag 'mxCell', but had tag '{cell.tag}'"
                 )
             try:
                 cell_value = self._value_of(cell)
@@ -1221,9 +1302,15 @@ class xml_data_core:
             if not cell_value:
                 self._add_arrow_if_find_label(cell)
                 continue
-            if cell_value.split(":")[0] not in self.prefixes.keys():
-                if self._is_possible_literal(cell):
-                    self.literal_cells.append((cell, self._dimensions(cell)))
+            raw_value = cell_value.strip()
+            has_separator = ":" in raw_value
+            prefix_head = raw_value.split(":", 1)[0] if has_separator else raw_value
+            remainder = raw_value.split(":", 1)[1] if has_separator else ""
+            is_literal_candidate = self._is_possible_literal(cell)
+            parent_id = cell.attrib.get("parent")
+            has_parent_box = parent_id not in {None, "1"}
+            if is_literal_candidate and (not has_parent_box):
+                self.literal_cells.append((cell, self._dimensions(cell)))
                 continue
             try:
                 parent = self._parent_of(cell)
@@ -1242,20 +1329,45 @@ class xml_data_core:
                 continue
             if not individual_identifier:
                 continue
-            for prefix in self.prefixes.keys():
-                for ric_class in cell_value.split(f"{prefix}:")[1:]:
-                    ric_class = f"{prefix}:" + ric_class.strip()
-                    _verify_is_ric_class(ric_class, self.prefixes)
-                    individual = Individual(individual_identifier, ric_class)
-                    self.individual_cells.append(
-                        (cell, individual, self._dimensions(parent))
-                    )
-            # for ric_class in cell_value.split("rico:")[1:]:
-            #    ric_class = ric_class.strip()
-            #    _verify_is_ric_class(ric_class)
-            #    individual = Individual(individual_identifier, ric_class)
-            #    self.individual_cells.append(
-            #        (cell, individual, self._dimensions(parent)))
+            if not has_separator:
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type without a CURIE prefix separator."
+                )
+            if not prefix_head:
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', but no prefix was provided before the ':' separator."
+                )
+            if not remainder.strip():
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', but no reference portion was provided after the prefix."
+                )
+            if prefix_head not in prefixes.keys():
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes."
+                )
+            dimensions = self._dimensions(parent)
+            seen_classes: set[str] = set()
+            had_tokens = False
+            for token in raw_value.replace(",", " ").replace(";", " ").split():
+                candidate = token.strip()
+                if not candidate:
+                    continue
+                had_tokens = True
+                if candidate in seen_classes:
+                    continue
+                try:
+                    _verify_is_ric_class(candidate, prefixes)
+                except NotInKnownException as exc:
+                    raise NotInKnownException(
+                        f"The node '{individual_identifier}' declares rdf:type '{candidate}', which is not defined by the available prefixes."
+                    ) from exc
+                seen_classes.add(candidate)
+                individual = Individual(individual_identifier, candidate)
+                self.individual_cells.append((cell, individual, dimensions))
+            if not had_tokens:
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares an rdf:type value but no CURIE tokens could be parsed."
+                )
 
     # END DrawIOXMLTree._extract_individual_and_arrow_and_literal_cells
     # BEGIN DrawIOXMLTree._close_enough
@@ -1384,17 +1496,20 @@ class xml_data_core:
 
 # ===== core.xml.control =====
 
+
 class xml_control_core:
     pass
 
 
 # ===== core.internal.metadata =====
 
+
 class internal_metadata_core:
     pass
 
 
 # ===== core.internal.data =====
+
 
 class internal_data_core:
     # BEGIN Individual
@@ -1515,6 +1630,7 @@ class internal_data_core:
 
 
 # ===== core.internal.control =====
+
 
 class internal_control_core:
     # BEGIN _parse_space_substitute
@@ -1681,32 +1797,121 @@ class internal_control_core:
     # END individual_blocks
     # BEGIN _build_graph_from_raw_xml
     # override from rml_export.py
-    def _build_graph_from_raw_xml(raw_xml: str, config_args: dict[str, Any]) -> DrawIOParserGraph:
-        metadata_prefixes, base_uri, csv_path, parsed_root = pipeline.pre.xml.metadata._extract_drawio_metadata(raw_xml)
+    def _build_graph_from_raw_xml(
+        raw_xml: str, config_args: dict[str, Any]
+    ) -> DrawIOParserGraph:
+        metadata_prefixes, base_uri, csv_path, parsed_root = (
+            pipeline.pre.xml.metadata._extract_drawio_metadata(raw_xml)
+        )
         prefixes = get_prefixes()
         prefixes.update(metadata_prefixes)
-        working_xml = pipeline.pre.xml.metadata._strip_metadata_user_object(raw_xml, parsed_root)
-        ontology_iri = config_args['ontology_iri'] or get_ontology_iri()
-        prefix = config_args['prefix'] or get_prefix()
-        prefix_iri = config_args['prefix_iri'] or base_uri or get_prefix_iri(ontology_iri)
-        serialisation_config = SerialisationConfig(infer_type_of_literals=config_args['infer_type_of_literals'], include_preamble=config_args['include_preamble'], ontology_iri=ontology_iri, prefix=prefix, prefix_iri=prefix_iri, indentation=config_args['indentation'], include_label=config_args['include_label'])
-        space_substitute = internal_control_core._parse_space_substitute(config_args['metacharacter_substitute'])
-        metacharacter_substitutes = list(internal_control_core._parse_metacharacter_substitutes(config_args['metacharacter_substitute']))
-        _parse_capitalisation_scheme(config_args['capitalisation_scheme'])
+        working_xml = pipeline.pre.xml.metadata._strip_metadata_user_object(
+            raw_xml, parsed_root
+        )
+        ontology_iri = config_args["ontology_iri"] or get_ontology_iri()
+        prefix = config_args["prefix"] or get_prefix()
+        prefix_iri = (
+            config_args["prefix_iri"] or base_uri or get_prefix_iri(ontology_iri)
+        )
+        serialisation_config = SerialisationConfig(
+            infer_type_of_literals=config_args["infer_type_of_literals"],
+            include_preamble=config_args["include_preamble"],
+            ontology_iri=ontology_iri,
+            prefix=prefix,
+            prefix_iri=prefix_iri,
+            indentation=config_args["indentation"],
+            include_label=config_args["include_label"],
+        )
+        space_substitute = internal_control_core._parse_space_substitute(
+            config_args["metacharacter_substitute"]
+        )
+        metacharacter_substitutes = list(
+            internal_control_core._parse_metacharacter_substitutes(
+                config_args["metacharacter_substitute"]
+            )
+        )
+        _parse_capitalisation_scheme(config_args["capitalisation_scheme"])
         draw_io_xml_tree = DrawIOXMLTree(working_xml, prefixes)
-        blocks, object_properties, datatype_properties = internal_control_core.individual_blocks(draw_io_xml_tree.individuals_and_arrows(config_args['strict_mode'], config_args['max_gap']), metacharacter_substitutes, space_substitute, config_args['capitalisation_scheme'], prefixes)
-        graph = serialise_to_graph(blocks, object_properties, datatype_properties, serialisation_config, prefixes, graph_cls=DrawIOParserGraph, graph_kwargs={'csv_path': csv_path})
+        try:
+            candidate_cells = draw_io_xml_tree.draw_io_xml_tree[0][0][0]
+        except IndexError:
+            candidate_cells = []
+        for cell in candidate_cells:
+            if cell.tag != "mxCell":
+                raise ParseException(
+                    f"Could not parse XML tree: expecting an element with tag 'mxCell', but had tag '{cell.tag}'"
+                )
+            if cell.attrib.get("edge") == "1":
+                continue
+            try:
+                cell_value = draw_io_xml_tree._value_of(cell)
+            except _NoValueException:
+                continue
+            if not cell_value:
+                continue
+            raw_value = cell_value.strip()
+            has_separator = ":" in raw_value
+            prefix_head = raw_value.split(":", 1)[0] if has_separator else raw_value
+            remainder = raw_value.split(":", 1)[1] if has_separator else ""
+            is_literal_candidate = draw_io_xml_tree._is_possible_literal(cell)
+            try:
+                parent = draw_io_xml_tree._parent_of(cell)
+                individual_identifier = draw_io_xml_tree._value_of(parent)
+            except _NoValueException:
+                continue
+            if not individual_identifier:
+                continue
+            if parent.attrib.get("edge") == "1":
+                continue
+            if prefix_head not in prefixes.keys() and is_literal_candidate:
+                continue
+            if not has_separator:
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type without a CURIE prefix separator."
+                )
+            if not prefix_head:
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', but no prefix was provided before the ':' separator."
+                )
+            if not remainder.strip():
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', but no reference portion was provided after the prefix."
+                )
+            if prefix_head not in prefixes.keys():
+                raise NotInKnownException(
+                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes."
+                )
+        blocks, object_properties, datatype_properties = (
+            internal_control_core.individual_blocks(
+                draw_io_xml_tree.individuals_and_arrows(
+                    config_args["strict_mode"], config_args["max_gap"]
+                ),
+                metacharacter_substitutes,
+                space_substitute,
+                config_args["capitalisation_scheme"],
+                prefixes,
+            )
+        )
+        graph = serialise_to_graph(
+            blocks,
+            object_properties,
+            datatype_properties,
+            serialisation_config,
+            prefixes,
+            graph_cls=DrawIOParserGraph,
+            graph_kwargs={"csv_path": csv_path},
+        )
         if base_uri:
-            graph.namespace_manager.bind('', Namespace(base_uri), replace=True)
+            graph.namespace_manager.bind("", Namespace(base_uri), replace=True)
 
         def _coerce_flag(value: Any) -> bool:
             if isinstance(value, bool):
                 return value
             if isinstance(value, str):
                 lowered = value.strip().lower()
-                if lowered in {'true', '1', 'yes', 'on'}:
+                if lowered in {"true", "1", "yes", "on"}:
                     return True
-                if lowered in {'false', '0', 'no', 'off'}:
+                if lowered in {"false", "0", "no", "off"}:
                     return False
             if value is None:
                 return False
@@ -1718,29 +1923,34 @@ class internal_control_core:
             metadata_node = parsed.find(".//mxGraphModel/root/UserObject[@id='0']")
             if metadata_node is None:
                 return False
-            flag = metadata_node.attrib.get('rmlEnabled')
+            flag = metadata_node.attrib.get("rmlEnabled")
             if flag is None:
                 return False
-            return flag.strip().lower() in {'true', '1', 'yes', 'on'}
+            return flag.strip().lower() in {"true", "1", "yes", "on"}
+
         rml_from_config = False
         if isinstance(config_args, dict):
-            rml_from_config = _coerce_flag(config_args.get('rml_enabled'))
+            rml_from_config = _coerce_flag(config_args.get("rml_enabled"))
         if rml_from_config or _metadata_enables_rml(parsed_root):
-            rr = Namespace('http://www.w3.org/ns/r2rml#')
-            graph.namespace_manager.bind('rr', rr, replace=False)
+            rr = Namespace("http://www.w3.org/ns/r2rml#")
+            graph.namespace_manager.bind("rr", rr, replace=False)
             from rdflib import BNode
+
             graph.add((BNode(), RDF.type, rr.TriplesMap))
         return graph
+
     # END _build_graph_from_raw_xml
 
 
 # ===== core.rdf.metadata =====
+
 
 class rdf_metadata_core:
     pass
 
 
 # ===== core.rdf.data =====
+
 
 class rdf_data_core:
     # BEGIN NotInKnownException
@@ -1783,6 +1993,7 @@ class rdf_data_core:
 
 # ===== core.rdf.control =====
 
+
 class rdf_control_core:
     # BEGIN DrawIOParserGraph
     class DrawIOParserGraph(Graph):
@@ -1794,96 +2005,98 @@ class rdf_control_core:
 
     # END DrawIOParserGraph
     # BEGIN serialise_to_graph
+    # override from curie_validator.py
     def serialise_to_graph(
         blocks: Blocks,
         object_properties: set[str],
         datatype_properties: set[str],
         serialisation_config: SerialisationConfig,
         prefixes: dict,
-        graph_cls: Type[Graph] = Graph,
-        graph_kwargs: Optional[Dict[str, Any]] = None,
+        graph_cls: type[Graph] = Graph,
+        graph_kwargs: dict[str, Any] | None = None,
     ) -> Graph:
         graph_kwargs = graph_kwargs or {}
-        g = graph_cls(**graph_kwargs)
-
-        # Bind prefixes
+        graph = graph_cls(**graph_kwargs)
         for prefix, uri in prefixes.items():
-            g.bind(prefix, Namespace(uri), replace=True)
+            graph.bind(prefix, Namespace(uri), replace=True)
         if serialisation_config.prefix:
-            g.bind(
+            graph.bind(
                 serialisation_config.prefix,
                 Namespace(
                     serialisation_config.prefix_iri
                     or get_prefix_iri(serialisation_config.ontology_iri)
                 ),
             )
-
         if serialisation_config.include_preamble:
-            # Add ontology definition
-            ontology_iri = serialisation_config.ontology_iri
-            if not ontology_iri:
-                ontology_iri = get_ontology_iri()
-            g.add((URIRef(ontology_iri), RDF.type, OWL.Ontology))
-            g.add((URIRef(ontology_iri), OWL.imports, URIRef(prefixes["rico"])))
-
-        # Add property definitions
+            ontology_iri = serialisation_config.ontology_iri or get_ontology_iri()
+            graph.add((URIRef(ontology_iri), RDF.type, OWL.Ontology))
+            graph.add((URIRef(ontology_iri), OWL.imports, URIRef(prefixes["rico"])))
         for prop in sorted(
-            prop for prop in object_properties if not prop.startswith("rico:")
+            (prop for prop in object_properties if not prop.startswith("rico:"))
         ):
             prop_prefix, prop_name = prop.split(":")
             prop_uri = Namespace(prefixes[prop_prefix])[prop_name]
-            g.add((prop_uri, RDF.type, OWL.ObjectProperty))
-
+            graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
         for prop in sorted(
-            prop for prop in datatype_properties if not prop.startswith("rico:")
+            (prop for prop in datatype_properties if not prop.startswith("rico:"))
         ):
             prop_prefix, prop_name = prop.split(":")
             prop_uri = Namespace(prefixes[prop_prefix])[prop_name]
-            g.add((prop_uri, RDF.type, OWL.DatatypeProperty))
-
-        # Add individuals and their properties
+            graph.add((prop_uri, RDF.type, OWL.DatatypeProperty))
+        absolute_overrides = {
+            individual_id: individual_label
+            for individual_id, individual_label in blocks.keys()
+            if "://" in individual_label
+        }
+        prefix = serialisation_config.prefix
+        prefix_iri = serialisation_config.prefix_iri or get_prefix_iri(
+            serialisation_config.ontology_iri
+        )
         for (individual_id, individual_label), types_and_facts in blocks.items():
-            prefix = serialisation_config.prefix
-            prefix_iri = serialisation_config.prefix_iri or get_prefix_iri(
-                serialisation_config.ontology_iri
-            )
-            if prefix and prefix_iri:
-                individual_uri = Namespace(prefix_iri)[individual_id]
+            if individual_id in absolute_overrides:
+                individual_uri = URIRef(absolute_overrides[individual_id])
+            elif prefix and serialisation_config.prefix_iri:
+                individual_uri = Namespace(serialisation_config.prefix_iri)[
+                    individual_id
+                ]
+            elif prefix_iri:
+                individual_uri = URIRef(f"{prefix_iri}{individual_id}")
             else:
-                # Fallback to a default base URI if no prefix is defined
-                base_uri = prefix_iri or get_prefix_iri(ontology_iri)
-                individual_uri = URIRef(f"{base_uri}{individual_id}")
-
-            g.add((individual_uri, RDF.type, OWL.NamedIndividual))
-
-            # Add types
+                individual_uri = URIRef(individual_id)
+            graph.add((individual_uri, RDF.type, OWL.NamedIndividual))
             for rdf_type in types_and_facts.get("Types", set()):
-                prefix, name = rdf_type.split(":")
-                g.add((individual_uri, RDF.type, Namespace(prefixes[prefix])[name]))
-
-            # Add label
+                type_prefix, type_name = rdf_type.split(":")
+                graph.add(
+                    (
+                        individual_uri,
+                        RDF.type,
+                        Namespace(prefixes[type_prefix])[type_name],
+                    )
+                )
             if serialisation_config.include_label:
-                g.add((individual_uri, RDFS.label, Literal(individual_label)))
-
-            # Add facts
+                graph.add((individual_uri, RDFS.label, Literal(individual_label)))
             for prop, values in types_and_facts.items():
                 if prop == "Types":
                     continue
-
                 prop_prefix, prop_name = prop.split(":")
                 prop_uri = Namespace(prefixes[prop_prefix])[prop_name]
-
                 for value in values:
                     if prop in object_properties:
-                        if prefix and prefix_iri:
-                            target_uri = Namespace(prefix_iri)[value]
+                        if value in absolute_overrides:
+                            target_uri = URIRef(absolute_overrides[value])
+                        elif prefix and serialisation_config.prefix_iri:
+                            target_uri = Namespace(serialisation_config.prefix_iri)[
+                                value
+                            ]
+                        elif prefix_iri:
+                            target_uri = URIRef(f"{prefix_iri}{value}")
                         else:
-                            base_uri = prefix_iri or get_prefix_iri(ontology_iri)
-                            target_uri = URIRef(f"{base_uri}{value}")
-                        g.add((individual_uri, prop_uri, target_uri))
+                            target_uri = URIRef(value)
+                        graph.add((individual_uri, prop_uri, target_uri))
                     elif prop in datatype_properties:
-                        # Simplified type inference
-                        if isinstance(value, int) or value.isnumeric():
+                        if isinstance(value, int) or (
+                            isinstance(value, str) and value.isnumeric()
+                        ):
                             literal_value = Literal(value, datatype=XSD.integer)
                         elif isinstance(value, float):
                             literal_value = Literal(value, datatype=XSD.float)
@@ -1893,17 +2106,14 @@ class rdf_control_core:
                                 literal_value = Literal(value, datatype=XSD.date)
                             except (ValueError, TypeError):
                                 literal_value = Literal(value)
-                        g.add((individual_uri, prop_uri, literal_value))
-                    else:
-                        # Default to treating as a literal for safety
-                        g.add((individual_uri, prop_uri, Literal(value)))
-
-        return g
+                        graph.add((individual_uri, prop_uri, literal_value))
+        return graph
 
     # END serialise_to_graph
 
 
 # ===== post.xml.metadata =====
+
 
 class xml_metadata_post:
     pass
@@ -1911,11 +2121,13 @@ class xml_metadata_post:
 
 # ===== post.xml.data =====
 
+
 class xml_data_post:
     pass
 
 
 # ===== post.xml.control =====
+
 
 class xml_control_post:
     pass
@@ -1923,17 +2135,20 @@ class xml_control_post:
 
 # ===== post.internal.metadata =====
 
+
 class internal_metadata_post:
     pass
 
 
 # ===== post.internal.data =====
 
+
 class internal_data_post:
     pass
 
 
 # ===== post.internal.control =====
+
 
 class internal_control_post:
     # BEGIN parse_drawio_to_graph
@@ -2043,17 +2258,20 @@ class internal_control_post:
 
 # ===== post.rdf.metadata =====
 
+
 class rdf_metadata_post:
     pass
 
 
 # ===== post.rdf.data =====
 
+
 class rdf_data_post:
     pass
 
 
 # ===== post.rdf.control =====
+
 
 class rdf_control_post:
     pass
@@ -2064,10 +2282,13 @@ class DrawIOParser:
     __data_type__ = "internal"
     __data_role__ = "metadata"
     __phase__ = "core"
+
     def __init__(self):
         self.pipeline = pipeline
+
     def to_graph_from_file(self, path, **kw):
         return pipeline.post.internal.control.parse_drawio_to_graph(path, **kw)
+
     def run_cli(self, argv=None):
         return pipeline.post.internal.control.main(argv)
 
@@ -2126,7 +2347,9 @@ _dimensions = xml_data_core._dimensions
 _is_possible_literal = xml_data_core._is_possible_literal
 _arrow_label = xml_data_core._arrow_label
 _add_arrow_if_find_label = xml_data_core._add_arrow_if_find_label
-_extract_individual_and_arrow_and_literal_cells = xml_data_core._extract_individual_and_arrow_and_literal_cells
+_extract_individual_and_arrow_and_literal_cells = (
+    xml_data_core._extract_individual_and_arrow_and_literal_cells
+)
 _close_enough = xml_data_core._close_enough
 _cell_close_to = xml_data_core._cell_close_to
 _defines_individual = xml_data_core._defines_individual
@@ -2140,16 +2363,24 @@ _split_curie = internal_data_core._split_curie
 _ensure_known_curie = internal_data_core._ensure_known_curie
 _verify_is_ric_class = internal_data_core._verify_is_ric_class
 _SourceNotIndividualException = internal_data_core._SourceNotIndividualException
-ArrowWithoutIndividualAsSourceException = internal_data_core.ArrowWithoutIndividualAsSourceException
+ArrowWithoutIndividualAsSourceException = (
+    internal_data_core.ArrowWithoutIndividualAsSourceException
+)
 _add_individual_type = internal_data_core._add_individual_type
 _parse_space_substitute = internal_control_core._parse_space_substitute
-_parse_metacharacter_substitutes = internal_control_core._parse_metacharacter_substitutes
+_parse_metacharacter_substitutes = (
+    internal_control_core._parse_metacharacter_substitutes
+)
 individual_blocks = internal_control_core.individual_blocks
 _build_graph_from_raw_xml = internal_control_core._build_graph_from_raw_xml
 NotInKnownException = rdf_data_core.NotInKnownException
-_MetacharacterSubstituteParseException = rdf_data_core._MetacharacterSubstituteParseException
+_MetacharacterSubstituteParseException = (
+    rdf_data_core._MetacharacterSubstituteParseException
+)
 MetacharacterException = rdf_data_core.MetacharacterException
-_InvalidCapitalisationSchemeException = rdf_data_core._InvalidCapitalisationSchemeException
+_InvalidCapitalisationSchemeException = (
+    rdf_data_core._InvalidCapitalisationSchemeException
+)
 DrawIOParserGraph = rdf_control_core.DrawIOParserGraph
 serialise_to_graph = rdf_control_core.serialise_to_graph
 parse_drawio_to_graph = internal_control_post.parse_drawio_to_graph
@@ -2157,92 +2388,242 @@ _run = internal_control_post._run
 main = internal_control_post.main
 
 # ===== attach to nested namespaces =====
-setattr(pipeline.pre.xml.metadata, '_extract_drawio_metadata', xml_metadata_pre._extract_drawio_metadata)
-setattr(pipeline.pre.xml.metadata, '_strip_metadata_user_object', xml_metadata_pre._strip_metadata_user_object)
-setattr(pipeline.pre.internal.metadata, 'DEFAULT_CAPITALISATION_SCHEME', internal_metadata_pre.DEFAULT_CAPITALISATION_SCHEME)
-setattr(pipeline.pre.internal.metadata, 'DEFAULT_INDENTATION', internal_metadata_pre.DEFAULT_INDENTATION)
-setattr(pipeline.pre.internal.metadata, 'DEFAULT_MAX_GAP', internal_metadata_pre.DEFAULT_MAX_GAP)
-setattr(pipeline.pre.internal.metadata, 'OWL_METACHARACTERS', internal_metadata_pre.OWL_METACHARACTERS)
-setattr(pipeline.pre.internal.metadata, 'Blocks', internal_metadata_pre.Blocks)
-setattr(pipeline.pre.internal.metadata, 'CellID', internal_metadata_pre.CellID)
-setattr(pipeline.pre.internal.metadata, 'XCoordinate', internal_metadata_pre.XCoordinate)
-setattr(pipeline.pre.internal.metadata, 'YCoordinate', internal_metadata_pre.YCoordinate)
-setattr(pipeline.pre.internal.metadata, 'Width', internal_metadata_pre.Width)
-setattr(pipeline.pre.internal.metadata, 'Height', internal_metadata_pre.Height)
-setattr(pipeline.pre.internal.metadata, 'ArrowStart', internal_metadata_pre.ArrowStart)
-setattr(pipeline.pre.internal.metadata, 'ArrowEnd', internal_metadata_pre.ArrowEnd)
-setattr(pipeline.pre.internal.metadata, 'Label', internal_metadata_pre.Label)
-setattr(pipeline.pre.internal.metadata, 'ArrowData', internal_metadata_pre.ArrowData)
-setattr(pipeline.pre.internal.metadata, 'Dimensions', internal_metadata_pre.Dimensions)
-setattr(pipeline.pre.internal.metadata, 'Paragraph', internal_metadata_pre.Paragraph)
-setattr(pipeline.pre.internal.metadata, 'Metacharacter', internal_metadata_pre.Metacharacter)
-setattr(pipeline.pre.internal.metadata, 'Replacement', internal_metadata_pre.Replacement)
-setattr(pipeline.pre.internal.metadata, 'get_prefixes', internal_metadata_pre.get_prefixes)
-setattr(pipeline.pre.internal.metadata, 'get_ontology_iri', internal_metadata_pre.get_ontology_iri)
-setattr(pipeline.pre.internal.metadata, 'get_prefix', internal_metadata_pre.get_prefix)
-setattr(pipeline.pre.internal.metadata, 'get_prefix_iri', internal_metadata_pre.get_prefix_iri)
-setattr(pipeline.pre.internal.metadata, 'SerialisationConfig', internal_metadata_pre.SerialisationConfig)
-setattr(pipeline.pre.internal.control, '_arguments_parser', internal_control_pre._arguments_parser)
-setattr(pipeline.pre.rdf.data, '_handle_spaces', rdf_data_pre._handle_spaces)
-setattr(pipeline.pre.rdf.data, '_replace_metacharacter', rdf_data_pre._replace_metacharacter)
-setattr(pipeline.pre.rdf.data, '_replace_metacharacters', rdf_data_pre._replace_metacharacters)
-setattr(pipeline.pre.rdf.control, '_parse_capitalisation_scheme', rdf_control_pre._parse_capitalisation_scheme)
-setattr(pipeline.core.xml.data, 'NothingToParseException', xml_data_core.NothingToParseException)
-setattr(pipeline.core.xml.data, 'NoSourceException', xml_data_core.NoSourceException)
-setattr(pipeline.core.xml.data, 'NoTargetException', xml_data_core.NoTargetException)
-setattr(pipeline.core.xml.data, '_NoValueException', xml_data_core._NoValueException)
-setattr(pipeline.core.xml.data, '_NoCellCloseEnoughException', xml_data_core._NoCellCloseEnoughException)
-setattr(pipeline.core.xml.data, 'ParseException', xml_data_core.ParseException)
-setattr(pipeline.core.xml.data, 'NodeHTMLParser', xml_data_core.NodeHTMLParser)
-setattr(pipeline.core.xml.data, 'DrawIOXMLTree', xml_data_core.DrawIOXMLTree)
-setattr(pipeline.core.xml.data, '_cell_with_id', xml_data_core._cell_with_id)
-setattr(pipeline.core.xml.data, '_value_of', xml_data_core._value_of)
-setattr(pipeline.core.xml.data, '_parent_of', xml_data_core._parent_of)
-setattr(pipeline.core.xml.data, '_child_of', xml_data_core._child_of)
-setattr(pipeline.core.xml.data, '_geometry', xml_data_core._geometry)
-setattr(pipeline.core.xml.data, '_x_and_y_in_geometry', xml_data_core._x_and_y_in_geometry)
-setattr(pipeline.core.xml.data, '_has_correct_as_attribute', xml_data_core._has_correct_as_attribute)
-setattr(pipeline.core.xml.data, '_is_locked', xml_data_core._is_locked)
-setattr(pipeline.core.xml.data, '_start_or_end', xml_data_core._start_or_end)
-setattr(pipeline.core.xml.data, '_arrow_start', xml_data_core._arrow_start)
-setattr(pipeline.core.xml.data, '_arrow_end', xml_data_core._arrow_end)
-setattr(pipeline.core.xml.data, '_dimensions', xml_data_core._dimensions)
-setattr(pipeline.core.xml.data, '_is_possible_literal', xml_data_core._is_possible_literal)
-setattr(pipeline.core.xml.data, '_arrow_label', xml_data_core._arrow_label)
-setattr(pipeline.core.xml.data, '_add_arrow_if_find_label', xml_data_core._add_arrow_if_find_label)
-setattr(pipeline.core.xml.data, '_extract_individual_and_arrow_and_literal_cells', xml_data_core._extract_individual_and_arrow_and_literal_cells)
-setattr(pipeline.core.xml.data, '_close_enough', xml_data_core._close_enough)
-setattr(pipeline.core.xml.data, '_cell_close_to', xml_data_core._cell_close_to)
-setattr(pipeline.core.xml.data, '_defines_individual', xml_data_core._defines_individual)
-setattr(pipeline.core.xml.data, '_cell_is_literal', xml_data_core._cell_is_literal)
-setattr(pipeline.core.xml.data, '_source_or_target', xml_data_core._source_or_target)
-setattr(pipeline.core.xml.data, '_arrow', xml_data_core._arrow)
-setattr(pipeline.core.xml.data, 'individuals_and_arrows', xml_data_core.individuals_and_arrows)
-setattr(pipeline.core.internal.data, 'Individual', internal_data_core.Individual)
-setattr(pipeline.core.internal.data, 'Arrow', internal_data_core.Arrow)
-setattr(pipeline.core.internal.data, '_split_curie', internal_data_core._split_curie)
-setattr(pipeline.core.internal.data, '_ensure_known_curie', internal_data_core._ensure_known_curie)
-setattr(pipeline.core.internal.data, '_verify_is_ric_class', internal_data_core._verify_is_ric_class)
-setattr(pipeline.core.internal.data, '_SourceNotIndividualException', internal_data_core._SourceNotIndividualException)
-setattr(pipeline.core.internal.data, 'ArrowWithoutIndividualAsSourceException', internal_data_core.ArrowWithoutIndividualAsSourceException)
-setattr(pipeline.core.internal.data, '_add_individual_type', internal_data_core._add_individual_type)
-setattr(pipeline.core.internal.control, '_parse_space_substitute', internal_control_core._parse_space_substitute)
-setattr(pipeline.core.internal.control, '_parse_metacharacter_substitutes', internal_control_core._parse_metacharacter_substitutes)
-setattr(pipeline.core.internal.control, 'individual_blocks', internal_control_core.individual_blocks)
-setattr(pipeline.core.internal.control, '_build_graph_from_raw_xml', internal_control_core._build_graph_from_raw_xml)
-setattr(pipeline.core.rdf.data, 'NotInKnownException', rdf_data_core.NotInKnownException)
-setattr(pipeline.core.rdf.data, '_MetacharacterSubstituteParseException', rdf_data_core._MetacharacterSubstituteParseException)
-setattr(pipeline.core.rdf.data, 'MetacharacterException', rdf_data_core.MetacharacterException)
-setattr(pipeline.core.rdf.data, '_InvalidCapitalisationSchemeException', rdf_data_core._InvalidCapitalisationSchemeException)
-setattr(pipeline.core.rdf.control, 'DrawIOParserGraph', rdf_control_core.DrawIOParserGraph)
-setattr(pipeline.core.rdf.control, 'serialise_to_graph', rdf_control_core.serialise_to_graph)
-setattr(pipeline.post.internal.control, 'parse_drawio_to_graph', internal_control_post.parse_drawio_to_graph)
-setattr(pipeline.post.internal.control, '_run', internal_control_post._run)
-setattr(pipeline.post.internal.control, 'main', internal_control_post.main)
-setattr(DrawIOXMLTree, '_geometry', staticmethod(_geometry))
-setattr(DrawIOXMLTree, '_x_and_y_in_geometry', staticmethod(_x_and_y_in_geometry))
-setattr(DrawIOXMLTree, '_has_correct_as_attribute', staticmethod(_has_correct_as_attribute))
-setattr(DrawIOXMLTree, '_is_locked', staticmethod(_is_locked))
-setattr(DrawIOXMLTree, '_dimensions', staticmethod(_dimensions))
-setattr(DrawIOXMLTree, '_is_possible_literal', staticmethod(_is_possible_literal))
-setattr(DrawIOXMLTree, '_close_enough', staticmethod(_close_enough))
+setattr(
+    pipeline.pre.xml.metadata,
+    "_extract_drawio_metadata",
+    xml_metadata_pre._extract_drawio_metadata,
+)
+setattr(
+    pipeline.pre.xml.metadata,
+    "_strip_metadata_user_object",
+    xml_metadata_pre._strip_metadata_user_object,
+)
+setattr(
+    pipeline.pre.internal.metadata,
+    "DEFAULT_CAPITALISATION_SCHEME",
+    internal_metadata_pre.DEFAULT_CAPITALISATION_SCHEME,
+)
+setattr(
+    pipeline.pre.internal.metadata,
+    "DEFAULT_INDENTATION",
+    internal_metadata_pre.DEFAULT_INDENTATION,
+)
+setattr(
+    pipeline.pre.internal.metadata,
+    "DEFAULT_MAX_GAP",
+    internal_metadata_pre.DEFAULT_MAX_GAP,
+)
+setattr(
+    pipeline.pre.internal.metadata,
+    "OWL_METACHARACTERS",
+    internal_metadata_pre.OWL_METACHARACTERS,
+)
+setattr(pipeline.pre.internal.metadata, "Blocks", internal_metadata_pre.Blocks)
+setattr(pipeline.pre.internal.metadata, "CellID", internal_metadata_pre.CellID)
+setattr(
+    pipeline.pre.internal.metadata, "XCoordinate", internal_metadata_pre.XCoordinate
+)
+setattr(
+    pipeline.pre.internal.metadata, "YCoordinate", internal_metadata_pre.YCoordinate
+)
+setattr(pipeline.pre.internal.metadata, "Width", internal_metadata_pre.Width)
+setattr(pipeline.pre.internal.metadata, "Height", internal_metadata_pre.Height)
+setattr(pipeline.pre.internal.metadata, "ArrowStart", internal_metadata_pre.ArrowStart)
+setattr(pipeline.pre.internal.metadata, "ArrowEnd", internal_metadata_pre.ArrowEnd)
+setattr(pipeline.pre.internal.metadata, "Label", internal_metadata_pre.Label)
+setattr(pipeline.pre.internal.metadata, "ArrowData", internal_metadata_pre.ArrowData)
+setattr(pipeline.pre.internal.metadata, "Dimensions", internal_metadata_pre.Dimensions)
+setattr(pipeline.pre.internal.metadata, "Paragraph", internal_metadata_pre.Paragraph)
+setattr(
+    pipeline.pre.internal.metadata, "Metacharacter", internal_metadata_pre.Metacharacter
+)
+setattr(
+    pipeline.pre.internal.metadata, "Replacement", internal_metadata_pre.Replacement
+)
+setattr(
+    pipeline.pre.internal.metadata, "get_prefixes", internal_metadata_pre.get_prefixes
+)
+setattr(
+    pipeline.pre.internal.metadata,
+    "get_ontology_iri",
+    internal_metadata_pre.get_ontology_iri,
+)
+setattr(pipeline.pre.internal.metadata, "get_prefix", internal_metadata_pre.get_prefix)
+setattr(
+    pipeline.pre.internal.metadata,
+    "get_prefix_iri",
+    internal_metadata_pre.get_prefix_iri,
+)
+setattr(
+    pipeline.pre.internal.metadata,
+    "SerialisationConfig",
+    internal_metadata_pre.SerialisationConfig,
+)
+setattr(
+    pipeline.pre.internal.control,
+    "_arguments_parser",
+    internal_control_pre._arguments_parser,
+)
+setattr(pipeline.pre.rdf.data, "_handle_spaces", rdf_data_pre._handle_spaces)
+setattr(
+    pipeline.pre.rdf.data, "_replace_metacharacter", rdf_data_pre._replace_metacharacter
+)
+setattr(
+    pipeline.pre.rdf.data,
+    "_replace_metacharacters",
+    rdf_data_pre._replace_metacharacters,
+)
+setattr(
+    pipeline.pre.rdf.control,
+    "_parse_capitalisation_scheme",
+    rdf_control_pre._parse_capitalisation_scheme,
+)
+setattr(
+    pipeline.core.xml.data,
+    "NothingToParseException",
+    xml_data_core.NothingToParseException,
+)
+setattr(pipeline.core.xml.data, "NoSourceException", xml_data_core.NoSourceException)
+setattr(pipeline.core.xml.data, "NoTargetException", xml_data_core.NoTargetException)
+setattr(pipeline.core.xml.data, "_NoValueException", xml_data_core._NoValueException)
+setattr(
+    pipeline.core.xml.data,
+    "_NoCellCloseEnoughException",
+    xml_data_core._NoCellCloseEnoughException,
+)
+setattr(pipeline.core.xml.data, "ParseException", xml_data_core.ParseException)
+setattr(pipeline.core.xml.data, "NodeHTMLParser", xml_data_core.NodeHTMLParser)
+setattr(pipeline.core.xml.data, "DrawIOXMLTree", xml_data_core.DrawIOXMLTree)
+setattr(pipeline.core.xml.data, "_cell_with_id", xml_data_core._cell_with_id)
+setattr(pipeline.core.xml.data, "_value_of", xml_data_core._value_of)
+setattr(pipeline.core.xml.data, "_parent_of", xml_data_core._parent_of)
+setattr(pipeline.core.xml.data, "_child_of", xml_data_core._child_of)
+setattr(pipeline.core.xml.data, "_geometry", xml_data_core._geometry)
+setattr(
+    pipeline.core.xml.data, "_x_and_y_in_geometry", xml_data_core._x_and_y_in_geometry
+)
+setattr(
+    pipeline.core.xml.data,
+    "_has_correct_as_attribute",
+    xml_data_core._has_correct_as_attribute,
+)
+setattr(pipeline.core.xml.data, "_is_locked", xml_data_core._is_locked)
+setattr(pipeline.core.xml.data, "_start_or_end", xml_data_core._start_or_end)
+setattr(pipeline.core.xml.data, "_arrow_start", xml_data_core._arrow_start)
+setattr(pipeline.core.xml.data, "_arrow_end", xml_data_core._arrow_end)
+setattr(pipeline.core.xml.data, "_dimensions", xml_data_core._dimensions)
+setattr(
+    pipeline.core.xml.data, "_is_possible_literal", xml_data_core._is_possible_literal
+)
+setattr(pipeline.core.xml.data, "_arrow_label", xml_data_core._arrow_label)
+setattr(
+    pipeline.core.xml.data,
+    "_add_arrow_if_find_label",
+    xml_data_core._add_arrow_if_find_label,
+)
+setattr(
+    pipeline.core.xml.data,
+    "_extract_individual_and_arrow_and_literal_cells",
+    xml_data_core._extract_individual_and_arrow_and_literal_cells,
+)
+setattr(pipeline.core.xml.data, "_close_enough", xml_data_core._close_enough)
+setattr(pipeline.core.xml.data, "_cell_close_to", xml_data_core._cell_close_to)
+setattr(
+    pipeline.core.xml.data, "_defines_individual", xml_data_core._defines_individual
+)
+setattr(pipeline.core.xml.data, "_cell_is_literal", xml_data_core._cell_is_literal)
+setattr(pipeline.core.xml.data, "_source_or_target", xml_data_core._source_or_target)
+setattr(pipeline.core.xml.data, "_arrow", xml_data_core._arrow)
+setattr(
+    pipeline.core.xml.data,
+    "individuals_and_arrows",
+    xml_data_core.individuals_and_arrows,
+)
+setattr(pipeline.core.internal.data, "Individual", internal_data_core.Individual)
+setattr(pipeline.core.internal.data, "Arrow", internal_data_core.Arrow)
+setattr(pipeline.core.internal.data, "_split_curie", internal_data_core._split_curie)
+setattr(
+    pipeline.core.internal.data,
+    "_ensure_known_curie",
+    internal_data_core._ensure_known_curie,
+)
+setattr(
+    pipeline.core.internal.data,
+    "_verify_is_ric_class",
+    internal_data_core._verify_is_ric_class,
+)
+setattr(
+    pipeline.core.internal.data,
+    "_SourceNotIndividualException",
+    internal_data_core._SourceNotIndividualException,
+)
+setattr(
+    pipeline.core.internal.data,
+    "ArrowWithoutIndividualAsSourceException",
+    internal_data_core.ArrowWithoutIndividualAsSourceException,
+)
+setattr(
+    pipeline.core.internal.data,
+    "_add_individual_type",
+    internal_data_core._add_individual_type,
+)
+setattr(
+    pipeline.core.internal.control,
+    "_parse_space_substitute",
+    internal_control_core._parse_space_substitute,
+)
+setattr(
+    pipeline.core.internal.control,
+    "_parse_metacharacter_substitutes",
+    internal_control_core._parse_metacharacter_substitutes,
+)
+setattr(
+    pipeline.core.internal.control,
+    "individual_blocks",
+    internal_control_core.individual_blocks,
+)
+setattr(
+    pipeline.core.internal.control,
+    "_build_graph_from_raw_xml",
+    internal_control_core._build_graph_from_raw_xml,
+)
+setattr(
+    pipeline.core.rdf.data, "NotInKnownException", rdf_data_core.NotInKnownException
+)
+setattr(
+    pipeline.core.rdf.data,
+    "_MetacharacterSubstituteParseException",
+    rdf_data_core._MetacharacterSubstituteParseException,
+)
+setattr(
+    pipeline.core.rdf.data,
+    "MetacharacterException",
+    rdf_data_core.MetacharacterException,
+)
+setattr(
+    pipeline.core.rdf.data,
+    "_InvalidCapitalisationSchemeException",
+    rdf_data_core._InvalidCapitalisationSchemeException,
+)
+setattr(
+    pipeline.core.rdf.control, "DrawIOParserGraph", rdf_control_core.DrawIOParserGraph
+)
+setattr(
+    pipeline.core.rdf.control, "serialise_to_graph", rdf_control_core.serialise_to_graph
+)
+setattr(
+    pipeline.post.internal.control,
+    "parse_drawio_to_graph",
+    internal_control_post.parse_drawio_to_graph,
+)
+setattr(pipeline.post.internal.control, "_run", internal_control_post._run)
+setattr(pipeline.post.internal.control, "main", internal_control_post.main)
+setattr(DrawIOXMLTree, "_geometry", staticmethod(_geometry))
+setattr(DrawIOXMLTree, "_x_and_y_in_geometry", staticmethod(_x_and_y_in_geometry))
+setattr(
+    DrawIOXMLTree, "_has_correct_as_attribute", staticmethod(_has_correct_as_attribute)
+)
+setattr(DrawIOXMLTree, "_is_locked", staticmethod(_is_locked))
+setattr(DrawIOXMLTree, "_dimensions", staticmethod(_dimensions))
+setattr(DrawIOXMLTree, "_is_possible_literal", staticmethod(_is_possible_literal))
+setattr(DrawIOXMLTree, "_close_enough", staticmethod(_close_enough))

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/curie_validator.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/curie_validator.py
@@ -54,6 +54,125 @@ def _ensure_known_curie(
     return prefix, reference
 
 
+@override(phase="core", type="xml", role="data")
+def _extract_individual_and_arrow_and_literal_cells(self, prefixes) -> None:
+    try:
+        if len(self.draw_io_xml_tree[0][0][0]) == 0:
+            raise NothingToParseException
+    except IndexError as key_error:
+        raise NothingToParseException from key_error
+
+    for cell in self.draw_io_xml_tree[0][0][0]:
+        if cell.tag != "mxCell":
+            raise ParseException(
+                "Could not parse XML tree: expecting an element with tag "
+                f"'mxCell', but had tag '{cell.tag}'"
+            )
+
+        try:
+            cell_value = self._value_of(cell)
+        except _NoValueException:
+            continue
+
+        if not cell_value:
+            self._add_arrow_if_find_label(cell)
+            continue
+
+        raw_value = cell_value.strip()
+        has_separator = ":" in raw_value
+        prefix_head = raw_value.split(":", 1)[0] if has_separator else raw_value
+        remainder = raw_value.split(":", 1)[1] if has_separator else ""
+        is_literal_candidate = self._is_possible_literal(cell)
+        parent_id = cell.attrib.get("parent")
+        has_parent_box = parent_id not in {None, "1"}
+
+        if is_literal_candidate and not has_parent_box:
+            self.literal_cells.append((cell, self._dimensions(cell)))
+            continue
+
+        try:
+            parent = self._parent_of(cell)
+            individual_identifier = self._value_of(parent)
+        except _NoValueException:
+            try:
+                arrow_data = (
+                    cell,
+                    self._arrow_start(cell),
+                    self._arrow_end(cell),
+                    cell.attrib["value"],
+                )
+                self.arrow_cells.append(arrow_data)
+            except _NoValueException:
+                pass
+            continue
+
+        if not individual_identifier:
+            continue
+
+        if not has_separator:
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    "without a CURIE prefix separator."
+                )
+            )
+
+        if not prefix_head:
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    f"'{raw_value}', but no prefix was provided before the ':' separator."
+                )
+            )
+
+        if not remainder.strip():
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    f"'{raw_value}', but no reference portion was provided after the prefix."
+                )
+            )
+
+        if prefix_head not in prefixes.keys():
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    f"'{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes."
+                )
+            )
+
+        dimensions = self._dimensions(parent)
+        seen_classes: set[str] = set()
+        had_tokens = False
+        for token in raw_value.replace(",", " ").replace(";", " ").split():
+            candidate = token.strip()
+            if not candidate:
+                continue
+            had_tokens = True
+            if candidate in seen_classes:
+                continue
+            try:
+                _verify_is_ric_class(candidate, prefixes)
+            except NotInKnownException as exc:
+                raise NotInKnownException(
+                    (
+                        f"The node '{individual_identifier}' declares rdf:type "
+                        f"'{candidate}', which is not defined by the available prefixes."
+                    )
+                ) from exc
+            seen_classes.add(candidate)
+            individual = Individual(individual_identifier, candidate)
+            self.individual_cells.append((cell, individual, dimensions))
+
+        if not had_tokens:
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares an rdf:type value "
+                    "but no CURIE tokens could be parsed."
+                )
+            )
+
+
 @override(phase="core", type="internal", role="control")
 def individual_blocks(
     individuals_and_arrows: Iterator[Individual | Arrow],
@@ -144,3 +263,114 @@ def individual_blocks(
             block[individual_or_arrow.identifier] = {target_identifier}
 
     return blocks, object_properties, datatype_properties
+
+
+@override(phase="core", type="rdf", role="control")
+def serialise_to_graph(
+    blocks: Blocks,
+    object_properties: set[str],
+    datatype_properties: set[str],
+    serialisation_config: SerialisationConfig,
+    prefixes: dict,
+    graph_cls: type[Graph] = Graph,
+    graph_kwargs: dict[str, Any] | None = None,
+) -> Graph:
+    graph_kwargs = graph_kwargs or {}
+    graph = graph_cls(**graph_kwargs)
+
+    for prefix, uri in prefixes.items():
+        graph.bind(prefix, Namespace(uri), replace=True)
+    if serialisation_config.prefix:
+        graph.bind(
+            serialisation_config.prefix,
+            Namespace(
+                serialisation_config.prefix_iri
+                or get_prefix_iri(serialisation_config.ontology_iri)
+            ),
+        )
+
+    if serialisation_config.include_preamble:
+        ontology_iri = serialisation_config.ontology_iri or get_ontology_iri()
+        graph.add((URIRef(ontology_iri), RDF.type, OWL.Ontology))
+        graph.add((URIRef(ontology_iri), OWL.imports, URIRef(prefixes["rico"])))
+
+    for prop in sorted(
+        prop for prop in object_properties if not prop.startswith("rico:")
+    ):
+        prop_prefix, prop_name = prop.split(":")
+        prop_uri = Namespace(prefixes[prop_prefix])[prop_name]
+        graph.add((prop_uri, RDF.type, OWL.ObjectProperty))
+
+    for prop in sorted(
+        prop for prop in datatype_properties if not prop.startswith("rico:")
+    ):
+        prop_prefix, prop_name = prop.split(":")
+        prop_uri = Namespace(prefixes[prop_prefix])[prop_name]
+        graph.add((prop_uri, RDF.type, OWL.DatatypeProperty))
+
+    absolute_overrides = {
+        individual_id: individual_label
+        for individual_id, individual_label in blocks.keys()
+        if "://" in individual_label
+    }
+
+    prefix = serialisation_config.prefix
+    prefix_iri = serialisation_config.prefix_iri or get_prefix_iri(
+        serialisation_config.ontology_iri
+    )
+
+    for (individual_id, individual_label), types_and_facts in blocks.items():
+        if individual_id in absolute_overrides:
+            individual_uri = URIRef(absolute_overrides[individual_id])
+        elif prefix and serialisation_config.prefix_iri:
+            individual_uri = Namespace(serialisation_config.prefix_iri)[individual_id]
+        elif prefix_iri:
+            individual_uri = URIRef(f"{prefix_iri}{individual_id}")
+        else:
+            individual_uri = URIRef(individual_id)
+
+        graph.add((individual_uri, RDF.type, OWL.NamedIndividual))
+
+        for rdf_type in types_and_facts.get("Types", set()):
+            type_prefix, type_name = rdf_type.split(":")
+            graph.add(
+                (individual_uri, RDF.type, Namespace(prefixes[type_prefix])[type_name])
+            )
+
+        if serialisation_config.include_label:
+            graph.add((individual_uri, RDFS.label, Literal(individual_label)))
+
+        for prop, values in types_and_facts.items():
+            if prop == "Types":
+                continue
+
+            prop_prefix, prop_name = prop.split(":")
+            prop_uri = Namespace(prefixes[prop_prefix])[prop_name]
+
+            for value in values:
+                if prop in object_properties:
+                    if value in absolute_overrides:
+                        target_uri = URIRef(absolute_overrides[value])
+                    elif prefix and serialisation_config.prefix_iri:
+                        target_uri = Namespace(serialisation_config.prefix_iri)[value]
+                    elif prefix_iri:
+                        target_uri = URIRef(f"{prefix_iri}{value}")
+                    else:
+                        target_uri = URIRef(value)
+                    graph.add((individual_uri, prop_uri, target_uri))
+                elif prop in datatype_properties:
+                    if isinstance(value, int) or (
+                        isinstance(value, str) and value.isnumeric()
+                    ):
+                        literal_value = Literal(value, datatype=XSD.integer)
+                    elif isinstance(value, float):
+                        literal_value = Literal(value, datatype=XSD.float)
+                    else:
+                        try:
+                            datetime.strptime(value, "%Y-%m-%d")
+                            literal_value = Literal(value, datatype=XSD.date)
+                        except (ValueError, TypeError):
+                            literal_value = Literal(value)
+                    graph.add((individual_uri, prop_uri, literal_value))
+
+    return graph

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
@@ -57,6 +57,82 @@ def _build_graph_from_raw_xml(
     )
 
     draw_io_xml_tree = DrawIOXMLTree(working_xml, prefixes)
+
+    try:
+        candidate_cells = draw_io_xml_tree.draw_io_xml_tree[0][0][0]
+    except IndexError:
+        candidate_cells = []
+
+    for cell in candidate_cells:
+        if cell.tag != "mxCell":
+            raise ParseException(
+                "Could not parse XML tree: expecting an element with tag "
+                f"'mxCell', but had tag '{cell.tag}'"
+            )
+
+        if cell.attrib.get("edge") == "1":
+            continue
+
+        try:
+            cell_value = draw_io_xml_tree._value_of(cell)
+        except _NoValueException:
+            continue
+
+        if not cell_value:
+            continue
+
+        raw_value = cell_value.strip()
+        has_separator = ":" in raw_value
+        prefix_head = raw_value.split(":", 1)[0] if has_separator else raw_value
+        remainder = raw_value.split(":", 1)[1] if has_separator else ""
+        is_literal_candidate = draw_io_xml_tree._is_possible_literal(cell)
+
+        try:
+            parent = draw_io_xml_tree._parent_of(cell)
+            individual_identifier = draw_io_xml_tree._value_of(parent)
+        except _NoValueException:
+            continue
+
+        if not individual_identifier:
+            continue
+
+        if parent.attrib.get("edge") == "1":
+            continue
+
+        if prefix_head not in prefixes.keys() and is_literal_candidate:
+            continue
+
+        if not has_separator:
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    "without a CURIE prefix separator."
+                )
+            )
+
+        if not prefix_head:
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    f"'{raw_value}', but no prefix was provided before the ':' separator."
+                )
+            )
+
+        if not remainder.strip():
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    f"'{raw_value}', but no reference portion was provided after the prefix."
+                )
+            )
+
+        if prefix_head not in prefixes.keys():
+            raise NotInKnownException(
+                (
+                    f"The node '{individual_identifier}' declares rdf:type "
+                    f"'{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes."
+                )
+            )
     blocks, object_properties, datatype_properties = (
         internal_control_core.individual_blocks(  # type: ignore[attr-defined]
             draw_io_xml_tree.individuals_and_arrows(

--- a/src/main/webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
@@ -2,10 +2,12 @@ import json
 import re
 import subprocess
 import sys
+import xml.etree.ElementTree as ET
 from pathlib import Path
+from typing import Optional
 
 import pytest
-from rdflib import Graph, Namespace
+from rdflib import Graph, Namespace, URIRef
 from rdflib.namespace import OWL, RDF
 
 LEGACY_DIR = Path(__file__).resolve().parents[1]
@@ -33,6 +35,39 @@ const patched = patchDrawioWithMetadata(readFileSync(inputPath, 'utf8'), options
 writeFileSync(outputPath, patched);
 """
 ).strip()
+
+
+TYPE_CELL_IDS = {
+    "unknown_prefix": "lTHjRTAcClQ9bYR0I0Gv-14",
+    "dangling_curie": "danglingCurieType",
+    "colon_only": "colonOnlyType",
+    "no_prefix": "noPrefixType",
+}
+
+TYPE_CASE_VALUES = {
+    "unknown_prefix": "<div>picoL:</div>",
+    "dangling_curie": "<div>:danglingCurie</div>",
+    "colon_only": "<div>:</div>",
+    "no_prefix": "<div>NoPrefixClass</div>",
+}
+
+
+def _mutate_fixture_for_case(tmp_path: Path, case_key: Optional[str]) -> Path:
+    tree = ET.parse(FIXTURES_DIR / "AA37-with-metadata-severely-mocked.drawio")
+    root = tree.getroot()
+
+    for key, cell_id in TYPE_CELL_IDS.items():
+        cell = root.find(f".//mxCell[@id='{cell_id}']")
+        if cell is None:
+            raise AssertionError(f"Expected mxCell with id '{cell_id}' in fixture")
+        if case_key is not None and key == case_key:
+            cell.set("value", TYPE_CASE_VALUES[key])
+        else:
+            cell.set("value", "<div>rico:CorporateBody</div>")
+
+    output = tmp_path / f"AA37-{case_key or 'all-valid'}.drawio"
+    tree.write(output, encoding="unicode", xml_declaration=False)
+    return output
 
 
 def test_individual_blocks_accepts_declared_prefix_curie():
@@ -93,6 +128,45 @@ def test_individual_blocks_tracks_datatype_properties():
     assert "rdfs:label" in datatype_props
     facts = blocks[("LiteralNode", "LiteralNode")]["rdfs:label"]
     assert "Example literal" in facts
+
+
+@pytest.mark.parametrize(
+    "case_key",
+    ["unknown_prefix", "dangling_curie", "colon_only", "no_prefix"],
+)
+def test_parse_drawio_rejects_malformed_type_variants(tmp_path: Path, case_key: str):
+    fixture_path = _mutate_fixture_for_case(tmp_path, case_key)
+
+    with pytest.raises(draw_io_parser.NotInKnownException):
+        draw_io_parser.parse_drawio_to_graph(
+            str(fixture_path),
+            metacharacter_substitute=["remove"],
+        )
+
+
+def test_parse_drawio_accepts_corrected_mock_types(tmp_path: Path):
+    fixture_path = _mutate_fixture_for_case(tmp_path, None)
+    graph = draw_io_parser.parse_drawio_to_graph(
+        str(fixture_path),
+        metacharacter_substitute=["remove"],
+    )
+
+    assert isinstance(graph, draw_io_parser.DrawIOParserGraph)
+
+    expected_subjects = {
+        "https://example.com",
+        "https://example.com/dangling-curie",
+        "https://example.com/colon-only",
+        "https://example.com/no-prefix",
+    }
+
+    observed = {
+        str(subject)
+        for subject in graph.subjects(RDF.type, None)
+        if isinstance(subject, URIRef)
+    }
+
+    assert expected_subjects.issubset(observed)
 
 
 def _normalise_graph(graph: Graph) -> Graph:

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,34 +1,51 @@
-Script started on 2025-10-20 04:53:51+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
+Script started on 2025-10-20 06:22:11+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 [0m[2m[35m$[0m [2m[1mpython -m meta_builder -o legacy/draw_io_parser.py && bun run lint:fix:py && bun run format:py[0m
-[metabuilder] Wrote legacy/draw_io_parser.py (overrides on; replacements=4, additions=0)
+[metabuilder] Wrote legacy/draw_io_parser.py ( overrides on; replacements=6 [_build_graph_from_raw_xml, _ensure_known_curie, _extract_individual_and_arrow_and_literal_cells, _split_curie, individual_blocks, serialise_to_graph] additions=0 )
 [metabuilder] Loaded override modules from /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: curie_validator.py, rml_export.py
 [0m[2m[35m$[0m [2m[1mruff check --fix .[0m
-All checks passed!
+Found 2 errors (2 fixed, 0 remaining).
 [0m[2m[35m$[0m [2m[1mruff format .[0m
 1 file reformatted, 19 files left unchanged
 Attempting to regenerate baselines from 1 commit(s)...
 Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
 
-[1m[91mF821 [0m[1mUndefined name `Tuple`[0m
-  [1m[94m-->[0m docs/chats/Claude_Export_2025-10-16_09-57-57_DrawIO_XML_parsing_pipeline_architecture/[2025-10-16_09-34-41] DrawIO_XML_parsing_pipeline_architecture - Branch1_main_v1_Updated_MAPPING_List_updated_mapping.py:11:15
-   [1m[94m|[0m
-[1m[94m 9 |[0m # ---
-[1m[94m10 |[0m
-[1m[94m11 |[0m MAPPING: List[Tuple[str, str, str, str]] = [
-   [1m[94m|[0m               [1m[91m^^^^^[0m
-[1m[94m12 |[0m     # ===== PRE PHASE =====
-   [1m[94m|[0m
+✅ Baselines regenerated using commit cf8f84bb84ff83843b6726ac96aff3a2055f4275
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio -> webapp/plugins/rdfexport/tests/baselines/AA37 Department of Health.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/AA42 Ministry of Health.drawio -> webapp/plugins/rdfexport/tests/baselines/AA42 Ministry of Health.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/BA619 Walkerton Inquiry.drawio -> webapp/plugins/rdfexport/tests/baselines/BA619 Walkerton Inquiry.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/CA1853 Chest Disease Service.drawio -> webapp/plugins/rdfexport/tests/baselines/CA1853 Chest Disease Service.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/CA1934 Division of Tuberculosis Prevention.drawio -> webapp/plugins/rdfexport/tests/baselines/CA1934 Division of Tuberculosis Prevention.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47 Simcoe Family fonds.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47 Simcoe Family fonds.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11 Elizabeth Simcoe sketches.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11 Elizabeth Simcoe sketches.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-1 Elizabeth Simcoe loose sketches.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-1 Elizabeth Simcoe loose sketches.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1 (VDB test).drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-1-0-1 (VDB test).nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-1-0-1.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-2 Elizabeth Simcoe sketchbook.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-2 Elizabeth Simcoe sketchbook.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-4 Notes on Elizabeth Simcoe sketches.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 4711 Orville Wood fonds.drawio -> webapp/plugins/rdfexport/tests/baselines/F 4711 Orville Wood fonds.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio -> webapp/plugins/rdfexport/tests/baselines/General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/General Authority to RiC-O Model_2025-06-25_PZ.drawio -> webapp/plugins/rdfexport/tests/baselines/General Authority to RiC-O Model_2025-06-25_PZ.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 10-142 Correspondence of the Chief of the Chest Disease Service.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 10-145 Mobile Tuberculosis Testing Clinic photographs.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.nt
+  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Walkerton Inquiry in RiC-O (original).drawio -> webapp/plugins/rdfexport/tests/baselines/RG 18-210 Walkerton Inquiry in RiC-O (original).nt
 
-[1m[91mF821 [0m[1mUndefined name `List`[0m
-  [1m[94m-->[0m docs/chats/Claude_Export_2025-10-16_09-57-57_DrawIO_XML_parsing_pipeline_architecture/[2025-10-16_09-55-56] DrawIO_XML_parsing_pipeline_architecture - Branch1_main_v2_Artifact_updated_mapping_updated_mapping.py:11:10
-   [1m[94m|[0m
-[1m[94m 9 |[0m # ---
-[1m[94m10 |[0m
-[1m[94m11 |[0m MAPPING: List[Tuple[str, str, str, str]] = [
-   [1m[94m|[0m          [1m[91m^^^^[0m
-[1m[94m12 |[0m     # ===== PRE PHASE =====
-   [1m[94m|[0m
+⚠️  Failed to generate baselines for 6 fixture(s):
+  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata-rml.drawio
+     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
+  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata.drawio
+     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
+  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked.drawio
+     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
+  ❌ webapp/plugins/rdfexport/tests/fixtures/General_Authority_bleep_mock.drawio
+     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
+  ❌ webapp/plugins/rdfexport/tests/fixtures/knut_olborgs_forskningsnotater.drawio
+     An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
+  ❌ webapp/plugins/rdfexport/tests/fixtures/koronakommisjonen.drawio
+     An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
 
 🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
 [1m===================================================== test session starts ======================================================[0m
@@ -36,183 +53,254 @@ platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/drawi
 cachedir: .pytest_cache
 rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
-[1mcollecting ... [0m[1m
-collected 31 items                                                                                                             [0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m   [  6%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [  9%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 12%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[32m [ 19%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[32m [ 22%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[32m [ 25%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[32m [ 29%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[32m [ 32%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[32m [ 35%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[32m [ 38%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[32m [ 41%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[32m [ 45%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[32m [ 48%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[32m [ 51%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[32m [ 54%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[32m [ 58%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[32m [ 61%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[32m [ 64%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[32m [ 67%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[32m [ 70%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[32m [ 74%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[32m [ 77%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 80%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 83%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[32m [ 87%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 90%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m     [ 93%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m       [ 96%][0m
+[1mcollecting ... [0m[1mcollected 36 items                                                                                                             [0m
+
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  2%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m   [  5%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[32m [  8%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[dangling_curie] [32mPASSED[0m[32m [ 11%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[colon_only] [32mPASSED[0m[32m [ 13%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[no_prefix] [32mPASSED[0m[32m [ 16%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[32m      [ 19%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [ 22%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 25%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[32m [ 27%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[32m [ 30%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[32m [ 33%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[32m [ 36%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[32m [ 38%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[32m [ 41%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[32m [ 44%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[32m [ 47%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[32m [ 50%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[32m [ 52%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[32m [ 55%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[32m [ 58%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[32m [ 61%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[32m [ 63%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[32m [ 66%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[32m [ 69%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[32m [ 72%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[32m [ 75%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[32m [ 77%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[32m [ 80%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 83%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 86%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[32m [ 88%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 91%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m     [ 94%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m       [ 97%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m         [100%][0m
-[32m====================================================== [32m[1m31 passed[0m[32m in 5.34s[0m[32m ======================================================[0m
+
+[32m====================================================== [32m[1m36 passed[0m[32m in 8.29s[0m[32m ======================================================[0m
 [1m===================================================== test session starts ======================================================[0m
 platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
 rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
-[1mcollecting ... [0m[1m
-collected 43 items                                                                                                             [0m
+configfile: pyproject.toml
+[1mcollecting ... [0m[1mcollected 48 items                                                                                                             [0m
+
 legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[32m                                                                                 [  6%][0m
-legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                      [ 79%][0m
-legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                               [ 88%][0m
+legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                 [ 81%][0m
+legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                               [ 89%][0m
 meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                     [100%][0m
-[32m====================================================== [32m[1m43 passed[0m[32m in 6.40s[0m[32m ======================================================[0m
+
+[32m===================================================== [32m[1m48 passed[0m[32m in 10.36s[0m[32m ======================================================[0m
 [0m[1mbun test [0m[2mv1.2.14 (6a363a38)[0m
+[0m
+tests/rdfexport.test.ts:
+[BLACKBOX] Received serialized payload (36445 characters)
 [PIPELINE] Initializing Pyodide runtime from /workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m5185.64ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[3.55ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m144.03ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (32192 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-1 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (3931 characters)
-[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-2 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (3931 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
-[PIPELINE] Generated DrawIO XML payload (32210 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (32210 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32210)
-[PIPELINE] DrawIO parser produced graph graph-3 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (3997 characters)
-[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m503.76ms[0m[2m][0m
+[PIPELINE] Pyodide runtime ready
+[PIPELINE] Preparing Pyodide Python environment
+[PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
+[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/__init__.py
+[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/drawio_pipeline.py
+[PIPELINE] Syncing Python wheel to virtual FS: /app/wheels/rdflib-7.2.1-py3-none-any.whl
+[PIPELINE] Pyodide Python environment ready
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
+[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
+[BLACKBOX] Black box processing completed
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[0m[33m8752.06ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[5.68ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m216.82ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (48145 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-4 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (5721 characters)
-[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-5 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (5721 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (48163 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (48163 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48163)
-[PIPELINE] DrawIO parser produced graph graph-6 with 89 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 89 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (5787 characters)
-[PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m426.52ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (40849 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-7 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (5715 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-8 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (5715 characters)
+[PIPELINE] Generated DrawIO XML payload (44778 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
+[PIPELINE] DrawIO parser produced graph graph-1 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (5458 characters)
+[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
+[PIPELINE] DrawIO parser produced graph graph-2 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (5458 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (40867 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (40867 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40867)
-[PIPELINE] DrawIO parser produced graph graph-9 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (5781 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1 (VDB test).rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m278.76ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (44796 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44796 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44796)
+[PIPELINE] DrawIO parser produced graph graph-3 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5524 characters)
+[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m939.71ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] DrawIO parser produced graph graph-10 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (5497 characters)
-[PIPELINE] DrawIO parser produced graph graph-11 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (5497 characters)
-[PIPELINE] DrawIO parser produced graph graph-12 with 94 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 94 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (5563 characters)
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m312.76ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[PIPELINE] DrawIO parser produced graph graph-13 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (5053 characters)
-[PIPELINE] DrawIO parser produced graph graph-14 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (5053 characters)
+[PIPELINE] Generated DrawIO XML payload (73820 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-4 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (9086 characters)
+[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-5 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (9086 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] DrawIO parser produced graph graph-15 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (5119 characters)
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m280.66ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (37282 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-16 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (4369 characters)
-[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-17 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (4369 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[PIPELINE] Generated DrawIO XML payload (37300 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (37300 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37300)
-[PIPELINE] DrawIO parser produced graph graph-18 with 76 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 76 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (4435 characters)
-[PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
-[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m251.18ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (73838 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (73838 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73838)
+[PIPELINE] DrawIO parser produced graph graph-6 with 137 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 137 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (9152 characters)
+[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m981.68ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (37601 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-7 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (4345 characters)
+[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-8 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (4345 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (37619 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37619 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37619)
+[PIPELINE] DrawIO parser produced graph graph-9 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (4411 characters)
+[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m420.74ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (58331 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
+[PIPELINE] DrawIO parser produced graph graph-10 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (9207 characters)
+[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
+[PIPELINE] DrawIO parser produced graph graph-11 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (9207 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (58349 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (58349 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58349)
+[PIPELINE] DrawIO parser produced graph graph-12 with 104 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 104 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (9273 characters)
+[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m630.36ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (23393 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
+[PIPELINE] DrawIO parser produced graph graph-13 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (3002 characters)
+[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
+[PIPELINE] DrawIO parser produced graph graph-14 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (3002 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (23411 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23411 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23411)
+[PIPELINE] DrawIO parser produced graph graph-15 with 54 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 54 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (3068 characters)
+[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m323.47ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (49927 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
+[PIPELINE] DrawIO parser produced graph graph-16 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (6443 characters)
+[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
+[PIPELINE] DrawIO parser produced graph graph-17 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (6443 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (49945 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (49945 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49945)
+[PIPELINE] DrawIO parser produced graph graph-18 with 99 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 99 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (6509 characters)
+[PIPELINE] Saving RML export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m582.43ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (42005 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
@@ -227,7 +315,10 @@ meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[3
 [BLACKBOX] Parsed DrawIO graph graph-20 with 75 triples
 [BLACKBOX] Returning Turtle payload for graph graph-20 (6307 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (42023 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (42023 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 42023)
@@ -236,418 +327,22 @@ meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[3
 [BLACKBOX] Returning Turtle payload for graph graph-21 (6373 characters)
 [PIPELINE] Saving RML export payload to F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m287.19ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (34878 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-22 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (5761 characters)
-[PIPELINE] Saving export payload to AA37 Department of Health.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-23 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (5761 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (34896 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (34896 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34896)
-[PIPELINE] DrawIO parser produced graph graph-24 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (5827 characters)
-[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m245.06ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (49927 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-25 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (6443 characters)
-[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-26 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (6443 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (49945 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (49945 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49945)
-[PIPELINE] DrawIO parser produced graph graph-27 with 99 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 99 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (6509 characters)
-[PIPELINE] Saving RML export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m404.06ms[0m[2m][0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m260.60ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23529 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-31 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-31 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-31 (3738 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-32 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-32 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-32 (3738 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23547 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23547 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23547)
-[PIPELINE] DrawIO parser produced graph graph-33 with 51 triples
-[BLACKBOX] Parsed DrawIO graph graph-33 with 51 triples
-[BLACKBOX] Returning Turtle payload for graph graph-33 (3804 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m168.57ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-34 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (9826 characters)
-[PIPELINE] DrawIO parser produced graph graph-35 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (9826 characters)
-[PIPELINE] DrawIO parser produced graph graph-36 with 144 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 144 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (9892 characters)
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m588.79ms[0m[2m][0m
-[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23393 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-37 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-37 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-37 (3002 characters)
-[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-38 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-38 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-38 (3002 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23411 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23411 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23411)
-[PIPELINE] DrawIO parser produced graph graph-39 with 54 triples
-[BLACKBOX] Parsed DrawIO graph graph-39 with 54 triples
-[BLACKBOX] Returning Turtle payload for graph graph-39 (3068 characters)
-[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m170.80ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-40 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-40 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-40 (6195 characters)
-[PIPELINE] DrawIO parser produced graph graph-41 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-41 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-41 (6195 characters)
-[PIPELINE] DrawIO parser produced graph graph-42 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-42 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-42 (6261 characters)
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m337.90ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (61812 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-43 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-43 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-43 (7040 characters)
-[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-44 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-44 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-44 (7040 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (61830 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (61830 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61830)
-[PIPELINE] DrawIO parser produced graph graph-45 with 127 triples
-[BLACKBOX] Parsed DrawIO graph graph-45 with 127 triples
-[BLACKBOX] Returning Turtle payload for graph graph-45 (7106 characters)
-[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m434.61ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-46 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-46 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-46 (9207 characters)
-[PIPELINE] DrawIO parser produced graph graph-47 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-47 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-47 (9207 characters)
-[PIPELINE] DrawIO parser produced graph graph-48 with 104 triples
-[BLACKBOX] Parsed DrawIO graph graph-48 with 104 triples
-[BLACKBOX] Returning Turtle payload for graph graph-48 (9273 characters)
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m348.22ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
-[PIPELINE] DrawIO parser produced graph graph-49 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-49 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-49 (4952 characters)
-[PIPELINE] DrawIO parser produced graph graph-50 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-50 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-50 (4952 characters)
-[PIPELINE] DrawIO parser produced graph graph-51 with 65 triples
-[BLACKBOX] Parsed DrawIO graph graph-51 with 65 triples
-[BLACKBOX] Returning Turtle payload for graph graph-51 (5018 characters)
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m263.71ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (44778 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-52 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-52 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-52 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-53 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-53 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-53 (5458 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[PIPELINE] Generated DrawIO XML payload (44796 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44796 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44796)
-[PIPELINE] DrawIO parser produced graph graph-54 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-54 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-54 (5524 characters)
-[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m293.17ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (80864 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-55 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-55 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-55 (11220 characters)
-[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-56 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-56 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-56 (11220 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
-[PIPELINE] Generated DrawIO XML payload (80882 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (80882 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80882)
-[PIPELINE] DrawIO parser produced graph graph-57 with 173 triples
-[BLACKBOX] Parsed DrawIO graph graph-57 with 173 triples
-[BLACKBOX] Returning Turtle payload for graph graph-57 (11286 characters)
-[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m607.02ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (73820 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-58 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-58 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-58 (9086 characters)
-[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-59 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-59 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-59 (9086 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (73838 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (73838 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73838)
-[PIPELINE] DrawIO parser produced graph graph-60 with 137 triples
-[BLACKBOX] Parsed DrawIO graph graph-60 with 137 triples
-[BLACKBOX] Returning Turtle payload for graph graph-60 (9152 characters)
-[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m465.29ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39382 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-61 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-61 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-61 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-62 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-62 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-62 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39400 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39400 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39400)
-[PIPELINE] DrawIO parser produced graph graph-63 with 78 triples
-[BLACKBOX] Parsed DrawIO graph graph-63 with 78 triples
-[BLACKBOX] Returning Turtle payload for graph graph-63 (4656 characters)
-[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m269.91ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m55.20ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m51.76ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m50.73ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m13.22ms[0m[2m][0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
- 684 expect() calls
-Ran 34 tests across 1 files. [0m[2m[[1m12.88s[0m[2m][0m
-Script done on 2025-10-20 04:54:18+00:00 [COMMAND_EXIT_CODE="0"]
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (32192 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-46 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-46 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-46 (3931 characters)
-[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-47 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-47 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-47 (3931 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (32210 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (32210 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32210)
-[PIPELINE] DrawIO parser produced graph graph-48 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-48 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-48 (3997 characters)
-[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m151.40ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (40849 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-49 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-49 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-49 (5715 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-50 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-50 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-50 (5715 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (40867 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (40867 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40867)
-[PIPELINE] DrawIO parser produced graph graph-51 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-51 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-51 (5781 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1 (VDB test).rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m135.24ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (48145 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-52 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-52 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-52 (5721 characters)
-[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-53 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-53 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-53 (5721 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (48163 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (48163 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48163)
-[PIPELINE] DrawIO parser produced graph graph-54 with 89 triples
-[BLACKBOX] Parsed DrawIO graph graph-54 with 89 triples
-[BLACKBOX] Returning Turtle payload for graph graph-54 (5787 characters)
-[PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m143.47ms[0m[2m][0m
-[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m500.98ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (30806 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-55 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-55 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-55 (4952 characters)
+[PIPELINE] DrawIO parser produced graph graph-22 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (4952 characters)
 [PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
 [PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
-[PIPELINE] DrawIO parser produced graph graph-56 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-56 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-56 (4952 characters)
+[PIPELINE] DrawIO parser produced graph graph-23 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (4952 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
@@ -656,27 +351,143 @@ Script done on 2025-10-20 04:54:18+00:00 [COMMAND_EXIT_CODE="0"]
 [PIPELINE] Generated DrawIO XML payload (30824 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (30824 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 30824)
-[PIPELINE] DrawIO parser produced graph graph-57 with 65 triples
-[BLACKBOX] Parsed DrawIO graph graph-57 with 65 triples
-[BLACKBOX] Returning Turtle payload for graph graph-57 (5018 characters)
+[PIPELINE] DrawIO parser produced graph graph-24 with 65 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 65 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (5018 characters)
 [PIPELINE] Saving RML export payload to BA619 Walkerton Inquiry.rml.ttl
 [PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m95.05ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m315.47ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (48145 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
+[PIPELINE] DrawIO parser produced graph graph-25 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (5721 characters)
+[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
+[PIPELINE] DrawIO parser produced graph graph-26 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (5721 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (48163 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (48163 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48163)
+[PIPELINE] DrawIO parser produced graph graph-27 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (5787 characters)
+[PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m476.65ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (40849 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
+[PIPELINE] DrawIO parser produced graph graph-28 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (5715 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
+[PIPELINE] DrawIO parser produced graph graph-29 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (5715 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (40867 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (40867 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40867)
+[PIPELINE] DrawIO parser produced graph graph-30 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (5781 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1-0-1 (VDB test).rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m451.50ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (54115 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
+[PIPELINE] DrawIO parser produced graph graph-31 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (6195 characters)
+[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
+[PIPELINE] DrawIO parser produced graph graph-32 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (6195 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (54133 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (54133 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54133)
+[PIPELINE] DrawIO parser produced graph graph-33 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (6261 characters)
+[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m575.32ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (44244 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
+[PIPELINE] DrawIO parser produced graph graph-34 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (5497 characters)
+[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
+[PIPELINE] DrawIO parser produced graph graph-35 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (5497 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (44262 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44262 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44262)
+[PIPELINE] DrawIO parser produced graph graph-36 with 94 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 94 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (5563 characters)
+[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m466.37ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (37282 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-58 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-58 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-58 (4369 characters)
+[PIPELINE] DrawIO parser produced graph graph-37 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (4369 characters)
 [PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
 [PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-59 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-59 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-59 (4369 characters)
+[PIPELINE] DrawIO parser produced graph graph-38 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (4369 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
@@ -685,53 +496,261 @@ Script done on 2025-10-20 04:54:18+00:00 [COMMAND_EXIT_CODE="0"]
 [PIPELINE] Generated DrawIO XML payload (37300 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (37300 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 37300)
-[PIPELINE] DrawIO parser produced graph graph-60 with 76 triples
-[BLACKBOX] Parsed DrawIO graph graph-60 with 76 triples
-[BLACKBOX] Returning Turtle payload for graph graph-60 (4435 characters)
+[PIPELINE] DrawIO parser produced graph graph-39 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (4435 characters)
 [PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
 [PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m108.91ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m393.97ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (42005 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
-[PIPELINE] DrawIO parser produced graph graph-61 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-61 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-61 (6307 characters)
-[PIPELINE] Saving export payload to F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
-[PIPELINE] DrawIO parser produced graph graph-62 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-62 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-62 (6307 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[PIPELINE] Generated DrawIO XML payload (23529 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-40 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (3738 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-41 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (3738 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (42023 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (42023 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42023)
-[PIPELINE] DrawIO parser produced graph graph-63 with 76 triples
-[BLACKBOX] Parsed DrawIO graph graph-63 with 76 triples
-[BLACKBOX] Returning Turtle payload for graph graph-63 (6373 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m114.43ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (23547 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23547 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23547)
+[PIPELINE] DrawIO parser produced graph graph-42 with 51 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 51 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (3804 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m256.65ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (80864 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
+[PIPELINE] DrawIO parser produced graph graph-43 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (11220 characters)
+[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
+[PIPELINE] DrawIO parser produced graph graph-44 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-44 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-44 (11220 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (80882 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (80882 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80882)
+[PIPELINE] DrawIO parser produced graph graph-45 with 173 triples
+[BLACKBOX] Parsed DrawIO graph graph-45 with 173 triples
+[BLACKBOX] Returning Turtle payload for graph graph-45 (11286 characters)
+[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m1044.26ms[0m[2m][0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (61812 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
+[PIPELINE] DrawIO parser produced graph graph-46 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-46 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-46 (7040 characters)
+[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
+[PIPELINE] DrawIO parser produced graph graph-47 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-47 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-47 (7040 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (61830 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (61830 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61830)
+[PIPELINE] DrawIO parser produced graph graph-48 with 127 triples
+[BLACKBOX] Parsed DrawIO graph graph-48 with 127 triples
+[BLACKBOX] Returning Turtle payload for graph graph-48 (7106 characters)
+[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m805.02ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (39382 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-49 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-49 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-49 (4590 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-50 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-50 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-50 (4590 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (39400 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39400 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39400)
+[PIPELINE] DrawIO parser produced graph graph-51 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-51 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-51 (4656 characters)
+[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m464.26ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (95196 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-52 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-52 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-52 (9826 characters)
+[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-53 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-53 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-53 (9826 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (95214 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (95214 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95214)
+[PIPELINE] DrawIO parser produced graph graph-54 with 144 triples
+[BLACKBOX] Parsed DrawIO graph graph-54 with 144 triples
+[BLACKBOX] Returning Turtle payload for graph graph-54 (9892 characters)
+[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m1131.08ms[0m[2m][0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (32192 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
+[PIPELINE] DrawIO parser produced graph graph-55 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-55 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-55 (3931 characters)
+[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
+[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
+[PIPELINE] DrawIO parser produced graph graph-56 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-56 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-56 (3931 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (32210 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (32210 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32210)
+[PIPELINE] DrawIO parser produced graph graph-57 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-57 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-57 (3997 characters)
+[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
+[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m385.99ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (34878 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-58 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-58 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-58 (5761 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-59 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-59 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-59 (5761 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (34896 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (34896 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34896)
+[PIPELINE] DrawIO parser produced graph graph-60 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-60 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-60 (5827 characters)
+[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m386.98ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (39312 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-61 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-61 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-61 (5053 characters)
+[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-62 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-62 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-62 (5053 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (39330 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39330 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39330)
+[PIPELINE] DrawIO parser produced graph graph-63 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-63 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-63 (5119 characters)
+[PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m439.09ms[0m[2m][0m
 [BLACKBOX] Generating Turtle payload for serialized input (36617 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 36617)
 [PIPELINE] DrawIO parser produced graph graph-64 with 73 triples
 [BLACKBOX] Parsed DrawIO graph graph-64 with 73 triples
 [BLACKBOX] Returning Turtle payload for graph graph-64 (5812 characters)
-[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m21.54ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m105.94ms[0m[2m][0m
 [BLACKBOX] Received serialized payload (36445 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
 [PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
 [BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
 [BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m20.33ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m86.29ms[0m[2m][0m
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (36445 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (36445 characters)
@@ -741,22 +760,21 @@ Script done on 2025-10-20 04:54:18+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-65 (4714 characters)
 [PIPELINE] Saving export payload to diagram.ttl
 [PIPELINE] Export pipeline completed for diagram.ttl
-[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m21.23ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[7.49ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m97.93ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m26.63ms[0m[2m][0m
 
 [0m[2m6 tests skipped:[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
 [0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
 [0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
 [0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
 
 [0m[32m 28 pass[0m
  [0m[33m6 skip[0m
 [0m[2m 0 fail[0m
- 686 expect() calls
-Ran 34 tests across 1 file. [0m[2m[[1m5.80s[0m[2m][0m
+ 684 expect() calls
+Ran 34 tests across 1 files. [0m[2m[[1m21.49s[0m[2m][0m
 
-Command exit status: 0
-Script done on Sun Oct 19 23:09:26 2025
+Script done on 2025-10-20 06:22:54+00:00 [COMMAND_EXIT_CODE="0"]

--- a/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked-README.md
+++ b/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked-README.md
@@ -7,6 +7,17 @@
 
 Note: Output Turtle file successfully validates (e.g., with `GBAD: Validate and Serialize` button from GBAD VS Code Extension [version 0.0.2-prerelease.2](https://github.com/gbad-project/records_in_contexts_draw_io_parser/blob/cd4f0f692cec8a2096b1b596161b2f53c50e9091/vs_code_extension/gbad-vsce-0.0.2-prerelease.2.vsix)) once the prefix IRI on Line 7 is fixed.
 
+## Malformed rdf:type scenarios
+
+The mocked diagram now includes dedicated nodes for each malformed rdf:type case that the parser must flag:
+
+- `https://example.com/dangling-curie` → rdf:type `:danglingCurie` (missing prefix component).
+- `https://example.com/colon-only` → rdf:type `:` (colon without reference component).
+- `https://example.com/no-prefix` → rdf:type `NoPrefixClass` (no CURIE separator at all).
+- `https://example.com` → rdf:type `picoL:` (unknown prefix combined with missing reference).
+
+All of these shapes are rectangular children of swimlane nodes, ensuring the parser interprets them as attempted individual type declarations rather than literals.
+
 ## Preparation process
 
 Please refer to the [main plugin readme](../../README.md) for launch/installation instructions.

--- a/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked.drawio
+++ b/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked.drawio
@@ -251,6 +251,30 @@
         <mxCell id="lTHjRTAcClQ9bYR0I0Gv-14" value="&lt;div&gt;picoL:&lt;/div&gt;" style="text;strokeColor=none;fillColor=none;align=center;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="lTHjRTAcClQ9bYR0I0Gv-13" vertex="1">
           <mxGeometry y="26" width="150" height="26" as="geometry" />
         </mxCell>
+        <mxCell id="danglingCurieNode" value="https://example.com/dangling-curie" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=none;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="40" y="270" width="150" height="52" as="geometry">
+            <mxRectangle x="1041" y="570" width="50" height="40" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="danglingCurieType" value="&lt;div&gt;:danglingCurie&lt;/div&gt;" style="text;strokeColor=none;fillColor=none;align=center;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="danglingCurieNode" vertex="1">
+          <mxGeometry y="26" width="150" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="colonOnlyNode" value="https://example.com/colon-only" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=none;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="220" y="270" width="150" height="52" as="geometry">
+            <mxRectangle x="1101" y="570" width="50" height="40" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="colonOnlyType" value="&lt;div&gt;:&lt;/div&gt;" style="text;strokeColor=none;fillColor=none;align=center;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="colonOnlyNode" vertex="1">
+          <mxGeometry y="26" width="150" height="26" as="geometry" />
+        </mxCell>
+        <mxCell id="noPrefixNode" value="https://example.com/no-prefix" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=none;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+          <mxGeometry x="400" y="270" width="150" height="52" as="geometry">
+            <mxRectangle x="1161" y="570" width="50" height="40" as="alternateBounds" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="noPrefixType" value="&lt;div&gt;NoPrefixClass&lt;/div&gt;" style="text;strokeColor=none;fillColor=none;align=center;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="noPrefixNode" vertex="1">
+          <mxGeometry y="26" width="150" height="26" as="geometry" />
+        </mxCell>
         <mxCell id="lTHjRTAcClQ9bYR0I0Gv-15" value="" style="endArrow=classic;html=1;rounded=0;exitX=0.43;exitY=-0.058;exitDx=0;exitDy=0;entryX=0.543;entryY=1.038;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="I4GB3cVhTv-sTvJ7h0Jz-29" target="lTHjRTAcClQ9bYR0I0Gv-14" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="-171" y="434" as="sourcePoint" />


### PR DESCRIPTION
## Summary
- require DrawIO literal detection to confirm the cell lacks a swimlane parent so malformed rdf:type CURIEs no longer slip through as literals
- regenerate the parser output and keep the AA37 severely mocked fixture, README, and pytest coverage in sync with the stricter malformed rdf:type handling
- add the corresponding AI code activity report for the override and test updates

## Testing
- bun run lint:py
- bun run lint:ts
- bun run format:check:py
- bun run format:check:ts
- bun run test
- bun run test:log:linux

------
https://chatgpt.com/codex/tasks/task_e_68f5c75ad3e4832dad4abf53aa7e2b83