### PR TITLE
Capture Draw.io decoration notes and ensure fixture coverage

### DIFF
--- a/src/main/webapp/plugins/rdfexport/debug/map.json
+++ b/src/main/webapp/plugins/rdfexport/debug/map.json
@@ -1,5 +1,10 @@
 {
   "fixtures": {
+    "AA37 Department of Health-with-metadata-preserve-html.drawio": {
+      "path": "AA37 Department of Health-with-metadata-preserve-html.drawio",
+      "sha256": "ad9b6f5fc9d159828e7e2166ed910331bfe2294932e7355ce69f145a57c23865",
+      "size_bytes": 36617
+    },
     "AA37 Department of Health-with-metadata-rml.drawio": {
       "path": "AA37 Department of Health-with-metadata-rml.drawio",
       "sha256": "b4c639d3a4c2fc21ea892eafe131574968e1f345aaf55190b6ff933a8d447af7",

--- a/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
@@ -1363,14 +1363,18 @@ class xml_data_core:
 
     # END DrawIOXMLTree._dimensions
     # BEGIN DrawIOXMLTree._is_possible_literal
-    @staticmethod
+    # override from literal_detection.py
     def _is_possible_literal(cell: Element) -> bool:
-        try:
-            if cell.attrib["parent"] != "1":
-                return False
-            return "rounded=1" in cell.attrib["style"]
-        except KeyError:
+        """Heuristically flag top-level text decorations as literals."""
+        parent = cell.attrib.get("parent")
+        if parent != "1":
             return False
+        style = cell.attrib.get("style", "")
+        if "rounded=1" in style:
+            return True
+        style_lower = style.lower()
+        decoration_tokens = ("text;", "shape=text", "shape=mxgraph.basic.text")
+        return any((token in style_lower for token in decoration_tokens))
 
     # END DrawIOXMLTree._is_possible_literal
     # BEGIN DrawIOXMLTree._arrow_label
@@ -2094,6 +2098,28 @@ class internal_control_core:
                 graph.add((subject_uri, prop_uri, Literal(raw_value)))
 
         draw_io_xml_tree = DrawIOXMLTree(working_xml, prefixes)
+        classifier_cls = pipeline.core.xml.data.DrawIOCellClassifier
+        decorations_attr = getattr(
+            classifier_cls, "DECORATION_REGISTRY_ATTR", "__drawio_literal_registry"
+        )
+        decorations: dict[str, dict[str, object]] = {}
+        connected_literal_ids: set[str] = set()
+        for arrow_cell, *_ in draw_io_xml_tree.arrow_cells:
+            target_id = arrow_cell.attrib.get("target")
+            if target_id:
+                connected_literal_ids.add(str(target_id))
+        for cell, _ in draw_io_xml_tree.literal_cells:
+            cell_id = cell.attrib.get("id")
+            if not cell_id:
+                continue
+            value = draw_io_xml_tree._value_of(cell).strip()
+            if not value:
+                continue
+            decorations[cell_id] = {
+                "value": value,
+                "connected": cell_id in connected_literal_ids,
+            }
+        setattr(pipeline.core.internal.data, decorations_attr, decorations)
         literal_replacements: list[tuple[str, str, str, str]] = []
         if not strip_html_preference:
             literal_replacements = _gather_literal_replacements(draw_io_xml_tree)

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/literal_detection.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/literal_detection.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from xml.etree.ElementTree import Element
+
+from meta_builder.drawio_meta_builder import override
+
+
+@override(phase="core", type="xml", role="data")
+def _is_possible_literal(cell: Element) -> bool:
+    """Heuristically flag top-level text decorations as literals."""
+    parent = cell.attrib.get("parent")
+    if parent != "1":
+        return False
+
+    style = cell.attrib.get("style", "")
+    if "rounded=1" in style:
+        return True
+
+    style_lower = style.lower()
+    decoration_tokens = (
+        "text;",
+        "shape=text",
+        "shape=mxgraph.basic.text",
+    )
+    return any(token in style_lower for token in decoration_tokens)

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
@@ -220,6 +220,34 @@ def _build_graph_from_raw_xml(
             graph.add((subject_uri, prop_uri, Literal(raw_value)))
 
     draw_io_xml_tree = DrawIOXMLTree(working_xml, prefixes)
+
+    classifier_cls = pipeline.core.xml.data.DrawIOCellClassifier  # type: ignore[attr-defined]
+    decorations_attr = getattr(
+        classifier_cls,
+        "DECORATION_REGISTRY_ATTR",
+        "__drawio_literal_registry",
+    )
+    decorations: dict[str, dict[str, object]] = {}
+
+    connected_literal_ids: set[str] = set()
+    for arrow_cell, *_ in draw_io_xml_tree.arrow_cells:
+        target_id = arrow_cell.attrib.get("target")
+        if target_id:
+            connected_literal_ids.add(str(target_id))
+
+    for cell, _ in draw_io_xml_tree.literal_cells:
+        cell_id = cell.attrib.get("id")
+        if not cell_id:
+            continue
+        value = draw_io_xml_tree._value_of(cell).strip()
+        if not value:
+            continue
+        decorations[cell_id] = {
+            "value": value,
+            "connected": cell_id in connected_literal_ids,
+        }
+
+    setattr(pipeline.core.internal.data, decorations_attr, decorations)
     literal_replacements: list[tuple[str, str, str, str]] = []
     if not strip_html_preference:
         literal_replacements = _gather_literal_replacements(draw_io_xml_tree)

--- a/src/main/webapp/plugins/rdfexport/legacy/tests/test_fixture_coverage.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/tests/test_fixture_coverage.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from urllib.parse import unquote
+
+import pytest
+from rdflib import Literal, URIRef
+from rdflib.namespace import RDF
+
+LEGACY_DIR = Path(__file__).resolve().parents[1]
+if str(LEGACY_DIR) not in sys.path:
+    sys.path.insert(0, str(LEGACY_DIR))
+
+import draw_io_parser  # type: ignore=import-not-found  # noqa: E402
+from draw_io_parser import pipeline  # noqa: E402
+
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "tests" / "fixtures"
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    sorted(FIXTURES_DIR.glob("*.drawio")),
+)
+def test_all_cells_reflected_in_graph(fixture_path: Path) -> None:
+    try:
+        graph = draw_io_parser.parse_drawio_to_graph(
+            str(fixture_path),
+            metacharacter_substitute=["url"],
+        )
+    except draw_io_parser.NotInKnownException as exc:  # type: ignore[attr-defined]
+        pytest.skip(f"parser rejected fixture: {exc}")
+
+    raw_xml = fixture_path.read_text(encoding="utf-8")
+    metadata_prefixes, base_uri, _, parsed_root = (
+        pipeline.pre.xml.metadata._extract_drawio_metadata(raw_xml)
+    )
+    working_xml = pipeline.pre.xml.metadata._strip_metadata_user_object(
+        raw_xml, parsed_root
+    )
+
+    prefixes = draw_io_parser.get_prefixes()
+    prefixes.update(metadata_prefixes)
+
+    tree = draw_io_parser.DrawIOXMLTree(working_xml, prefixes)
+    classifier = pipeline.core.xml.data.DrawIOCellClassifier(tree, prefixes)
+
+    predicate_uris = {pred for pred in graph.predicates() if isinstance(pred, URIRef)}
+    type_uris = {
+        obj for obj in graph.objects(predicate=RDF.type) if isinstance(obj, URIRef)
+    }
+
+    base_candidates = set()
+    if base_uri:
+        base_candidates.add(base_uri)
+        base_candidates.add(base_uri.split("://", 1)[-1])
+    uri_names: set[str] = set()
+    for node in set(graph.subjects()) | set(graph.objects()):
+        if isinstance(node, URIRef):
+            segment = str(node)
+            if "#" in segment:
+                segment = segment.rsplit("#", 1)[-1]
+            else:
+                segment = segment.rstrip("/").rsplit("/", 1)[-1]
+            uri_names.add(unquote(segment))
+            for candidate in base_candidates:
+                if segment.startswith(candidate):
+                    remainder = segment[len(candidate) :]
+                    if remainder:
+                        uri_names.add(unquote(remainder))
+
+    unresolved: list[tuple[str | None, str, str]] = []
+
+    for cell in tree.draw_io_xml_tree[0][0][0]:
+        try:
+            raw_value = tree._value_of(cell)
+        except draw_io_parser._NoValueException:
+            continue
+        value = raw_value.strip()
+        if not value:
+            continue
+
+        classification = classifier.classify(cell, raw_value)
+        kind = getattr(classification.kind, "name", "")
+
+        if kind == "ARROW_LABEL":
+            if ":" not in value:
+                unresolved.append((cell.attrib.get("id"), value, "arrow label"))
+                continue
+            prefix, reference = value.split(":", 1)
+            base = prefixes.get(prefix)
+            if not base:
+                unresolved.append((cell.attrib.get("id"), value, "arrow prefix"))
+                continue
+            predicate_uri = URIRef(f"{base}{reference}")
+            if predicate_uri not in predicate_uris:
+                unresolved.append((cell.attrib.get("id"), value, "missing predicate"))
+            continue
+
+        if kind in {"TYPED_INDIVIDUAL", "STANDALONE_INDIVIDUAL"}:
+            missing_reference = False
+            for token in classification.tokens:
+                if ":" not in token:
+                    missing_reference = True
+                    break
+                prefix, reference = token.split(":", 1)
+                base = prefixes.get(prefix)
+                if not base:
+                    missing_reference = True
+                    break
+                candidate = URIRef(f"{base}{reference}")
+                if (
+                    candidate not in type_uris
+                    and candidate not in predicate_uris
+                    and candidate not in graph.objects()
+                ):
+                    missing_reference = True
+                    break
+            if missing_reference:
+                unresolved.append((cell.attrib.get("id"), value, "reference"))
+            continue
+
+        if any(
+            value in str(obj) for obj in graph.objects() if isinstance(obj, Literal)
+        ):
+            continue
+        if value in uri_names:
+            continue
+        unresolved.append((cell.attrib.get("id"), value, "literal"))
+
+    assert not unresolved, (
+        f"Unreflected mxCell values for {fixture_path.name}: {unresolved[:5]}"
+    )

--- a/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.ttl
+++ b/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.ttl
@@ -4,6 +4,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rico: <rico://mock-rico> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix somprefix: <h://hello> .
 @prefix unknown: <unknown://link> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -21,6 +22,9 @@ somprefix:lol a owl:ObjectProperty .
 rdf:some-predicate a owl:DatatypeProperty .
 
 rdf:type a owl:ObjectProperty .
+
+<ontology://generated-from-draw-io/mock#> skos:note "Heading This diagram illustrates that the current implementation has a neat feature that any node that doesn't look like an individual (i.e., two-part stacked box) nor is connected to an individual via a labeled arrow, is ignored. This allows users to add arbitrary decorations to the diagram without risking to break the onotology.  Anything that is the target of a labeled arrow (by the way, this does not require strict linking by default unless \"strict arrow parsing\" is enabled in parser settings) but doesn't look like an individual",
+        "hellothere2" .
 
 hellow:there a owl:DatatypeProperty,
         owl:ObjectProperty .


### PR DESCRIPTION
## Summary
- add a literal-detection override so `_is_possible_literal` recognises top-level text decorations
- propagate decoration values into the RML override so they surface as SKOS notes in the exported Turtle
- add a pytest that loads every DrawIO fixture and asserts that each meaningful mxCell is represented in the resulting graph
- refresh the AA37 “even-more-severely-mocked” Turtle fixture and update the debug fixture map metadata

## Testing
- `pytest legacy/tests/test_fixture_coverage.py`
- `bun run lint`
- `bun run format:check:py`
- `bun run format:check:ts`

------
https://chatgpt.com/codex/tasks/task_e_68f68bfe50e0832da9af3b8db6a854fa