### PR TITLE
Fix debugger cell classification for typed parents and decorations

### DIFF
--- a/src/main/webapp/plugins/rdfexport/debug/__main__.py
+++ b/src/main/webapp/plugins/rdfexport/debug/__main__.py
@@ -275,7 +275,7 @@ class Debugger:
         # Extract cell classifications before generating graphs - always try to get them
         try:
             cell_classifications = self._extract_cell_classifications(
-                patched_xml, config
+                original_xml, config
             )
         except Exception as e:
             self.console.print(
@@ -732,12 +732,32 @@ class Debugger:
             classifier = classifier_cls(mock_tree, prefixes)
 
             classifications = {}
+            typed_parent_tokens: dict[str, set[str]] = {}
+            typed_parent_children: dict[str, set[str]] = {}
 
             # Get all mxCell and UserObject elements
             try:
                 cells = root.findall(".//mxGraphModel/root//*[@id]")
             except Exception:
                 return {}
+
+            connected_ids: set[str] = set()
+            for cell in cells:
+                cell_id = cell.attrib.get("id")
+                if not cell_id:
+                    continue
+                parent_id = cell.attrib.get("parent")
+                if parent_id and parent_id not in {"0", "1"}:
+                    connected_ids.add(parent_id)
+                    connected_ids.add(cell_id)
+                if cell.attrib.get("edge") == "1":
+                    connected_ids.add(cell_id)
+                    source = cell.attrib.get("source")
+                    target = cell.attrib.get("target")
+                    if source:
+                        connected_ids.add(source)
+                    if target:
+                        connected_ids.add(target)
 
             for cell in cells:
                 # Skip if not mxCell or UserObject
@@ -759,10 +779,16 @@ class Debugger:
                 # Classify the cell
                 try:
                     classification = classifier.classify(cell, value)
-                    classifications[cell_id] = {
-                        "kind": classification.kind.name
+                    parent_cell_id = None
+                    if getattr(classification, "parent_cell", None) is not None:
+                        parent_cell_id = classification.parent_cell.attrib.get("id")
+                    kind_name = (
+                        classification.kind.name
                         if hasattr(classification.kind, "name")
-                        else str(classification.kind),
+                        else str(classification.kind)
+                    )
+                    classifications[cell_id] = {
+                        "kind": kind_name,
                         "raw_value": classification.raw_value,
                         "identifier": classification.identifier,
                         "parent_identifier": classification.parent_identifier,
@@ -770,6 +796,15 @@ class Debugger:
                         if classification.tokens
                         else [],
                     }
+                    if parent_cell_id:
+                        classifications[cell_id]["parent_cell_id"] = parent_cell_id
+                    if kind_name == "TYPED_INDIVIDUAL" and parent_cell_id:
+                        typed_parent_tokens.setdefault(parent_cell_id, set()).update(
+                            classification.tokens or []
+                        )
+                        typed_parent_children.setdefault(parent_cell_id, set()).add(
+                            cell_id
+                        )
                 except Exception as e:
                     classifications[cell_id] = {
                         "kind": "CLASSIFICATION_ERROR",
@@ -777,12 +812,32 @@ class Debugger:
                         "error": str(e),
                     }
 
+            for parent_id, tokens in typed_parent_tokens.items():
+                parent_entry = classifications.get(parent_id)
+                if not parent_entry:
+                    continue
+                if parent_entry.get("kind") == "LITERAL":
+                    parent_entry["kind"] = "STANDALONE_INDIVIDUAL"
+                if not parent_entry.get("identifier"):
+                    parent_entry["identifier"] = parent_entry.get("raw_value")
+                existing_tokens = set(parent_entry.get("tokens") or [])
+                existing_tokens.update(tokens)
+                parent_entry["tokens"] = sorted(existing_tokens)
+                parent_entry["derived_type_cells"] = sorted(
+                    typed_parent_children.get(parent_id, set())
+                )
+
+            for cell_id, entry in classifications.items():
+                if entry.get("kind") == "LITERAL" and cell_id not in connected_ids:
+                    entry["kind"] = "DECORATION"
+
             if classifications:
                 stats = {
                     "LITERAL": 0,
                     "ARROW_LABEL": 0,
                     "TYPED_INDIVIDUAL": 0,
                     "STANDALONE_INDIVIDUAL": 0,
+                    "DECORATION": 0,
                     "CLASSIFICATION_ERROR": 0,
                 }
                 for cell_data in classifications.values():

--- a/src/main/webapp/plugins/rdfexport/debug/map.json
+++ b/src/main/webapp/plugins/rdfexport/debug/map.json
@@ -176,9 +176,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health\u00a0Authority Record",
           "raw_value": "rico:Record",
-          "tokens": [
-            "rico:Record"
-          ]
+          "tokens": ["rico:Record"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-31": {
           "identifier": null,
@@ -220,9 +218,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Authority Record",
           "raw_value": "rico:DocumentaryFormType",
-          "tokens": [
-            "rico:DocumentaryFormType"
-          ]
+          "tokens": ["rico:DocumentaryFormType"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-37": {
           "identifier": null,
@@ -250,9 +246,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Rules for Archival Description",
           "raw_value": "rico:Rule",
-          "tokens": [
-            "rico:Rule"
-          ]
+          "tokens": ["rico:Rule"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-41": {
           "identifier": null,
@@ -280,9 +274,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Authority Record Creation",
           "raw_value": "rico:Activity",
-          "tokens": [
-            "rico:Activity"
-          ]
+          "tokens": ["rico:Activity"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-45": {
           "identifier": null,
@@ -310,9 +302,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "R. Anger",
           "raw_value": "rico:Person",
-          "tokens": [
-            "rico:Person"
-          ]
+          "tokens": ["rico:Person"]
         },
         "I4bDPw6PqqAUihyiD4HI-1": {
           "identifier": null,
@@ -382,9 +372,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-23": {
           "identifier": null,
@@ -398,9 +386,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Provincial Board of Health of Ontario",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "_-RjwaxhbeTWfwVWe4ke-13": {
           "identifier": null,
@@ -456,9 +442,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "AA37",
           "raw_value": "rico:Identifier",
-          "tokens": [
-            "rico:Identifier"
-          ]
+          "tokens": ["rico:Identifier"]
         },
         "gmwnegnUR_CNORKRYM6Y-16": {
           "identifier": null,
@@ -500,9 +484,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Agent Identifier",
           "raw_value": "rico:IdentifierType",
-          "tokens": [
-            "rico:IdentifierType"
-          ]
+          "tokens": ["rico:IdentifierType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-1": {
           "identifier": null,
@@ -530,9 +512,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "1924",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-17": {
           "identifier": null,
@@ -560,18 +540,14 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:AgentName",
-          "tokens": [
-            "rico:AgentName"
-          ]
+          "tokens": ["rico:AgentName"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-20": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "1972",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-3": {
           "identifier": null,
@@ -599,9 +575,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "A Ontario Government Name",
           "raw_value": "rico:CorporateBodyType",
-          "tokens": [
-            "rico:CorporateBodyType"
-          ]
+          "tokens": ["rico:CorporateBodyType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-7": {
           "identifier": null,
@@ -664,9 +638,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Web Ready: Y",
           "raw_value": "rico:RecordState",
-          "tokens": [
-            "rico:RecordState"
-          ]
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-13": {
           "identifier": null,
@@ -680,9 +652,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Status: Approved",
           "raw_value": "rico:RecordState",
-          "tokens": [
-            "rico:RecordState"
-          ]
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-15": {
           "identifier": null,
@@ -717,9 +687,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
           "raw_value": "rico:Mandate",
-          "tokens": [
-            "rico:Mandate"
-          ]
+          "tokens": ["rico:Mandate"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-3": {
           "identifier": null,
@@ -747,9 +715,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Ministry of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-7": {
           "identifier": null,
@@ -804,14 +770,14 @@
       "cell_classifications": {
         "0": {
           "identifier": null,
-          "kind": "LITERAL",
+          "kind": "DECORATION",
           "parent_identifier": null,
           "raw_value": "",
           "tokens": []
         },
         "1": {
           "identifier": null,
-          "kind": "LITERAL",
+          "kind": "DECORATION",
           "parent_identifier": null,
           "raw_value": "",
           "tokens": []
@@ -852,11 +818,12 @@
           "tokens": []
         },
         "EUA9VVVl7iRi0US9AbU_-16": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["EUA9VVVl7iRi0US9AbU_-20"],
+          "identifier": "Vertical Container",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Vertical Container",
-          "tokens": []
+          "tokens": ["lol:index"]
         },
         "EUA9VVVl7iRi0US9AbU_-17": {
           "identifier": null,
@@ -873,43 +840,48 @@
           "tokens": []
         },
         "EUA9VVVl7iRi0US9AbU_-2": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": [
+            "EUA9VVVl7iRi0US9AbU_-3",
+            "EUA9VVVl7iRi0US9AbU_-4",
+            "EUA9VVVl7iRi0US9AbU_-5"
+          ],
+          "identifier": "List pnnpni",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "List pnnpni",
-          "tokens": []
+          "tokens": ["lol:Item%203", "rdf:Item%202", "rico:Item%201"]
         },
         "EUA9VVVl7iRi0US9AbU_-20": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "EUA9VVVl7iRi0US9AbU_-16",
+          "parent_identifier": "Vertical Container",
           "raw_value": "lol:index",
-          "tokens": []
+          "tokens": ["lol:index"]
         },
         "EUA9VVVl7iRi0US9AbU_-3": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "EUA9VVVl7iRi0US9AbU_-2",
           "parent_identifier": "List pnnpni",
           "raw_value": "rico:Item%201",
-          "tokens": [
-            "rico:Item%201"
-          ]
+          "tokens": ["rico:Item%201"]
         },
         "EUA9VVVl7iRi0US9AbU_-4": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "EUA9VVVl7iRi0US9AbU_-2",
           "parent_identifier": "List pnnpni",
           "raw_value": "rdf:Item%202",
-          "tokens": [
-            "rdf:Item%202"
-          ]
+          "tokens": ["rdf:Item%202"]
         },
         "EUA9VVVl7iRi0US9AbU_-5": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "EUA9VVVl7iRi0US9AbU_-2",
+          "parent_identifier": "List pnnpni",
           "raw_value": "lol:Item%203",
-          "tokens": []
+          "tokens": ["lol:Item%203"]
         },
         "EUA9VVVl7iRi0US9AbU_-6": {
           "identifier": null,
@@ -920,38 +892,40 @@
         },
         "EUA9VVVl7iRi0US9AbU_-7": {
           "identifier": null,
-          "kind": "LITERAL",
+          "kind": "DECORATION",
           "parent_identifier": null,
           "raw_value": "hellothere2",
           "tokens": []
         },
         "EUA9VVVl7iRi0US9AbU_-8": {
           "identifier": null,
-          "kind": "LITERAL",
+          "kind": "DECORATION",
           "parent_identifier": null,
           "raw_value": "hellothere",
           "tokens": []
         },
         "EUA9VVVl7iRi0US9AbU_-9": {
           "identifier": null,
-          "kind": "LITERAL",
+          "kind": "DECORATION",
           "parent_identifier": null,
           "raw_value": "Heading This diagram illustrates that the current implementation has a neat feature that any node that doesn't look like an individual (i.e., two-part stacked box) nor is connected to an individual via a labeled arrow, is ignored. This allows users to add arbitrary decorations to the diagram without risking to break the onotology.  Anything that is the target of a labeled arrow (by the way, this does not require strict linking by default unless \"strict arrow parsing\" is enabled in parser settings) but doesn't look like an individual",
           "tokens": []
         },
         "I4GB3cVhTv-sTvJ7h0Jz-29": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["I4GB3cVhTv-sTvJ7h0Jz-30"],
+          "identifier": "Ontario. Dept. of Health\u00a0Authority Record",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Ontario. Dept. of Health\u00a0Authority Record",
-          "tokens": []
+          "tokens": ["lol:individual"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-30": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "I4GB3cVhTv-sTvJ7h0Jz-29",
+          "parent_identifier": "Ontario. Dept. of Health\u00a0Authority Record",
           "raw_value": "lol:individual",
-          "tokens": []
+          "tokens": ["lol:individual"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-31": {
           "identifier": null,
@@ -982,20 +956,20 @@
           "tokens": []
         },
         "I4GB3cVhTv-sTvJ7h0Jz-35": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["I4GB3cVhTv-sTvJ7h0Jz-36"],
+          "identifier": "Authority Record",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Authority Record",
-          "tokens": []
+          "tokens": ["rico:DocumentaryFormType"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-36": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "I4GB3cVhTv-sTvJ7h0Jz-35",
           "parent_identifier": "Authority Record",
           "raw_value": "rico:DocumentaryFormType",
-          "tokens": [
-            "rico:DocumentaryFormType"
-          ]
+          "tokens": ["rico:DocumentaryFormType"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-37": {
           "identifier": null,
@@ -1012,20 +986,20 @@
           "tokens": []
         },
         "I4GB3cVhTv-sTvJ7h0Jz-39": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["I4GB3cVhTv-sTvJ7h0Jz-40"],
+          "identifier": "Rules for Archival Description",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Rules for Archival Description",
-          "tokens": []
+          "tokens": ["rico:Rule"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-40": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "I4GB3cVhTv-sTvJ7h0Jz-39",
           "parent_identifier": "Rules for Archival Description",
           "raw_value": "rico:Rule",
-          "tokens": [
-            "rico:Rule"
-          ]
+          "tokens": ["rico:Rule"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-41": {
           "identifier": null,
@@ -1042,20 +1016,20 @@
           "tokens": []
         },
         "I4GB3cVhTv-sTvJ7h0Jz-43": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["I4GB3cVhTv-sTvJ7h0Jz-44"],
+          "identifier": "Authority Record Creation",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Authority Record Creation",
-          "tokens": []
+          "tokens": ["rico:Activity"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-44": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "I4GB3cVhTv-sTvJ7h0Jz-43",
           "parent_identifier": "Authority Record Creation",
           "raw_value": "rico:Activity",
-          "tokens": [
-            "rico:Activity"
-          ]
+          "tokens": ["rico:Activity"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-45": {
           "identifier": null,
@@ -1072,20 +1046,20 @@
           "tokens": []
         },
         "I4GB3cVhTv-sTvJ7h0Jz-47": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["I4GB3cVhTv-sTvJ7h0Jz-48"],
+          "identifier": "R. Anger",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "R. Anger",
-          "tokens": []
+          "tokens": ["rico:Person"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-48": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "I4GB3cVhTv-sTvJ7h0Jz-47",
           "parent_identifier": "R. Anger",
           "raw_value": "rico:Person",
-          "tokens": [
-            "rico:Person"
-          ]
+          "tokens": ["rico:Person"]
         },
         "I4bDPw6PqqAUihyiD4HI-1": {
           "identifier": null,
@@ -1144,36 +1118,36 @@
           "tokens": []
         },
         "Tc_GIQojTk6pTu17JZoE-1": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["Tc_GIQojTk6pTu17JZoE-2"],
+          "identifier": "Ontario. Dept. of Health",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Ontario. Dept. of Health",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-2": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "Tc_GIQojTk6pTu17JZoE-1",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-23": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["Tc_GIQojTk6pTu17JZoE-24"],
+          "identifier": "Provincial Board of Health of Ontario",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Provincial Board of Health of Ontario",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-24": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "Tc_GIQojTk6pTu17JZoE-23",
           "parent_identifier": "Provincial Board of Health of Ontario",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "_-RjwaxhbeTWfwVWe4ke-13": {
           "identifier": null,
@@ -1218,20 +1192,20 @@
           "tokens": []
         },
         "gmwnegnUR_CNORKRYM6Y-13": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["gmwnegnUR_CNORKRYM6Y-14"],
+          "identifier": "AA37",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "AA37",
-          "tokens": []
+          "tokens": ["rico:Identifier"]
         },
         "gmwnegnUR_CNORKRYM6Y-14": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "gmwnegnUR_CNORKRYM6Y-13",
           "parent_identifier": "AA37",
           "raw_value": "rico:Identifier",
-          "tokens": [
-            "rico:Identifier"
-          ]
+          "tokens": ["rico:Identifier"]
         },
         "gmwnegnUR_CNORKRYM6Y-16": {
           "identifier": null,
@@ -1262,27 +1236,28 @@
           "tokens": []
         },
         "gmwnegnUR_CNORKRYM6Y-20": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["gmwnegnUR_CNORKRYM6Y-21"],
+          "identifier": "Agent Identifier",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Agent Identifier",
-          "tokens": []
+          "tokens": ["rico:IdentifierType"]
         },
         "gmwnegnUR_CNORKRYM6Y-21": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "gmwnegnUR_CNORKRYM6Y-20",
           "parent_identifier": "Agent Identifier",
           "raw_value": "rico:IdentifierType",
-          "tokens": [
-            "rico:IdentifierType"
-          ]
+          "tokens": ["rico:IdentifierType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-1": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["iiJ8OJKaNMLrSCaLO3TT-2"],
+          "identifier": "Ontario. Dept. of Health",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Ontario. Dept. of Health",
-          "tokens": []
+          "tokens": ["rico:AgentName"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-10": {
           "identifier": null,
@@ -1292,20 +1267,20 @@
           "tokens": []
         },
         "iiJ8OJKaNMLrSCaLO3TT-11": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["iiJ8OJKaNMLrSCaLO3TT-12"],
+          "identifier": "1924",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "1924",
-          "tokens": []
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-12": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "iiJ8OJKaNMLrSCaLO3TT-11",
           "parent_identifier": "1924",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-17": {
           "identifier": null,
@@ -1322,29 +1297,28 @@
           "tokens": []
         },
         "iiJ8OJKaNMLrSCaLO3TT-19": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["iiJ8OJKaNMLrSCaLO3TT-20"],
+          "identifier": "1972",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "1972",
-          "tokens": []
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-2": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "iiJ8OJKaNMLrSCaLO3TT-1",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:AgentName",
-          "tokens": [
-            "rico:AgentName"
-          ]
+          "tokens": ["rico:AgentName"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-20": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "iiJ8OJKaNMLrSCaLO3TT-19",
           "parent_identifier": "1972",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-3": {
           "identifier": null,
@@ -1361,20 +1335,20 @@
           "tokens": []
         },
         "iiJ8OJKaNMLrSCaLO3TT-5": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["iiJ8OJKaNMLrSCaLO3TT-6"],
+          "identifier": "A Ontario Government Name",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "A Ontario Government Name",
-          "tokens": []
+          "tokens": ["rico:CorporateBodyType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-6": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "iiJ8OJKaNMLrSCaLO3TT-5",
           "parent_identifier": "A Ontario Government Name",
           "raw_value": "rico:CorporateBodyType",
-          "tokens": [
-            "rico:CorporateBodyType"
-          ]
+          "tokens": ["rico:CorporateBodyType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-7": {
           "identifier": null,
@@ -1426,34 +1400,36 @@
           "tokens": []
         },
         "lTHjRTAcClQ9bYR0I0Gv-11": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["lTHjRTAcClQ9bYR0I0Gv-12"],
+          "identifier": "Web Ready: Y",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Web Ready: Y",
-          "tokens": []
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-12": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "lTHjRTAcClQ9bYR0I0Gv-11",
           "parent_identifier": "Web Ready: Y",
           "raw_value": "rico:RecordState",
-          "tokens": [
-            "rico:RecordState"
-          ]
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-13": {
+          "derived_type_cells": ["lTHjRTAcClQ9bYR0I0Gv-14"],
           "identifier": "https://example.com",
           "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "https://example.com",
-          "tokens": []
+          "tokens": ["picoL:j"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-14": {
           "identifier": null,
-          "kind": "LITERAL",
-          "parent_identifier": null,
+          "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "lTHjRTAcClQ9bYR0I0Gv-13",
+          "parent_identifier": "https://example.com",
           "raw_value": "picoL:j",
-          "tokens": []
+          "tokens": ["picoL:j"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-15": {
           "identifier": null,
@@ -1477,20 +1453,20 @@
           "tokens": []
         },
         "ysJAvTtuVAxGOwe6Rh7X-1": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["ysJAvTtuVAxGOwe6Rh7X-2"],
+          "identifier": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
-          "tokens": []
+          "tokens": ["rico:Mandate"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-2": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "ysJAvTtuVAxGOwe6Rh7X-1",
           "parent_identifier": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
           "raw_value": "rico:Mandate",
-          "tokens": [
-            "rico:Mandate"
-          ]
+          "tokens": ["rico:Mandate"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-3": {
           "identifier": null,
@@ -1507,20 +1483,20 @@
           "tokens": []
         },
         "ysJAvTtuVAxGOwe6Rh7X-5": {
-          "identifier": null,
-          "kind": "LITERAL",
+          "derived_type_cells": ["ysJAvTtuVAxGOwe6Rh7X-6"],
+          "identifier": "Ontario. Ministry of Health",
+          "kind": "STANDALONE_INDIVIDUAL",
           "parent_identifier": null,
           "raw_value": "Ontario. Ministry of Health",
-          "tokens": []
+          "tokens": ["rico:CorporateBody"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-6": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
+          "parent_cell_id": "ysJAvTtuVAxGOwe6Rh7X-5",
           "parent_identifier": "Ontario. Ministry of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-7": {
           "identifier": null,
@@ -1538,7 +1514,7 @@
         }
       },
       "csv_path": "/mock/path/to/file.csv",
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -1546,11 +1522,11 @@
         ],
         "ts_pipeline": [
           "TypeScript pipeline graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23444280,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23444280,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ],
         "ts_plugin": [
           "TypeScript plugin graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23444280,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23444280,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ]
       },
       "format": "turtle",

--- a/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20250207T235959Z.md
+++ b/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20250207T235959Z.md
@@ -1,0 +1,27 @@
+# Debugging AA37-with-metadata-even-more-severely-mocked scenario
+
+## Context
+- Ran `python -m debug --scenario aa37-with-metadata-even-more-severely-mocked` after preparing the environment (Bun install, uv sync, Pyodide assets). Observed misclassified cells in `debug/map.json`.
+- Verified examples:
+  - `EUA9VVVl7iRi0US9AbU_-2` ("List pnnpni") lacked all type tokens and appeared as a literal despite having child type rows.
+  - `EUA9VVVl7iRi0US9AbU_-16` ("Vertical Container") failed to surface its type `lol:index`.
+  - `EUA9VVVl7iRi0US9AbU_-9` (decoration text) showed up as a literal rather than a decoration.
+- Confirmed that `_apply_metadata_overrides` stripped the diagram’s prefix metadata before classification and that parent containers were not promoted to individuals when their typed children resolved to valid CURIEs.
+
+## Changes made
+1. Updated `Debugger._run_scenario` to classify cells using the original DrawIO XML so metadata-derived prefixes remain available.
+2. Enhanced `_extract_cell_classifications`:
+   - Track edge connectivity and typed-child relationships before classifying cells.
+   - Promote parents of typed individuals to `STANDALONE_INDIVIDUAL`, merging the child tokens and recording `derived_type_cells`.
+   - Reclassify unconnected literals as `DECORATION` (mirrors `legacy/tests/test_cell_classifier.py`).
+   - Record `parent_cell_id` on typed children for traceability.
+3. Regenerated `debug/map.json` via the debugger run; confirmed the examples now read as expected (individual tokens aggregated, decorations marked correctly).
+
+## Verification
+- Re-ran `python -m debug --scenario debug/scenarios/aa37-with-metadata-even-more-severely-mocked.yml` to refresh the map and inspect the corrected entries.
+- Executed `bun run check` (lint + formatting) and `bun run test:log:linux`.
+  - The latter exercises pytest suites (`legacy/tests/test_cell_classifier.py` checks the same decoration logic) and the Bun integration tests that drive the Pyodide pipeline, ensuring the classification semantics line up with the debug output.
+
+## Notes
+- Symlinked the macOS-specific fixture path under `/Volumes/home/anonymous/...` to reuse the existing scenario YAML.
+- No changes were required in the generated parser; all adjustments live in the debugger helper.

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,9 +1,8 @@
-Script started on Mon Oct 20 16:40:14 2025
-Command: bun run test
+Script started on 2025-10-20 21:04:06+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 [0m[2m[35m$[0m [2m[1mpython -m meta_builder -o legacy/draw_io_parser.py && bun run lint:fix:py && bun run format:py[0m
 [metabuilder] Wrote legacy/draw_io_parser.py ( overrides on; replacements=8 [NodeHTMLParser, _build_graph_from_raw_xml, _cell_is_literal, _ensure_known_curie, _extract_individual_and_arrow_and_literal_cells, _split_curie, individual_blocks, serialise_to_graph] additions=3 [CellClassification, CellKind, DrawIOCellClassifier] )
-[metabuilder] Loaded override modules from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
+[metabuilder] Loaded override modules from /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
 [0m[2m[35m$[0m [2m[1mruff check --fix .[0m
 Found 15 errors (15 fixed, 0 remaining).
 [0m[2m[35m$[0m [2m[1mruff format .[0m
@@ -53,132 +52,131 @@ Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
      An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
 
 🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
-[1m============================================== test session starts ===============================================[0m
-platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0 -- /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
+[1m===================================================== test session starts ======================================================[0m
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
 cachedir: .pytest_cache
-rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
+rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 39 items                                                                                               [0m
-
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  2%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m [  5%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[32m [  7%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[dangling_curie] [32mPASSED[0m[32m [ 10%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[colon_only] [32mPASSED[0m[32m [ 12%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[no_prefix] [32mPASSED[0m[32m [ 15%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[32m [ 17%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [ 20%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 23%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[32m [ 25%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[32m [ 28%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[32m [ 30%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[32m [ 33%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[32m [ 35%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[32m [ 38%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[32m [ 41%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[32m [ 43%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[32m [ 46%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[32m [ 48%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[32m [ 51%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[32m [ 53%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[32m [ 56%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[32m [ 58%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[32m [ 61%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[32m [ 64%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[32m [ 66%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[32m [ 69%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[32m [ 71%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[32m [ 74%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 76%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 79%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[32m [ 82%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[32m [ 84%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [32mPASSED[0m[32m [ 87%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [32mPASSED[0m[32m [ 89%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 92%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m [ 94%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m [ 97%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m [100%][0m
-
-[32m=============================================== [32m[1m39 passed[0m[32m in 1.59s[0m[32m ===============================================[0m
-[1m============================================== test session starts ===============================================[0m
-platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0
-rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
-configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 59 items                                                                                               [0m
-
-legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                               [ 11%][0m
-legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[32m                                                                   [ 16%][0m
-legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                [ 83%][0m
-legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                 [ 89%][0m
-meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                      [100%][0m
-
-[32m=============================================== [32m[1m59 passed[0m[32m in 2.04s[0m[32m ===============================================[0m
-[0m[1mbun test [0m[2mv1.2.21 (7c45ed97)[0m
-[0m
-tests/rdfexport.test.ts:
-[BLACKBOX] Received serialized payload (36445 characters)
-[PIPELINE] Initializing Pyodide runtime from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
-[PIPELINE] Pyodide runtime ready
-[PIPELINE] Preparing Pyodide Python environment
-[PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/__init__.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/drawio_pipeline.py
-[PIPELINE] Syncing Python wheel to virtual FS: /app/wheels/rdflib-7.2.1-py3-none-any.whl
-[PIPELINE] Pyodide Python environment ready
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
-[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
-[BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m1391.65ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[0.62ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m21.26ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[1mcollecting ... [0m[1mcollected 39 items                                                                                                             [0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m   [  5%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[32m      [ 17%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[32m      [ 84%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [32mPASSED[0m[32m        [ 87%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [32mPASSED[0m[32m      [ 89%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m     [ 94%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m       [ 97%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m         [100%][0m
+[32m====================================================== [32m[1m39 passed[0m[32m in 8.36s[0m[32m ======================================================[0m
+[1m===================================================== test session starts ======================================================[0m
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
+[1mcollecting ... [0m[1mcollected 59 items                                                                                                             [0m
+legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                             [ 11%][0m
+legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[32m                                                                                 [ 16%][0m
+legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                              [ 83%][0m
+legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                               [ 89%][0m
+meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                    [100%][0m
+[32m===================================================== [32m[1m59 passed[0m[32m in 11.68s[0m[32m ======================================================[0m
+[0m[1mbun test [0m[2mv1.2.14 (6a363a38)[0m
+[PIPELINE] Initializing Pyodide runtime from /workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[0m[33m9009.08ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[4.39ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m203.74ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-1 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (5458 characters)
+[PIPELINE] DrawIO parser produced graph graph-2 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (5458 characters)
+[PIPELINE] DrawIO parser produced graph graph-3 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5524 characters)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m1020.83ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-4 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (9086 characters)
+[PIPELINE] DrawIO parser produced graph graph-5 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (9086 characters)
+[PIPELINE] DrawIO parser produced graph graph-6 with 137 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 137 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (9152 characters)
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m1081.07ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (42022 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (42022 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42022)
+[PIPELINE] DrawIO parser produced graph graph-7 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (6307 characters)
+[PIPELINE] Saving export payload to F 47-11-1 Elizabeth Simcoe loose sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
+[PIPELINE] DrawIO parser produced graph graph-8 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (6307 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (42040 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (42040 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42040)
+[PIPELINE] DrawIO parser produced graph graph-9 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (6373 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m482.71ms[0m[2m][0m
 [0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (61829 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
-[PIPELINE] DrawIO parser produced graph graph-1 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (7040 characters)
-[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-2 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (7040 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
+[PIPELINE] Generated DrawIO XML payload (37299 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37299 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37299)
+[PIPELINE] DrawIO parser produced graph graph-10 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (4369 characters)
+[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-11 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (4369 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
-[PIPELINE] DrawIO parser produced graph graph-3 with 127 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 127 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (7106 characters)
-[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m227.33ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (37317 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37317 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37317)
+[PIPELINE] DrawIO parser produced graph graph-12 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (4435 characters)
+[PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m452.65ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (44261 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
-[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
+[PIPELINE] DrawIO parser produced graph graph-13 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (5497 characters)
 [PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
 [PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-5 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (5497 characters)
+[PIPELINE] DrawIO parser produced graph graph-14 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (5497 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
@@ -187,27 +185,97 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
-[PIPELINE] DrawIO parser produced graph graph-6 with 94 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 94 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (5563 characters)
+[PIPELINE] DrawIO parser produced graph graph-15 with 94 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 94 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (5563 characters)
 [PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
 [PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m123.24ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m542.70ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] DrawIO parser produced graph graph-16 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (4345 characters)
+[PIPELINE] DrawIO parser produced graph graph-17 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (4345 characters)
+[PIPELINE] DrawIO parser produced graph graph-18 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (4411 characters)
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m428.43ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (39399 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
+[PIPELINE] DrawIO parser produced graph graph-19 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (4590 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-20 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (4590 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
+[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
+[PIPELINE] DrawIO parser produced graph graph-21 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (4656 characters)
+[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m431.26ms[0m[2m][0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[PIPELINE] DrawIO parser produced graph graph-22 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-23 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-24 with 104 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 104 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (9273 characters)
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m667.84ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-25 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (6443 characters)
+[PIPELINE] DrawIO parser produced graph graph-26 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (6443 characters)
+[PIPELINE] exportRml action invoked
+[PIPELINE] DrawIO parser produced graph graph-27 with 99 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 99 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (6509 characters)
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m555.51ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-28 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-29 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-30 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (3997 characters)
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m344.63ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (23410 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
-[PIPELINE] DrawIO parser produced graph graph-7 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (3002 characters)
+[PIPELINE] DrawIO parser produced graph graph-31 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (3002 characters)
 [PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
 [PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-8 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (3002 characters)
+[PIPELINE] DrawIO parser produced graph graph-32 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (3002 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
@@ -216,307 +284,52 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
-[PIPELINE] DrawIO parser produced graph graph-9 with 54 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 54 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (3068 characters)
+[PIPELINE] DrawIO parser produced graph graph-33 with 54 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 54 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (3068 characters)
 [PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
 [PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m67.60ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m292.90ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23546 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
-[PIPELINE] DrawIO parser produced graph graph-10 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (3738 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-11 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (3738 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
+[PIPELINE] Generated DrawIO XML payload (30823 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (30823 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30823)
+[PIPELINE] DrawIO parser produced graph graph-34 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (4952 characters)
+[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
+[PIPELINE] DrawIO parser produced graph graph-35 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (4952 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
-[PIPELINE] DrawIO parser produced graph graph-12 with 51 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 51 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (3804 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m70.38ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39399 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
-[PIPELINE] DrawIO parser produced graph graph-13 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-14 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
-[PIPELINE] DrawIO parser produced graph graph-15 with 78 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 78 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (4656 characters)
-[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m102.02ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44795 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
-[PIPELINE] DrawIO parser produced graph graph-16 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-17 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (5458 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
-[PIPELINE] DrawIO parser produced graph graph-18 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5524 characters)
-[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m133.09ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39329 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
-[PIPELINE] DrawIO parser produced graph graph-19 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (5053 characters)
-[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-20 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (5053 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
-[PIPELINE] DrawIO parser produced graph graph-21 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (5119 characters)
-[PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m102.54ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (73837 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
-[PIPELINE] DrawIO parser produced graph graph-22 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (9086 characters)
-[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-23 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (9086 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (73855 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (73855 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73855)
-[PIPELINE] DrawIO parser produced graph graph-24 with 137 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 137 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (9152 characters)
-[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m201.83ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (30841 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (30841 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30841)
+[PIPELINE] DrawIO parser produced graph graph-36 with 65 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 65 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (5018 characters)
+[PIPELINE] Saving RML export payload to BA619 Walkerton Inquiry.rml.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m326.58ms[0m[2m][0m
 [0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (80881 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
-[PIPELINE] DrawIO parser produced graph graph-25 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (11220 characters)
-[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-26 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (11220 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
-[PIPELINE] DrawIO parser produced graph graph-27 with 173 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 173 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (11286 characters)
-[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m232.98ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37618 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
-[PIPELINE] DrawIO parser produced graph graph-28 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-28 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-28 (4345 characters)
-[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-29 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-29 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-29 (4345 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
-[PIPELINE] DrawIO parser produced graph graph-30 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-30 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-30 (4411 characters)
-[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m96.51ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (95213 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
-[PIPELINE] DrawIO parser produced graph graph-31 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-31 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-31 (9826 characters)
-[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-32 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-32 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-32 (9826 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
-[PIPELINE] DrawIO parser produced graph graph-33 with 144 triples
-[BLACKBOX] Parsed DrawIO graph graph-33 with 144 triples
-[BLACKBOX] Returning Turtle payload for graph graph-33 (9892 characters)
-[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m236.74ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (54132 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
-[PIPELINE] DrawIO parser produced graph graph-34 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (6195 characters)
-[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-35 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (6195 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
-[PIPELINE] DrawIO parser produced graph graph-36 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (6261 characters)
-[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m130.30ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (58348 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
-[PIPELINE] DrawIO parser produced graph graph-37 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-37 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-37 (9207 characters)
-[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-38 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-38 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-38 (9207 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
-[PIPELINE] DrawIO parser produced graph graph-39 with 104 triples
-[BLACKBOX] Parsed DrawIO graph graph-39 with 104 triples
-[BLACKBOX] Returning Turtle payload for graph graph-39 (9273 characters)
-[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m138.56ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-37 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (5715 characters)
+[PIPELINE] DrawIO parser produced graph graph-38 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (5715 characters)
+[PIPELINE] DrawIO parser produced graph graph-39 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (5781 characters)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m454.02ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (34895 characters)
@@ -542,6 +355,194 @@ tests/rdfexport.test.ts:
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
 [PIPELINE] DrawIO parser produced graph graph-42 with 73 triples
 [BLACKBOX] Parsed DrawIO graph graph-42 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (5827 characters)
+[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m365.76ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-43 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (5721 characters)
+[PIPELINE] DrawIO parser produced graph graph-44 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-44 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-44 (5721 characters)
+[PIPELINE] DrawIO parser produced graph graph-45 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-45 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-45 (5787 characters)
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m507.80ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (54132 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
+[PIPELINE] DrawIO parser produced graph graph-46 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-46 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-46 (6195 characters)
+[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
+[PIPELINE] DrawIO parser produced graph graph-47 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-47 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-47 (6195 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
+[PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
+[PIPELINE] DrawIO parser produced graph graph-48 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-48 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-48 (6261 characters)
+[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m506.43ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (23546 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
+[PIPELINE] DrawIO parser produced graph graph-49 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-49 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-49 (3738 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-50 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-50 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-50 (3738 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
+[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
+[PIPELINE] DrawIO parser produced graph graph-51 with 51 triples
+[BLACKBOX] Parsed DrawIO graph graph-51 with 51 triples
+[BLACKBOX] Returning Turtle payload for graph graph-51 (3804 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m271.67ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (80881 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
+[PIPELINE] DrawIO parser produced graph graph-52 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-52 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-52 (11220 characters)
+[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
+[PIPELINE] DrawIO parser produced graph graph-53 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-53 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-53 (11220 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
+[PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
+[PIPELINE] DrawIO parser produced graph graph-54 with 173 triples
+[BLACKBOX] Parsed DrawIO graph graph-54 with 173 triples
+[BLACKBOX] Returning Turtle payload for graph graph-54 (11286 characters)
+[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m1025.73ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (61829 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
+[PIPELINE] DrawIO parser produced graph graph-55 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-55 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-55 (7040 characters)
+[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
+git status -sb
+[PIPELINE] DrawIO parser produced graph graph-56 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-56 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-56 (7040 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
+[PIPELINE] DrawIO parser produced graph graph-57 with 127 triples
+[BLACKBOX] Parsed DrawIO graph graph-57 with 127 triples
+[BLACKBOX] Returning Turtle payload for graph graph-57 (7106 characters)
+[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m665.12ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (39329 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
+[PIPELINE] DrawIO parser produced graph graph-58 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-58 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-58 (5053 characters)
+[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-59 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-59 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-59 (5053 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
+[PIPELINE] DrawIO parser produced graph graph-60 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-60 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-60 (5119 characters)
+[PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m397.99ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (95213 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
+[PIPELINE] DrawIO parser produced graph graph-61 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-61 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-61 (9826 characters)
+[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-62 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-62 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-62 (9826 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
+[PIPELINE] DrawIO parser produced graph graph-63 with 144 triples
+[BLACKBOX] Parsed DrawIO graph graph-63 with 144 triples
+[BLACKBOX] Returning Turtle payload for graph graph-63 (9892 characters)
+[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m1009.36ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m95.33ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m179.21ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m90.73ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m86.25ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m21.35ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+ 693 expect() calls
+Ran 37 tests across 1 files. [0m[2m[[1m21.78s[0m[2m][0m
+Script done on 2025-10-20 21:04:52+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Returning Turtle payload for graph graph-42 (5827 characters)
 [PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
 [PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)


### PR DESCRIPTION
## Summary
- rework the debugger helper to classify cells against the original DrawIO XML so diagram prefixes remain intact
- promote parents of typed individuals to standalone entries, capture parent cell ids, and mark unconnected literals as decorations in the exported map
- document the debugging steps for AA37-with-metadata-even-more-severely-mocked in docs/aicode

## Testing
- bun run check
- bun run test:log:linux

------
https://chatgpt.com/codex/tasks/task_e_68f6a17f6770832d9a8b7c47b9d5424a