### PR TITLE
Fix debugger cell classification prefixes

### DIFF
--- a/src/main/webapp/plugins/rdfexport.js
+++ b/src/main/webapp/plugins/rdfexport.js
@@ -18728,6 +18728,8 @@ import traceback
 import os
 from rdflib import Graph, URIRef, Literal, Namespace
 from rdflib.namespace import RDF, RDFS, OWL, XSD
+from enum import Enum, auto
+from typing import Iterable
 
 
 class pipeline:
@@ -18768,7 +18770,141 @@ class pipeline:
                 pass
 
             class data:
-                pass
+                # BEGIN override cell_classifier.py.CellClassification
+                @dataclass(slots=True)
+                class CellClassification:
+                    kind: Enum
+                    raw_value: str
+                    parent_cell: Optional[Element] = None
+                    parent_identifier: Optional[str] = None
+                    identifier: Optional[str] = None
+                    tokens: list[str] = field(default_factory=list)
+
+                # END override cell_classifier.py.CellClassification
+                # BEGIN override cell_classifier.py.CellKind
+                class CellKind(Enum):
+                    ARROW_LABEL = auto()
+                    TYPED_INDIVIDUAL = auto()
+                    STANDALONE_INDIVIDUAL = auto()
+                    LITERAL = auto()
+
+                # END override cell_classifier.py.CellKind
+                # BEGIN override cell_classifier.py.DrawIOCellClassifier
+                class DrawIOCellClassifier:
+                    """Centralised DrawIO mxCell role classification."""
+
+                    DECORATION_REGISTRY_ATTR = "__drawio_literal_registry"
+                    DEFAULT_STANDALONE_TYPE = "rico:Thing"
+
+                    def __init__(self, tree, prefixes: dict[str, str]):
+                        self._tree = tree
+                        self._prefixes = prefixes
+                        self._namespace_manager = Graph().namespace_manager
+                        for prefix, iri in prefixes.items():
+                            self._namespace_manager.bind(prefix, iri, replace=True)
+
+                    def classify(self, cell: Element, cell_value: str):
+                        CellClassificationType = (
+                            pipeline.core.xml.data.CellClassification
+                        )
+                        Kind = pipeline.core.xml.data.CellKind
+                        raw_value = cell_value.strip()
+                        if not raw_value:
+                            return CellClassificationType(Kind.LITERAL, raw_value)
+                        style = cell.attrib.get("style", "")
+                        if "edgeLabel" in style:
+                            return CellClassificationType(Kind.ARROW_LABEL, raw_value)
+                        parent_cell, parent_identifier = self._resolve_parent(cell)
+                        tokens = self._tokenise(raw_value)
+                        tokens_are_valid = self._tokens_are_valid(tokens)
+                        if (
+                            parent_cell is not None
+                            and parent_identifier
+                            and tokens
+                            and tokens_are_valid
+                        ):
+                            return CellClassificationType(
+                                kind=Kind.TYPED_INDIVIDUAL,
+                                raw_value=raw_value,
+                                parent_cell=parent_cell,
+                                parent_identifier=parent_identifier,
+                                tokens=tokens,
+                            )
+                        if tokens and tokens_are_valid:
+                            return CellClassificationType(
+                                kind=Kind.STANDALONE_INDIVIDUAL,
+                                raw_value=raw_value,
+                                identifier=raw_value,
+                                tokens=tokens,
+                            )
+                        if self._looks_like_absolute_uri(raw_value):
+                            return CellClassificationType(
+                                kind=Kind.STANDALONE_INDIVIDUAL,
+                                raw_value=raw_value,
+                                identifier=raw_value,
+                                tokens=[],
+                            )
+                        return CellClassificationType(Kind.LITERAL, raw_value)
+
+                    def _resolve_parent(
+                        self, cell: Element
+                    ) -> tuple[Optional[Element], Optional[str]]:
+                        parent_id = cell.attrib.get("parent")
+                        if parent_id in {None, "1"}:
+                            return (None, None)
+                        try:
+                            parent = self._tree._parent_of(cell)
+                        except ParseException:
+                            return (None, None)
+                        try:
+                            parent_value = self._tree._value_of(parent).strip()
+                        except _NoValueException:
+                            return (parent, None)
+                        if not parent_value:
+                            return (parent, None)
+                        return (parent, parent_value)
+
+                    @staticmethod
+                    def _tokenise(value: str) -> list[str]:
+                        normalised = value.replace(",", " ").replace(";", " ")
+                        deduped: dict[str, None] = {}
+                        for token in normalised.split():
+                            cleaned = token.strip()
+                            if not cleaned:
+                                continue
+                            deduped.setdefault(cleaned)
+                        return list(deduped.keys())
+
+                    def _tokens_are_valid(self, tokens: Iterable[str]) -> bool:
+                        has_token = False
+                        for token in tokens:
+                            if not token:
+                                continue
+                            has_token = True
+                            if ":" not in token:
+                                return False
+                            prefix, remainder = token.split(":", 1)
+                            if not prefix or not remainder.strip():
+                                return False
+                            if prefix not in self._prefixes:
+                                return False
+                            try:
+                                self._namespace_manager.expand_curie(token)
+                            except Exception:
+                                return False
+                        return has_token
+
+                    @staticmethod
+                    def _looks_like_absolute_uri(value: str) -> bool:
+                        if not value or any((ch.isspace() for ch in value)):
+                            return False
+                        try:
+                            candidate = URIRef(value)
+                        except Exception:
+                            return False
+                        return str(candidate) == value and "://" in value
+
+                # END override cell_classifier.py.DrawIOCellClassifier
 
             class control:
                 pass
@@ -19975,6 +20111,16 @@ class xml_data_core:
     # BEGIN DrawIOXMLTree._extract_individual_and_arrow_and_literal_cells
     # override from curie_validator.py
     def _extract_individual_and_arrow_and_literal_cells(self, prefixes) -> None:
+        classifier_cls = pipeline.core.xml.data.DrawIOCellClassifier
+        decorations_attr = getattr(
+            classifier_cls, "DECORATION_REGISTRY_ATTR", "__drawio_literal_registry"
+        )
+        default_standalone_type = getattr(
+            classifier_cls, "DEFAULT_STANDALONE_TYPE", "rico:Thing"
+        )
+        classifier = classifier_cls(self, prefixes)
+        decorations: dict[str, dict[str, object]] = {}
+        setattr(pipeline.core.internal.data, decorations_attr, decorations)
         try:
             if len(self.draw_io_xml_tree[0][0][0]) == 0:
                 raise NothingToParseException
@@ -19992,72 +20138,67 @@ class xml_data_core:
             if not cell_value:
                 self._add_arrow_if_find_label(cell)
                 continue
-            raw_value = cell_value.strip()
-            has_separator = ":" in raw_value
-            prefix_head = raw_value.split(":", 1)[0] if has_separator else raw_value
-            remainder = raw_value.split(":", 1)[1] if has_separator else ""
-            is_literal_candidate = self._is_possible_literal(cell)
-            parent_id = cell.attrib.get("parent")
-            has_parent_box = parent_id not in {None, "1"}
-            if is_literal_candidate and (not has_parent_box):
-                self.literal_cells.append((cell, self._dimensions(cell)))
+            classification = classifier.classify(cell, cell_value)
+            kind_name = getattr(classification.kind, "name", "")
+            if kind_name == "ARROW_LABEL":
                 continue
-            try:
-                parent = self._parent_of(cell)
-                individual_identifier = self._value_of(parent)
-            except _NoValueException:
-                try:
-                    arrow_data = (
-                        cell,
-                        self._arrow_start(cell),
-                        self._arrow_end(cell),
-                        cell.attrib["value"],
-                    )
-                    self.arrow_cells.append(arrow_data)
-                except _NoValueException:
-                    pass
-                continue
-            if not individual_identifier:
-                continue
-            if not has_separator:
-                raise NotInKnownException(
-                    f"The node '{individual_identifier}' declares rdf:type without a CURIE prefix separator."
-                )
-            if not prefix_head:
-                raise NotInKnownException(
-                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', but no prefix was provided before the ':' separator."
-                )
-            if not remainder.strip():
-                raise NotInKnownException(
-                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', but no reference portion was provided after the prefix."
-                )
-            if prefix_head not in prefixes.keys():
-                raise NotInKnownException(
-                    f"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes."
-                )
-            dimensions = self._dimensions(parent)
-            seen_classes: set[str] = set()
-            had_tokens = False
-            for token in raw_value.replace(",", " ").replace(";", " ").split():
-                candidate = token.strip()
-                if not candidate:
+            if kind_name == "TYPED_INDIVIDUAL":
+                parent = classification.parent_cell
+                identifier = classification.parent_identifier
+                if parent is None or not identifier:
                     continue
-                had_tokens = True
-                if candidate in seen_classes:
-                    continue
-                try:
-                    _verify_is_ric_class(candidate, prefixes)
-                except NotInKnownException as exc:
+                dimensions = self._dimensions(parent)
+                seen_classes: set[str] = set()
+                had_tokens = False
+                for token in classification.tokens:
+                    candidate = token.strip()
+                    if not candidate:
+                        continue
+                    had_tokens = True
+                    if candidate in seen_classes:
+                        continue
+                    try:
+                        _verify_is_ric_class(candidate, prefixes)
+                    except NotInKnownException as exc:
+                        raise NotInKnownException(
+                            f"The node '{identifier}' declares rdf:type '{candidate}', which is not defined by the available prefixes.'"
+                        ) from exc
+                    seen_classes.add(candidate)
+                    individual = Individual(identifier, candidate)
+                    self.individual_cells.append((cell, individual, dimensions))
+                if not had_tokens:
                     raise NotInKnownException(
-                        f"The node '{individual_identifier}' declares rdf:type '{candidate}', which is not defined by the available prefixes."
-                    ) from exc
-                seen_classes.add(candidate)
-                individual = Individual(individual_identifier, candidate)
-                self.individual_cells.append((cell, individual, dimensions))
-            if not had_tokens:
-                raise NotInKnownException(
-                    f"The node '{individual_identifier}' declares an rdf:type value but no CURIE tokens could be parsed."
-                )
+                        f"The node '{identifier}' declares an rdf:type value but no CURIE tokens could be parsed."
+                    )
+                continue
+            if kind_name == "STANDALONE_INDIVIDUAL":
+                identifier = classification.identifier or classification.raw_value
+                dimensions = self._dimensions(cell)
+                types = classification.tokens or [default_standalone_type]
+                seen_types: set[str] = set()
+                for rdf_type in types:
+                    candidate = rdf_type.strip()
+                    if not candidate:
+                        continue
+                    if candidate in seen_types:
+                        continue
+                    try:
+                        _verify_is_ric_class(candidate, prefixes)
+                    except NotInKnownException as exc:
+                        raise NotInKnownException(
+                            f"The standalone node '{identifier}' declares rdf:type '{candidate}', which is not defined by the available prefixes.'"
+                        ) from exc
+                    seen_types.add(candidate)
+                    individual = Individual(identifier, candidate)
+                    self.individual_cells.append((cell, individual, dimensions))
+                continue
+            self.literal_cells.append((cell, self._dimensions(cell)))
+            cell_id = cell.attrib.get("id")
+            if cell_id:
+                decorations[cell_id] = {
+                    "value": classification.raw_value,
+                    "connected": False,
+                }
 
     # END DrawIOXMLTree._extract_individual_and_arrow_and_literal_cells
     # BEGIN DrawIOXMLTree._close_enough
@@ -20096,8 +20237,19 @@ class xml_data_core:
 
     # END DrawIOXMLTree._defines_individual
     # BEGIN DrawIOXMLTree._cell_is_literal
+    # override from curie_validator.py
     def _cell_is_literal(self, candidate: Element) -> bool:
-        return any(literal_cell is candidate for literal_cell, _ in self.literal_cells)
+        is_literal = any(
+            (literal_cell is candidate for literal_cell, _ in self.literal_cells)
+        )
+        if is_literal:
+            decorations_attr = "__drawio_literal_registry"
+            registry = getattr(pipeline.core.internal.data, decorations_attr, None)
+            if isinstance(registry, dict):
+                cell_id = candidate.attrib.get("id")
+                if cell_id in registry:
+                    registry[cell_id]["connected"] = True
+        return is_literal
 
     # END DrawIOXMLTree._cell_is_literal
     # BEGIN DrawIOXMLTree._source_or_target
@@ -20816,6 +20968,9 @@ class rdf_control_core:
         graph_cls: type[Graph] = Graph,
         graph_kwargs: dict[str, Any] | None = None,
     ) -> Graph:
+        from rdflib import BNode
+        from rdflib.namespace import SKOS
+
         graph_kwargs = graph_kwargs or {}
         graph = graph_cls(**graph_kwargs)
         for prefix, uri in prefixes.items():
@@ -20908,6 +21063,24 @@ class rdf_control_core:
                             except (ValueError, TypeError):
                                 literal_value = Literal(value)
                         graph.add((individual_uri, prop_uri, literal_value))
+        decorations_attr = "__drawio_literal_registry"
+        decoration_registry = getattr(pipeline.core.internal.data, decorations_attr, {})
+        decoration_values = [
+            entry.get("value")
+            for entry in decoration_registry.values()
+            if isinstance(entry, dict)
+            and entry.get("value")
+            and (not entry.get("connected"))
+        ]
+        if decoration_values:
+            if serialisation_config.ontology_iri:
+                decoration_subject = URIRef(serialisation_config.ontology_iri)
+            else:
+                decoration_subject = BNode()
+            for note in decoration_values:
+                graph.add((decoration_subject, SKOS.note, Literal(note)))
+        if hasattr(pipeline.core.internal.data, decorations_attr):
+            delattr(pipeline.core.internal.data, decorations_attr)
         return graph
 
     # END serialise_to_graph

--- a/src/main/webapp/plugins/rdfexport/debug/__main__.py
+++ b/src/main/webapp/plugins/rdfexport/debug/__main__.py
@@ -674,13 +674,6 @@ class Debugger:
         self, xml_text: str, config: ScenarioConfig
     ) -> dict[str, dict]:
         """Extract cell classifications for all mxCell elements."""
-        from xml.etree import ElementTree as ET
-
-        try:
-            root = ET.fromstring(xml_text)
-        except ET.ParseError:
-            return {}
-
         # Import directly from the generated parser
         import sys
 
@@ -690,9 +683,22 @@ class Debugger:
             sys.path.insert(0, str(parser_dir))
 
         try:
-            from legacy.draw_io_parser import pipeline, _NoValueException
+            from legacy.draw_io_parser import (
+                _NoValueException,
+                _extract_drawio_metadata,
+                get_prefixes,
+                pipeline,
+            )
 
-            prefixes = dict(config.prefixes)
+            metadata_prefixes, _, _, root = _extract_drawio_metadata(xml_text)
+            if root is None:
+                return {}
+
+            prefixes = get_prefixes()
+            prefixes.update(metadata_prefixes)
+            for prefix, iri in config.prefixes:
+                if prefix and iri:
+                    prefixes[prefix] = iri
 
             # Don't use DrawIOXMLTree - it validates structure too strictly
             # Just get the cells directly and use the classifier

--- a/src/main/webapp/plugins/rdfexport/debug/map.json
+++ b/src/main/webapp/plugins/rdfexport/debug/map.json
@@ -173,10 +173,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-30": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Ontario. Dept. of Health\u00a0Authority Record",
           "raw_value": "rico:Record",
-          "tokens": []
+          "tokens": ["rico:Record"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-31": {
           "identifier": null,
@@ -215,10 +215,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-36": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Authority Record",
           "raw_value": "rico:DocumentaryFormType",
-          "tokens": []
+          "tokens": ["rico:DocumentaryFormType"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-37": {
           "identifier": null,
@@ -243,10 +243,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-40": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Rules for Archival Description",
           "raw_value": "rico:Rule",
-          "tokens": []
+          "tokens": ["rico:Rule"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-41": {
           "identifier": null,
@@ -271,10 +271,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-44": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Authority Record Creation",
           "raw_value": "rico:Activity",
-          "tokens": []
+          "tokens": ["rico:Activity"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-45": {
           "identifier": null,
@@ -299,10 +299,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-48": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "R. Anger",
           "raw_value": "rico:Person",
-          "tokens": []
+          "tokens": ["rico:Person"]
         },
         "I4bDPw6PqqAUihyiD4HI-1": {
           "identifier": null,
@@ -369,10 +369,10 @@
         },
         "Tc_GIQojTk6pTu17JZoE-2": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-23": {
           "identifier": null,
@@ -383,10 +383,10 @@
         },
         "Tc_GIQojTk6pTu17JZoE-24": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Provincial Board of Health of Ontario",
           "raw_value": "rico:CorporateBody",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "_-RjwaxhbeTWfwVWe4ke-13": {
           "identifier": null,
@@ -439,10 +439,10 @@
         },
         "gmwnegnUR_CNORKRYM6Y-14": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "AA37",
           "raw_value": "rico:Identifier",
-          "tokens": []
+          "tokens": ["rico:Identifier"]
         },
         "gmwnegnUR_CNORKRYM6Y-16": {
           "identifier": null,
@@ -481,10 +481,10 @@
         },
         "gmwnegnUR_CNORKRYM6Y-21": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Agent Identifier",
           "raw_value": "rico:IdentifierType",
-          "tokens": []
+          "tokens": ["rico:IdentifierType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-1": {
           "identifier": null,
@@ -509,10 +509,10 @@
         },
         "iiJ8OJKaNMLrSCaLO3TT-12": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "1924",
           "raw_value": "rico:Date",
-          "tokens": []
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-17": {
           "identifier": null,
@@ -537,17 +537,17 @@
         },
         "iiJ8OJKaNMLrSCaLO3TT-2": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:AgentName",
-          "tokens": []
+          "tokens": ["rico:AgentName"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-20": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "1972",
           "raw_value": "rico:Date",
-          "tokens": []
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-3": {
           "identifier": null,
@@ -572,10 +572,10 @@
         },
         "iiJ8OJKaNMLrSCaLO3TT-6": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "A Ontario Government Name",
           "raw_value": "rico:CorporateBodyType",
-          "tokens": []
+          "tokens": ["rico:CorporateBodyType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-7": {
           "identifier": null,
@@ -635,10 +635,10 @@
         },
         "lTHjRTAcClQ9bYR0I0Gv-12": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Web Ready: Y",
           "raw_value": "rico:RecordState",
-          "tokens": []
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-13": {
           "identifier": null,
@@ -649,10 +649,10 @@
         },
         "lTHjRTAcClQ9bYR0I0Gv-14": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Status: Approved",
           "raw_value": "rico:RecordState",
-          "tokens": []
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-15": {
           "identifier": null,
@@ -684,10 +684,10 @@
         },
         "ysJAvTtuVAxGOwe6Rh7X-2": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
           "raw_value": "rico:Mandate",
-          "tokens": []
+          "tokens": ["rico:Mandate"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-3": {
           "identifier": null,
@@ -712,10 +712,10 @@
         },
         "ysJAvTtuVAxGOwe6Rh7X-6": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Ontario. Ministry of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-7": {
           "identifier": null,
@@ -733,7 +733,7 @@
         }
       },
       "csv_path": "/mock/path/to/file.csv",
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio",
       "format": "nt",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -754,12 +754,12 @@
           "triples": 87
         },
         "ts_pipeline": {
-          "nt_sha256": "fad215d00708f42981cd8ba75913b08e26d7d8eff9ac56752739e63afc8121b0",
+          "nt_sha256": "3fbf44b885771e584527a372d9eed2e972302e9eb4119c569e12d2c0b183b799",
           "path": "results/aa37-department-of-health/ts_pipeline.nt",
           "triples": 72
         },
         "ts_plugin": {
-          "nt_sha256": "fad215d00708f42981cd8ba75913b08e26d7d8eff9ac56752739e63afc8121b0",
+          "nt_sha256": "3fbf44b885771e584527a372d9eed2e972302e9eb4119c569e12d2c0b183b799",
           "path": "results/aa37-department-of-health/ts_plugin.nt",
           "triples": 72
         }

--- a/src/main/webapp/plugins/rdfexport/debug/map.json
+++ b/src/main/webapp/plugins/rdfexport/debug/map.json
@@ -733,7 +733,7 @@
         }
       },
       "csv_path": "/mock/path/to/file.csv",
-      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio",
+      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio",
       "format": "nt",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -754,12 +754,12 @@
           "triples": 87
         },
         "ts_pipeline": {
-          "nt_sha256": "3fbf44b885771e584527a372d9eed2e972302e9eb4119c569e12d2c0b183b799",
+          "nt_sha256": "ac593309f11fde0062f2ccde3b79e8b80e5cca61b6d30a97ed88a840e527bad1",
           "path": "results/aa37-department-of-health/ts_pipeline.nt",
           "triples": 72
         },
         "ts_plugin": {
-          "nt_sha256": "3fbf44b885771e584527a372d9eed2e972302e9eb4119c569e12d2c0b183b799",
+          "nt_sha256": "ac593309f11fde0062f2ccde3b79e8b80e5cca61b6d30a97ed88a840e527bad1",
           "path": "results/aa37-department-of-health/ts_plugin.nt",
           "triples": 72
         }
@@ -854,17 +854,17 @@
         },
         "EUA9VVVl7iRi0US9AbU_-3": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "List pnnpni",
           "raw_value": "rico:Item%201",
-          "tokens": []
+          "tokens": ["rico:Item%201"]
         },
         "EUA9VVVl7iRi0US9AbU_-4": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "List pnnpni",
           "raw_value": "rdf:Item%202",
-          "tokens": []
+          "tokens": ["rdf:Item%202"]
         },
         "EUA9VVVl7iRi0US9AbU_-5": {
           "identifier": null,
@@ -952,10 +952,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-36": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Authority Record",
           "raw_value": "rico:DocumentaryFormType",
-          "tokens": []
+          "tokens": ["rico:DocumentaryFormType"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-37": {
           "identifier": null,
@@ -980,10 +980,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-40": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Rules for Archival Description",
           "raw_value": "rico:Rule",
-          "tokens": []
+          "tokens": ["rico:Rule"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-41": {
           "identifier": null,
@@ -1008,10 +1008,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-44": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Authority Record Creation",
           "raw_value": "rico:Activity",
-          "tokens": []
+          "tokens": ["rico:Activity"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-45": {
           "identifier": null,
@@ -1036,10 +1036,10 @@
         },
         "I4GB3cVhTv-sTvJ7h0Jz-48": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "R. Anger",
           "raw_value": "rico:Person",
-          "tokens": []
+          "tokens": ["rico:Person"]
         },
         "I4bDPw6PqqAUihyiD4HI-1": {
           "identifier": null,
@@ -1106,10 +1106,10 @@
         },
         "Tc_GIQojTk6pTu17JZoE-2": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-23": {
           "identifier": null,
@@ -1120,10 +1120,10 @@
         },
         "Tc_GIQojTk6pTu17JZoE-24": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Provincial Board of Health of Ontario",
           "raw_value": "rico:CorporateBody",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "_-RjwaxhbeTWfwVWe4ke-13": {
           "identifier": null,
@@ -1176,10 +1176,10 @@
         },
         "gmwnegnUR_CNORKRYM6Y-14": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "AA37",
           "raw_value": "rico:Identifier",
-          "tokens": []
+          "tokens": ["rico:Identifier"]
         },
         "gmwnegnUR_CNORKRYM6Y-16": {
           "identifier": null,
@@ -1218,10 +1218,10 @@
         },
         "gmwnegnUR_CNORKRYM6Y-21": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Agent Identifier",
           "raw_value": "rico:IdentifierType",
-          "tokens": []
+          "tokens": ["rico:IdentifierType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-1": {
           "identifier": null,
@@ -1246,10 +1246,10 @@
         },
         "iiJ8OJKaNMLrSCaLO3TT-12": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "1924",
           "raw_value": "rico:Date",
-          "tokens": []
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-17": {
           "identifier": null,
@@ -1274,17 +1274,17 @@
         },
         "iiJ8OJKaNMLrSCaLO3TT-2": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:AgentName",
-          "tokens": []
+          "tokens": ["rico:AgentName"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-20": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "1972",
           "raw_value": "rico:Date",
-          "tokens": []
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-3": {
           "identifier": null,
@@ -1309,10 +1309,10 @@
         },
         "iiJ8OJKaNMLrSCaLO3TT-6": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "A Ontario Government Name",
           "raw_value": "rico:CorporateBodyType",
-          "tokens": []
+          "tokens": ["rico:CorporateBodyType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-7": {
           "identifier": null,
@@ -1372,10 +1372,10 @@
         },
         "lTHjRTAcClQ9bYR0I0Gv-12": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Web Ready: Y",
           "raw_value": "rico:RecordState",
-          "tokens": []
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-13": {
           "identifier": "https://example.com",
@@ -1421,10 +1421,10 @@
         },
         "ysJAvTtuVAxGOwe6Rh7X-2": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
           "raw_value": "rico:Mandate",
-          "tokens": []
+          "tokens": ["rico:Mandate"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-3": {
           "identifier": null,
@@ -1449,10 +1449,10 @@
         },
         "ysJAvTtuVAxGOwe6Rh7X-6": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_identifier": "Ontario. Ministry of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-7": {
           "identifier": null,
@@ -1478,11 +1478,11 @@
         ],
         "ts_pipeline": [
           "TypeScript pipeline graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 16432464,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 16432464,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 19778288,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 19778288,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
         ],
         "ts_plugin": [
           "TypeScript plugin graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 16432464,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 16432464,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 19778288,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 19778288,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
         ]
       },
       "format": "turtle",

--- a/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_pipeline.nt
+++ b/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_pipeline.nt
@@ -1,5 +1,5 @@
-<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
-<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
+<ontology://generated-from-draw-io/2025-10-20T16-30-40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
+<ontology://generated-from-draw-io/2025-10-20T16-30-40> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.ica.org/standards/RiC/ontology#Date> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/2000/01/rdf-schema#label> "1924" .

--- a/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_pipeline.nt
+++ b/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_pipeline.nt
@@ -1,5 +1,5 @@
-<ontology://generated-from-draw-io/2025-10-20T16-06-46> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
-<ontology://generated-from-draw-io/2025-10-20T16-06-46> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
+<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
+<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.ica.org/standards/RiC/ontology#Date> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/2000/01/rdf-schema#label> "1924" .

--- a/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_plugin.nt
+++ b/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_plugin.nt
@@ -1,5 +1,5 @@
-<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
-<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
+<ontology://generated-from-draw-io/2025-10-20T16-30-40> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
+<ontology://generated-from-draw-io/2025-10-20T16-30-40> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.ica.org/standards/RiC/ontology#Date> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/2000/01/rdf-schema#label> "1924" .

--- a/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_plugin.nt
+++ b/src/main/webapp/plugins/rdfexport/debug/results/aa37-department-of-health/ts_plugin.nt
@@ -1,5 +1,5 @@
-<ontology://generated-from-draw-io/2025-10-20T16-06-46> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
-<ontology://generated-from-draw-io/2025-10-20T16-06-46> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
+<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .
+<ontology://generated-from-draw-io/2025-10-20T20-22-43> <http://www.w3.org/2002/07/owl#imports> <https://www.ica.org/standards/RiC/ontology#> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#NamedIndividual> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.ica.org/standards/RiC/ontology#Date> .
 <ontology://generated-from-draw-io/mock#1924> <http://www.w3.org/2000/01/rdf-schema#label> "1924" .

--- a/src/main/webapp/plugins/rdfexport/debug/scenarios/aa37-department-of-health.yml
+++ b/src/main/webapp/plugins/rdfexport/debug/scenarios/aa37-department-of-health.yml
@@ -1,7 +1,5 @@
 slug: aa37-department-of-health
-drawio:
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37
-  Department of Health.drawio
+drawio: "tests/fixtures/AA37 Department of Health.drawio"
 csv_path: /mock/path/to/file.csv
 base_uri: ontology://generated-from-draw-io/mock#
 prefixes:

--- a/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251020T202559Z.md
+++ b/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251020T202559Z.md
@@ -1,0 +1,25 @@
+# Debug Session Report — DrawIO RDF Export Debugger
+
+## Summary
+- Investigated `python -m debug --scenario aa37-department-of-health` failing to classify DrawIO cells as individuals.
+- Identified missing prefix expansion in the debugger's cell classification helper which caused all CURIE tokens to be rejected.
+- Updated `_extract_cell_classifications` to reuse `legacy.draw_io_parser` metadata utilities so the classifier sees the full prefix map (built-ins + diagram metadata + CLI overrides).
+- Normalised the aa37 scenario YAML to reference the repository fixture path so it works cross-platform.
+
+## Investigation Notes
+1. Reproduced the issue via `python -m debug --drawio "tests/fixtures/AA37 Department of Health.drawio" --slug aa37-department-of-health` after bootstrapping dependencies with `bun install --force`, `bun run setup:uv`, and `bun run setup:pyodide`.
+2. Observed the debugger reporting 83 cell classifications, but only `LITERAL`/`ARROW_LABEL` kinds appeared in `debug/map.json`.
+3. Confirmed that `DrawIOCellClassifier` requires known CURIE prefixes to emit `TYPED_INDIVIDUAL`/`STANDALONE_INDIVIDUAL`, yet the debugger only forwarded ad-hoc CLI prefixes (`mock1`) instead of the parser defaults.
+4. Verified the DrawIO parser's `_extract_drawio_metadata` and `get_prefixes` helpers merge built-in RiC-O prefixes with metadata-defined ones before parsing.
+
+## Fix Implementation
+- Hooked `_extract_cell_classifications` into `_extract_drawio_metadata` to reuse the parser's XML root and metadata prefixes.
+- Seeded the prefix map with `get_prefixes()` and layered metadata + CLI overrides to mimic the runtime pipeline.
+- Removed the redundant local `ElementTree` import once metadata parsing moved to the parser helper.
+- Updated `debug/scenarios/aa37-department-of-health.yml` to quote the fixture path and keep it relative to the repo.
+
+## Verification
+- `CI=1 PRETTIER_LOG_LEVEL=error bun run check`
+- `CI=1 bun run test:log:linux`
+- Manual inspection of `debug/map.json` confirmed 17 `TYPED_INDIVIDUAL` entries and preserved literal counts for the aa37 scenario.
+

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,4 +1,4 @@
-Script started on 2025-10-20 19:05:34+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
+Script started on 2025-10-20 20:24:48+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 [0m[2m[35m$[0m [2m[1mpython -m meta_builder -o legacy/draw_io_parser.py && bun run lint:fix:py && bun run format:py[0m
 [metabuilder] Wrote legacy/draw_io_parser.py ( overrides on; replacements=8 [NodeHTMLParser, _build_graph_from_raw_xml, _cell_is_literal, _ensure_known_curie, _extract_individual_and_arrow_and_literal_cells, _split_curie, individual_blocks, serialise_to_graph] additions=3 [CellClassification, CellKind, DrawIOCellClassifier] )
@@ -57,160 +57,450 @@ platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/drawi
 cachedir: .pytest_cache
 rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 39 items                                                                                                             [0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m   [  5%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[32m      [ 17%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[32m      [ 84%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [32mPASSED[0m[32m        [ 87%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [32mPASSED[0m[32m      [ 89%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m     [ 94%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m       [ 97%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m         [100%][0m
-[32m====================================================== [32m[1m39 passed[0m[32m in 8.52s[0m[32m ======================================================[0m
-[1m===================================================== test session starts ======================================================[0m
-platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
-rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
-[1mcollecting ... [0m[1mcollected 59 items                                                                                                             [0m
-legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                             [ 11%][0m
-legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[32m                                                                                 [ 16%][0m
-legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                              [ 83%][0m
-legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                               [ 89%][0m
-meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                    [100%][0m
-[32m===================================================== [32m[1m59 passed[0m[32m in 11.28s[0m[32m ======================================================[0m
-[0m[1mbun test [0m[2mv1.2.14 (6a363a38)[0m
-[PIPELINE] Initializing Pyodide runtime from /workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[0m[33m9269.56ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[[1m15.21ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m228.75ms[0m[2m][0m
-[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  2%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[32m [  7%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[dangling_curie] [32mPASSED[0m[32m [ 10%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[colon_only] [32mPASSED[0m[32m [ 12%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[no_prefix] [32mPASSED[0m[32m [ 15%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [ 20%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 23%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[32m [ 25%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[32m [ 28%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[32m [ 30%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[32m [ 33%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[32m [ 35%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[32m [ 38%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[32m [ 41%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[32m [ 43%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[32m [ 46%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[32m [ 48%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[32m [ 51%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[32m [ 53%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[32m [ 56%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[32m [ 58%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[32m [ 61%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[32m [ 64%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[32m [ 66%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[32m [ 69%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[32m [ 71%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[32m [ 74%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 76%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 79%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[32m [ 82%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 92%][0m
+
+[32m====================================================== [32m[1m39 passed[0m[32m in 6.12s[0m[32m ======================================================[0m
+configfile: pyproject.toml
+
+
+[32m====================================================== [32m[1m59 passed[0m[32m in 8.06s[0m[32m ======================================================[0m
+[0m
+tests/rdfexport.test.ts:
+[BLACKBOX] Received serialized payload (36445 characters)
+[PIPELINE] Pyodide runtime ready
+[PIPELINE] Preparing Pyodide Python environment
+[PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
+[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/__init__.py
+[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/drawio_pipeline.py
+[PIPELINE] Syncing Python wheel to virtual FS: /app/wheels/rdflib-7.2.1-py3-none-any.whl
+[PIPELINE] Pyodide Python environment ready
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
+[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
+[BLACKBOX] Black box processing completed
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m5707.88ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[7.80ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m165.09ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (44795 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
+[PIPELINE] DrawIO parser produced graph graph-1 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (5458 characters)
+[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
+[PIPELINE] DrawIO parser produced graph graph-2 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (5458 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
+[PIPELINE] DrawIO parser produced graph graph-3 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5524 characters)
+[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m772.09ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (37618 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
+[PIPELINE] DrawIO parser produced graph graph-4 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (4345 characters)
+[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-5 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (4345 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
+[PIPELINE] DrawIO parser produced graph graph-6 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (4411 characters)
+[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m358.37ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (58348 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
+[PIPELINE] DrawIO parser produced graph graph-7 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (9207 characters)
+[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
+[PIPELINE] DrawIO parser produced graph graph-8 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (9207 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
+[PIPELINE] DrawIO parser produced graph graph-9 with 104 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 104 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (9273 characters)
+[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m469.21ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (32209 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (32209 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32209)
+[PIPELINE] DrawIO parser produced graph graph-10 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (3931 characters)
+[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
+[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
+[PIPELINE] DrawIO parser produced graph graph-11 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (3931 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (32227 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (32227 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32227)
+[PIPELINE] DrawIO parser produced graph graph-12 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (3997 characters)
+[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
+[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m266.29ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (44261 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
+[PIPELINE] DrawIO parser produced graph graph-13 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (5497 characters)
+[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
+[PIPELINE] DrawIO parser produced graph graph-14 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (5497 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
+[PIPELINE] DrawIO parser produced graph graph-15 with 94 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 94 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (5563 characters)
+[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m340.12ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] DrawIO parser produced graph graph-16 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (4590 characters)
+[PIPELINE] DrawIO parser produced graph graph-17 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (4590 characters)
+[PIPELINE] DrawIO parser produced graph graph-18 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (4656 characters)
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m297.10ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (23546 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
+[PIPELINE] DrawIO parser produced graph graph-19 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (3738 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-20 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (3738 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
+[PIPELINE] DrawIO parser produced graph graph-21 with 51 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 51 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (3804 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m203.79ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (61829 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
+[PIPELINE] DrawIO parser produced graph graph-22 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (7040 characters)
+[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
+[PIPELINE] DrawIO parser produced graph graph-23 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (7040 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
+[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
+[PIPELINE] DrawIO parser produced graph graph-24 with 127 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 127 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (7106 characters)
+[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m548.80ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] DrawIO parser produced graph graph-25 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (4369 characters)
+[PIPELINE] DrawIO parser produced graph graph-26 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (4369 characters)
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] DrawIO parser produced graph graph-27 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (4435 characters)
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m267.03ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (23410 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
+[PIPELINE] DrawIO parser produced graph graph-28 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (3002 characters)
+[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
+[PIPELINE] DrawIO parser produced graph graph-29 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (3002 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
+[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
+[PIPELINE] DrawIO parser produced graph graph-30 with 54 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 54 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (3068 characters)
+[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m224.71ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m366.22ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (48162 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (48162 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 48162)
-[PIPELINE] DrawIO parser produced graph graph-1 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (5721 characters)
+[PIPELINE] DrawIO parser produced graph graph-34 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (5721 characters)
 [PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
 [PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-2 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (5721 characters)
+[PIPELINE] DrawIO parser produced graph graph-35 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (5721 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (48180 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (48180 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 48180)
-[PIPELINE] DrawIO parser produced graph graph-3 with 89 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 89 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (5787 characters)
+[PIPELINE] DrawIO parser produced graph graph-36 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (5787 characters)
 [PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
 [PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m1050.46ms[0m[2m][0m
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39399 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
-[PIPELINE] DrawIO parser produced graph graph-4 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-5 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m340.93ms[0m[2m][0m
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
-[PIPELINE] DrawIO parser produced graph graph-6 with 78 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 78 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (4656 characters)
-[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m584.94ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m287.63ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] DrawIO parser produced graph graph-7 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (3738 characters)
-[PIPELINE] DrawIO parser produced graph graph-8 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (3738 characters)
-[PIPELINE] DrawIO parser produced graph graph-9 with 51 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 51 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (3804 characters)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m379.39ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (40866 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (40866 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40866)
-[PIPELINE] DrawIO parser produced graph graph-10 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (5715 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-11 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (5715 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[PIPELINE] Generated DrawIO XML payload (40884 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (40884 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40884)
-[PIPELINE] DrawIO parser produced graph graph-12 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (5781 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1 (VDB test).rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m609.20ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (39329 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
+[PIPELINE] DrawIO parser produced graph graph-40 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (5053 characters)
+[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-41 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (5053 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
+[PIPELINE] DrawIO parser produced graph graph-42 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (5119 characters)
+[PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m278.04ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (80881 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
-[PIPELINE] DrawIO parser produced graph graph-13 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-43 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (11220 characters)
 [PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
 [BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-14 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-44 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-44 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-44 (11220 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
-[PIPELINE] DrawIO parser produced graph graph-15 with 173 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 173 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (11286 characters)
+[PIPELINE] DrawIO parser produced graph graph-45 with 173 triples
+[BLACKBOX] Parsed DrawIO graph graph-45 with 173 triples
+[BLACKBOX] Returning Turtle payload for graph graph-45 (11286 characters)
 [PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m1258.02ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m643.35ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m612.90ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m325.62ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (34895 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
+[PIPELINE] DrawIO parser produced graph graph-52 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-52 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-52 (5761 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-53 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-53 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-53 (5761 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
+[PIPELINE] DrawIO parser produced graph graph-54 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-54 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-54 (5827 characters)
+[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m260.14ms[0m[2m][0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (95213 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
-[PIPELINE] DrawIO parser produced graph graph-16 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (9826 characters)
+[PIPELINE] DrawIO parser produced graph graph-55 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-55 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-55 (9826 characters)
 [PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
 [PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-17 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (9826 characters)
+[PIPELINE] DrawIO parser produced graph graph-56 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-56 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-56 (9826 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
@@ -219,352 +509,62 @@ meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[3
 [PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
-[PIPELINE] DrawIO parser produced graph graph-18 with 144 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 144 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (9892 characters)
+[PIPELINE] DrawIO parser produced graph graph-57 with 144 triples
+[BLACKBOX] Parsed DrawIO graph graph-57 with 144 triples
+[BLACKBOX] Returning Turtle payload for graph graph-57 (9892 characters)
 [PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
 [PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m1299.67ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m555.78ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (37299 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37299 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37299)
-[PIPELINE] DrawIO parser produced graph graph-22 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (4369 characters)
-[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
-[PIPELINE] DrawIO parser produced graph graph-23 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (4369 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (37317 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (37317 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37317)
-[PIPELINE] DrawIO parser produced graph graph-24 with 76 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 76 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (4435 characters)
-[PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
-[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m487.88ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (61829 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
-[PIPELINE] DrawIO parser produced graph graph-25 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (7040 characters)
-[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-26 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (7040 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
-[PIPELINE] DrawIO parser produced graph graph-27 with 127 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 127 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (7106 characters)
-[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m838.10ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (34895 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
-[PIPELINE] DrawIO parser produced graph graph-28 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-28 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-28 (5761 characters)
-[PIPELINE] Saving export payload to AA37 Department of Health.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-29 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-29 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-29 (5761 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
-[PIPELINE] DrawIO parser produced graph graph-30 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-30 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-30 (5827 characters)
-[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m466.07ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (49944 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (49944 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49944)
-[PIPELINE] DrawIO parser produced graph graph-31 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-31 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-31 (6443 characters)
-[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-32 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-32 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-32 (6443 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (49962 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (49962 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49962)
-[PIPELINE] DrawIO parser produced graph graph-33 with 99 triples
-[BLACKBOX] Parsed DrawIO graph graph-33 with 99 triples
-[BLACKBOX] Returning Turtle payload for graph graph-33 (6509 characters)
-[PIPELINE] Saving RML export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m676.92ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] DrawIO parser produced graph graph-34 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (4345 characters)
-[PIPELINE] DrawIO parser produced graph graph-35 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (4345 characters)
-[PIPELINE] DrawIO parser produced graph graph-36 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (4411 characters)
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m503.23ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[PIPELINE] Generated DrawIO XML payload (42022 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (42022 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42022)
-[PIPELINE] DrawIO parser produced graph graph-37 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-37 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-37 (6307 characters)
-[PIPELINE] Saving export payload to F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
-[PIPELINE] DrawIO parser produced graph graph-38 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-38 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-38 (6307 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
-[PIPELINE] Generated DrawIO XML payload (42040 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (42040 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42040)
-[PIPELINE] DrawIO parser produced graph graph-39 with 76 triples
-[BLACKBOX] Parsed DrawIO graph graph-39 with 76 triples
-[BLACKBOX] Returning Turtle payload for graph graph-39 (6373 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m543.55ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
-[PIPELINE] DrawIO parser produced graph graph-40 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-40 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-40 (9207 characters)
-[PIPELINE] DrawIO parser produced graph graph-41 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-41 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-41 (9207 characters)
-[PIPELINE] DrawIO parser produced graph graph-42 with 104 triples
-[BLACKBOX] Parsed DrawIO graph graph-42 with 104 triples
-[BLACKBOX] Returning Turtle payload for graph graph-42 (9273 characters)
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m709.87ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (44261 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
-[PIPELINE] DrawIO parser produced graph graph-43 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-43 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-43 (5497 characters)
-[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-44 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-44 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-44 (5497 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
-[PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
-[PIPELINE] DrawIO parser produced graph graph-45 with 94 triples
-[BLACKBOX] Parsed DrawIO graph graph-45 with 94 triples
-[BLACKBOX] Returning Turtle payload for graph graph-45 (5563 characters)
-[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m590.15ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m691.95ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-58 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-58 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-58 (4952 characters)
+[PIPELINE] DrawIO parser produced graph graph-59 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-59 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-59 (4952 characters)
+[PIPELINE] DrawIO parser produced graph graph-60 with 65 triples
+[BLACKBOX] Parsed DrawIO graph graph-60 with 65 triples
+[BLACKBOX] Returning Turtle payload for graph graph-60 (5018 characters)
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m251.67ms[0m[2m][0m
 [0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[PIPELINE] Generated DrawIO XML payload (73837 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
-[PIPELINE] DrawIO parser produced graph graph-46 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-46 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-46 (9086 characters)
-[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-47 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-47 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-47 (9086 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[PIPELINE] Generated DrawIO XML payload (73855 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (73855 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73855)
-[PIPELINE] DrawIO parser produced graph graph-48 with 137 triples
-[BLACKBOX] Parsed DrawIO graph graph-48 with 137 triples
-[BLACKBOX] Returning Turtle payload for graph graph-48 (9152 characters)
-[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m811.31ms[0m[2m][0m
 [PIPELINE] Generated DrawIO XML payload (54132 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
-[PIPELINE] DrawIO parser produced graph graph-49 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-49 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-49 (6195 characters)
+[PIPELINE] DrawIO parser produced graph graph-61 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-61 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-61 (6195 characters)
 [PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
 [PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-50 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-50 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-50 (6195 characters)
+[PIPELINE] DrawIO parser produced graph graph-62 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-62 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-62 (6195 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
-[PIPELINE] DrawIO parser produced graph graph-51 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-51 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-51 (6261 characters)
+[PIPELINE] DrawIO parser produced graph graph-63 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-63 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-63 (6261 characters)
 [PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
 [PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m541.09ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m405.23ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
 [0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44795 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
-[PIPELINE] DrawIO parser produced graph graph-52 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-52 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-52 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-53 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-53 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-53 (5458 characters)
-[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
-[PIPELINE] DrawIO parser produced graph graph-54 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-54 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-54 (5524 characters)
-[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m464.75ms[0m[2m][0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m359.94ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (23410 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
-[PIPELINE] DrawIO parser produced graph graph-58 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-58 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-58 (3002 characters)
-[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-59 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-59 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-59 (3002 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
-[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
-[PIPELINE] DrawIO parser produced graph graph-60 with 54 triples
-[BLACKBOX] Parsed DrawIO graph graph-60 with 54 triples
-[BLACKBOX] Returning Turtle payload for graph graph-60 (3068 characters)
-[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m283.15ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (32209 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (32209 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32209)
-[PIPELINE] DrawIO parser produced graph graph-61 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-61 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-61 (3931 characters)
-[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-62 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-62 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-62 (3931 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
-[PIPELINE] Generated DrawIO XML payload (32227 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (32227 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32227)
-[PIPELINE] DrawIO parser produced graph graph-63 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-63 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-63 (3997 characters)
-[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m359.38ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m82.68ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m176.10ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m87.00ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m89.20ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m20.54ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m61.50ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m109.93ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m51.99ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m57.37ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m14.08ms[0m[2m][0m
 [0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
 [0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
 [0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
  693 expect() calls
-Ran 37 tests across 1 files. [0m[2m[[1m23.61s[0m[2m][0m
-Script done on 2025-10-20 19:06:21+00:00 [COMMAND_EXIT_CODE="0"]
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (49944 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (49944 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49944)
-[PIPELINE] DrawIO parser produced graph graph-43 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-43 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-43 (6443 characters)
-[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-44 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-44 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-44 (6443 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
+Ran 37 tests across 1 files. [0m[2m[[1m14.57s[0m[2m][0m
+Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (49962 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (49962 characters)

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,8 +1,9 @@
-Script started on 2025-10-20 20:24:48+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
+Script started on Mon Oct 20 16:32:32 2025
+Command: bun run test
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 [0m[2m[35m$[0m [2m[1mpython -m meta_builder -o legacy/draw_io_parser.py && bun run lint:fix:py && bun run format:py[0m
 [metabuilder] Wrote legacy/draw_io_parser.py ( overrides on; replacements=8 [NodeHTMLParser, _build_graph_from_raw_xml, _cell_is_literal, _ensure_known_curie, _extract_individual_and_arrow_and_literal_cells, _split_curie, individual_blocks, serialise_to_graph] additions=3 [CellClassification, CellKind, DrawIOCellClassifier] )
-[metabuilder] Loaded override modules from /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
+[metabuilder] Loaded override modules from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
 [0m[2m[35m$[0m [2m[1mruff check --fix .[0m
 Found 15 errors (15 fixed, 0 remaining).
 [0m[2m[35m$[0m [2m[1mruff format .[0m
@@ -52,17 +53,20 @@ Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
      An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
 
 🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
-[1m===================================================== test session starts ======================================================[0m
-platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
+[1m============================================== test session starts ===============================================[0m
+platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0 -- /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
 cachedir: .pytest_cache
-rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
+rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
+[1mcollecting ... [0m[1mcollected 39 items                                                                                               [0m
 
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  2%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m [  5%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[32m [  7%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[dangling_curie] [32mPASSED[0m[32m [ 10%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[colon_only] [32mPASSED[0m[32m [ 12%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[no_prefix] [32mPASSED[0m[32m [ 15%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[32m [ 17%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [ 20%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 23%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[32m [ 25%][0m
@@ -88,16 +92,33 @@ webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 76%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 79%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[32m [ 82%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[32m [ 84%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [32mPASSED[0m[32m [ 87%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [32mPASSED[0m[32m [ 89%][0m
 webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 92%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m [ 94%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m [ 97%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m [100%][0m
 
-[32m====================================================== [32m[1m39 passed[0m[32m in 6.12s[0m[32m ======================================================[0m
+[32m=============================================== [32m[1m39 passed[0m[32m in 1.58s[0m[32m ===============================================[0m
+[1m============================================== test session starts ===============================================[0m
+platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0
+rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
+[1mcollecting ... [0m[1mcollected 59 items                                                                                               [0m
 
+legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                               [ 11%][0m
+legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[32m                                                                   [ 16%][0m
+legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                [ 83%][0m
+legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                 [ 89%][0m
+meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                      [100%][0m
 
-[32m====================================================== [32m[1m59 passed[0m[32m in 8.06s[0m[32m ======================================================[0m
+[32m=============================================== [32m[1m59 passed[0m[32m in 2.08s[0m[32m ===============================================[0m
+[0m[1mbun test [0m[2mv1.2.21 (7c45ed97)[0m
 [0m
 tests/rdfexport.test.ts:
 [BLACKBOX] Received serialized payload (36445 characters)
+[PIPELINE] Initializing Pyodide runtime from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
 [PIPELINE] Pyodide runtime ready
 [PIPELINE] Preparing Pyodide Python environment
 [PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
@@ -109,141 +130,55 @@ tests/rdfexport.test.ts:
 [PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
 [BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
 [BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m5707.88ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[7.80ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m165.09ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m1383.72ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[0.59ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m25.50ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44795 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
-[PIPELINE] DrawIO parser produced graph graph-1 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-2 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (5458 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
+[PIPELINE] Generated DrawIO XML payload (61829 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
+[PIPELINE] DrawIO parser produced graph graph-1 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (7040 characters)
+[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
+[PIPELINE] DrawIO parser produced graph graph-2 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (7040 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
-[PIPELINE] DrawIO parser produced graph graph-3 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (5524 characters)
-[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m772.09ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37618 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
-[PIPELINE] DrawIO parser produced graph graph-4 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (4345 characters)
-[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-5 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (4345 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
-[PIPELINE] DrawIO parser produced graph graph-6 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (4411 characters)
-[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m358.37ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (58348 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
-[PIPELINE] DrawIO parser produced graph graph-7 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (9207 characters)
-[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-8 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (9207 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
-[PIPELINE] DrawIO parser produced graph graph-9 with 104 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 104 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (9273 characters)
-[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m469.21ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (32209 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (32209 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32209)
-[PIPELINE] DrawIO parser produced graph graph-10 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (3931 characters)
-[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-11 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (3931 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (32227 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (32227 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32227)
-[PIPELINE] DrawIO parser produced graph graph-12 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (3997 characters)
-[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m266.29ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
+[PIPELINE] DrawIO parser produced graph graph-3 with 127 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 127 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (7106 characters)
+[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m231.28ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (44261 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
-[PIPELINE] DrawIO parser produced graph graph-13 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (5497 characters)
+[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
 [PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
 [PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-14 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (5497 characters)
+[PIPELINE] DrawIO parser produced graph graph-5 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (5497 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
@@ -252,36 +187,56 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
-[PIPELINE] DrawIO parser produced graph graph-15 with 94 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 94 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (5563 characters)
+[PIPELINE] DrawIO parser produced graph graph-6 with 94 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 94 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (5563 characters)
 [PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
 [PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m340.12ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m122.39ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] DrawIO parser produced graph graph-16 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (4590 characters)
-[PIPELINE] DrawIO parser produced graph graph-17 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (4590 characters)
-[PIPELINE] DrawIO parser produced graph graph-18 with 78 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 78 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (4656 characters)
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m297.10ms[0m[2m][0m
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (23410 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
+[PIPELINE] DrawIO parser produced graph graph-7 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (3002 characters)
+[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
+[PIPELINE] DrawIO parser produced graph graph-8 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (3002 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
+[PIPELINE] DrawIO parser produced graph graph-9 with 54 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 54 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (3068 characters)
+[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m69.73ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (23546 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
-[PIPELINE] DrawIO parser produced graph graph-19 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (3738 characters)
+[PIPELINE] DrawIO parser produced graph graph-10 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (3738 characters)
 [PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
 [PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-20 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (3738 characters)
+[PIPELINE] DrawIO parser produced graph graph-11 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (3738 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
@@ -290,124 +245,86 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
-[PIPELINE] DrawIO parser produced graph graph-21 with 51 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 51 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (3804 characters)
+[PIPELINE] DrawIO parser produced graph graph-12 with 51 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 51 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (3804 characters)
 [PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m203.79ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (61829 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
-[PIPELINE] DrawIO parser produced graph graph-22 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (7040 characters)
-[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-23 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (7040 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
-[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
-[PIPELINE] DrawIO parser produced graph graph-24 with 127 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 127 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (7106 characters)
-[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m548.80ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m69.82ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] DrawIO parser produced graph graph-25 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (4369 characters)
-[PIPELINE] DrawIO parser produced graph graph-26 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (4369 characters)
+[PIPELINE] Generated DrawIO XML payload (39399 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
+[PIPELINE] DrawIO parser produced graph graph-13 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (4590 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-14 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (4590 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] DrawIO parser produced graph graph-27 with 76 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 76 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (4435 characters)
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m267.03ms[0m[2m][0m
-[PIPELINE] Generated DrawIO XML payload (23410 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
-[PIPELINE] DrawIO parser produced graph graph-28 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-28 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-28 (3002 characters)
-[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-29 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-29 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-29 (3002 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
-[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
-[PIPELINE] DrawIO parser produced graph graph-30 with 54 triples
-[BLACKBOX] Parsed DrawIO graph graph-30 with 54 triples
-[BLACKBOX] Returning Turtle payload for graph graph-30 (3068 characters)
-[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m224.71ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m366.22ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
+[PIPELINE] DrawIO parser produced graph graph-15 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (4656 characters)
+[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m103.39ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (48162 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (48162 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48162)
-[PIPELINE] DrawIO parser produced graph graph-34 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (5721 characters)
-[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
-[PIPELINE] DrawIO parser produced graph graph-35 with 88 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 88 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (5721 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
+[PIPELINE] Generated DrawIO XML payload (44795 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
+[PIPELINE] DrawIO parser produced graph graph-16 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (5458 characters)
+[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
+[PIPELINE] DrawIO parser produced graph graph-17 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (5458 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (48180 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (48180 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48180)
-[PIPELINE] DrawIO parser produced graph graph-36 with 89 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 89 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (5787 characters)
-[PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m340.93ms[0m[2m][0m
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m287.63ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
+[PIPELINE] DrawIO parser produced graph graph-18 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (5524 characters)
+[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m116.96ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (39329 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
-[PIPELINE] DrawIO parser produced graph graph-40 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-40 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-40 (5053 characters)
+[PIPELINE] DrawIO parser produced graph graph-19 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (5053 characters)
 [PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
 [PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-41 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-41 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-41 (5053 characters)
+[PIPELINE] DrawIO parser produced graph graph-20 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (5053 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
@@ -416,27 +333,60 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
-[PIPELINE] DrawIO parser produced graph graph-42 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-42 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-42 (5119 characters)
+[PIPELINE] DrawIO parser produced graph graph-21 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (5119 characters)
 [PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m278.04ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m103.64ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (73837 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
+[PIPELINE] DrawIO parser produced graph graph-22 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (9086 characters)
+[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-23 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (9086 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (73855 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (73855 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73855)
+[PIPELINE] DrawIO parser produced graph graph-24 with 137 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 137 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (9152 characters)
+[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m205.92ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (80881 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
-[PIPELINE] DrawIO parser produced graph graph-43 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-43 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-43 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-25 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (11220 characters)
 [PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
 [BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-44 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-44 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-44 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-26 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (11220 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
@@ -445,62 +395,56 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
-[PIPELINE] DrawIO parser produced graph graph-45 with 173 triples
-[BLACKBOX] Parsed DrawIO graph graph-45 with 173 triples
-[BLACKBOX] Returning Turtle payload for graph graph-45 (11286 characters)
+[PIPELINE] DrawIO parser produced graph graph-27 with 173 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 173 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (11286 characters)
 [PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m643.35ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m238.06ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (37618 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
+[PIPELINE] DrawIO parser produced graph graph-28 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (4345 characters)
+[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-29 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (4345 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m612.90ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m325.62ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
-[PIPELINE] Generated DrawIO XML payload (34895 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
-[PIPELINE] DrawIO parser produced graph graph-52 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-52 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-52 (5761 characters)
-[PIPELINE] Saving export payload to AA37 Department of Health.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-53 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-53 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-53 (5761 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
-[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
-[PIPELINE] DrawIO parser produced graph graph-54 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-54 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-54 (5827 characters)
-[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m260.14ms[0m[2m][0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
+[PIPELINE] DrawIO parser produced graph graph-30 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (4411 characters)
+[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m97.61ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (95213 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
-[PIPELINE] DrawIO parser produced graph graph-55 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-55 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-55 (9826 characters)
+[PIPELINE] DrawIO parser produced graph graph-31 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (9826 characters)
 [PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
 [PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-56 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-56 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-56 (9826 characters)
+[PIPELINE] DrawIO parser produced graph graph-32 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (9826 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
@@ -509,62 +453,118 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
-[PIPELINE] DrawIO parser produced graph graph-57 with 144 triples
-[BLACKBOX] Parsed DrawIO graph graph-57 with 144 triples
-[BLACKBOX] Returning Turtle payload for graph graph-57 (9892 characters)
+[PIPELINE] DrawIO parser produced graph graph-33 with 144 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 144 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (9892 characters)
 [PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
 [PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m691.95ms[0m[2m][0m
-[PIPELINE] DrawIO parser produced graph graph-58 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-58 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-58 (4952 characters)
-[PIPELINE] DrawIO parser produced graph graph-59 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-59 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-59 (4952 characters)
-[PIPELINE] DrawIO parser produced graph graph-60 with 65 triples
-[BLACKBOX] Parsed DrawIO graph graph-60 with 65 triples
-[BLACKBOX] Returning Turtle payload for graph graph-60 (5018 characters)
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m251.67ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m240.21ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (54132 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
-[PIPELINE] DrawIO parser produced graph graph-61 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-61 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-61 (6195 characters)
+[PIPELINE] DrawIO parser produced graph graph-34 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (6195 characters)
 [PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
 [PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-62 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-62 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-62 (6195 characters)
+[PIPELINE] DrawIO parser produced graph graph-35 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (6195 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
-[PIPELINE] DrawIO parser produced graph graph-63 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-63 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-63 (6261 characters)
+[PIPELINE] DrawIO parser produced graph graph-36 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (6261 characters)
 [PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
 [PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m405.23ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
-[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m61.50ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m109.93ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m51.99ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m57.37ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m14.08ms[0m[2m][0m
-[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
- 693 expect() calls
-Ran 37 tests across 1 files. [0m[2m[[1m14.57s[0m[2m][0m
-Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m131.64ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (58348 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
+[PIPELINE] DrawIO parser produced graph graph-37 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (9207 characters)
+[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
+[PIPELINE] DrawIO parser produced graph graph-38 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (9207 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
+[PIPELINE] DrawIO parser produced graph graph-39 with 104 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 104 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (9273 characters)
+[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m140.12ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (34895 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
+[PIPELINE] DrawIO parser produced graph graph-40 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (5761 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-41 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (5761 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
+[PIPELINE] DrawIO parser produced graph graph-42 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (5827 characters)
+[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m89.38ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (49944 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (49944 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49944)
+[PIPELINE] DrawIO parser produced graph graph-43 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (6443 characters)
+[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
+[PIPELINE] DrawIO parser produced graph graph-44 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-44 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-44 (6443 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (49962 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (49962 characters)
@@ -574,7 +574,7 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-45 (6509 characters)
 [PIPELINE] Saving RML export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m168.94ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m148.81ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (32209 characters)
@@ -603,7 +603,7 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-48 (3997 characters)
 [PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
 [PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m95.52ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m84.48ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (40866 characters)
@@ -632,7 +632,7 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-51 (5781 characters)
 [PIPELINE] Saving RML export payload to F 47-11-1-0-1 (VDB test).rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m129.75ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m110.28ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (48162 characters)
@@ -661,7 +661,7 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-54 (5787 characters)
 [PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
 [PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m137.27ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m121.32ms[0m[2m][0m
 [0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
@@ -691,7 +691,7 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-57 (5018 characters)
 [PIPELINE] Saving RML export payload to BA619 Walkerton Inquiry.rml.ttl
 [PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m98.88ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m80.93ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (37299 characters)
@@ -720,7 +720,7 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-60 (4435 characters)
 [PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
 [PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m103.58ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m94.76ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (42022 characters)
@@ -749,13 +749,13 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-63 (6373 characters)
 [PIPELINE] Saving RML export payload to F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m108.91ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m100.18ms[0m[2m][0m
 [BLACKBOX] Generating Turtle payload for serialized input (36617 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 36617)
 [PIPELINE] DrawIO parser produced graph graph-64 with 73 triples
 [BLACKBOX] Parsed DrawIO graph graph-64 with 73 triples
 [BLACKBOX] Returning Turtle payload for graph graph-64 (5812 characters)
-[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m23.60ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m22.29ms[0m[2m][0m
 [BLACKBOX] Generating Turtle payload for serialized input (36617 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 36617)
 [PIPELINE] DrawIO parser produced graph graph-65 with 73 triples
@@ -766,13 +766,13 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [PIPELINE] DrawIO parser produced graph graph-66 with 73 triples
 [BLACKBOX] Parsed DrawIO graph graph-66 with 73 triples
 [BLACKBOX] Returning Turtle payload for graph graph-66 (6144 characters)
-[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m46.53ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m43.61ms[0m[2m][0m
 [BLACKBOX] Received serialized payload (36445 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
 [PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
 [BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
 [BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m22.14ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m20.81ms[0m[2m][0m
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (36445 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (36445 characters)
@@ -782,8 +782,8 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-67 (5046 characters)
 [PIPELINE] Saving export payload to diagram.ttl
 [PIPELINE] Export pipeline completed for diagram.ttl
-[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m24.11ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[5.73ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m21.92ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[3.97ms[0m[2m][0m
 
 [0m[2m8 tests skipped:[0m
 [0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
@@ -799,7 +799,7 @@ Script done on 2025-10-20 20:25:20+00:00 [COMMAND_EXIT_CODE="0"]
  [0m[33m8 skip[0m
 [0m[2m 0 fail[0m
  695 expect() calls
-Ran 37 tests across 1 file. [0m[2m[[1m4.86s[0m[2m][0m
+Ran 37 tests across 1 file. [0m[2m[[1m4.25s[0m[2m][0m
 
 Command exit status: 0
-Script done on Mon Oct 20 14:53:44 2025
+Script done on Mon Oct 20 16:32:41 2025


### PR DESCRIPTION
## Summary
- reuse the draw.io parser metadata helpers so the debugger seeds the classifier with built-in and diagram prefixes
- make the aa37 Department of Health scenario point at the repository fixture instead of a host-specific path
- add an investigation report under docs/aicode per contributor guidance

## Testing
- CI=1 PRETTIER_LOG_LEVEL=error bun run check
- CI=1 bun run test:log:linux


------
https://chatgpt.com/codex/tasks/task_e_68f698fc7d08832da1598a3a5621d374