### PR TITLE
Capture DrawIO decorations and cover fixture accounting

### DIFF
--- a/src/main/webapp/plugins/rdfexport/CHANGELOG.md
+++ b/src/main/webapp/plugins/rdfexport/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- 2025-10-20 – Added a regression pytest that loads every DrawIO fixture and asserts each mxCell is represented in the parsed graph to prevent silent drops.
 - 2025-10-20 – Introduced an experimental "Export RML" action that mirrors the Turtle export workflow, toggles the new `rmlEnabled` metadata flag, and injects a mock `rr:TriplesMap` triple through parser overrides with full Bun and pytest coverage.
 - 2025-10-20 – Added a parser setting and metadata flag to control HTML stripping so literals can preserve markup end-to-end, updating the DrawIO UI, Pyodide pipeline, parser overrides, fixtures, and Bun/pytest coverage.
 
@@ -25,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - 2025-10-20 – Hardened DrawIO rdf:type detection so swimlane child cells are always treated as attempted individuals, rejecting missing-prefix or colon-only CURIEs and extending the AA37 severely mocked fixture and pytest suite to cover these failures.
 - 2025-10-20 – Ensured the meta builder preserves external imports from override modules so generated parser bundles include rdflib and HTML parsing dependencies required by the overrides.
 - 2025-10-20 – Registered the DrawIO cell classifier override with the pipeline so CURIE validation no longer imports helper classes from the override package, tightening pytest coverage for literal handling and typed individuals.
+- 2025-10-20 – Restored unconnected DrawIO decoration text as `skos:note` metadata during serialization so mocked AA37 fixtures no longer lose their explanatory heading in Turtle output.
 
 ## [2025-10-17] - Historical Review (Pavel Zhelnov contributions)
 

--- a/src/main/webapp/plugins/rdfexport/debug/map.json
+++ b/src/main/webapp/plugins/rdfexport/debug/map.json
@@ -176,9 +176,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health\u00a0Authority Record",
           "raw_value": "rico:Record",
-          "tokens": [
-            "rico:Record"
-          ]
+          "tokens": ["rico:Record"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-31": {
           "identifier": null,
@@ -220,9 +218,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Authority Record",
           "raw_value": "rico:DocumentaryFormType",
-          "tokens": [
-            "rico:DocumentaryFormType"
-          ]
+          "tokens": ["rico:DocumentaryFormType"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-37": {
           "identifier": null,
@@ -250,9 +246,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Rules for Archival Description",
           "raw_value": "rico:Rule",
-          "tokens": [
-            "rico:Rule"
-          ]
+          "tokens": ["rico:Rule"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-41": {
           "identifier": null,
@@ -280,9 +274,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Authority Record Creation",
           "raw_value": "rico:Activity",
-          "tokens": [
-            "rico:Activity"
-          ]
+          "tokens": ["rico:Activity"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-45": {
           "identifier": null,
@@ -310,9 +302,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "R. Anger",
           "raw_value": "rico:Person",
-          "tokens": [
-            "rico:Person"
-          ]
+          "tokens": ["rico:Person"]
         },
         "I4bDPw6PqqAUihyiD4HI-1": {
           "identifier": null,
@@ -382,9 +372,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-23": {
           "identifier": null,
@@ -398,9 +386,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Provincial Board of Health of Ontario",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "_-RjwaxhbeTWfwVWe4ke-13": {
           "identifier": null,
@@ -456,9 +442,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "AA37",
           "raw_value": "rico:Identifier",
-          "tokens": [
-            "rico:Identifier"
-          ]
+          "tokens": ["rico:Identifier"]
         },
         "gmwnegnUR_CNORKRYM6Y-16": {
           "identifier": null,
@@ -500,9 +484,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Agent Identifier",
           "raw_value": "rico:IdentifierType",
-          "tokens": [
-            "rico:IdentifierType"
-          ]
+          "tokens": ["rico:IdentifierType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-1": {
           "identifier": null,
@@ -530,9 +512,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "1924",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-17": {
           "identifier": null,
@@ -560,18 +540,14 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:AgentName",
-          "tokens": [
-            "rico:AgentName"
-          ]
+          "tokens": ["rico:AgentName"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-20": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "1972",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-3": {
           "identifier": null,
@@ -599,9 +575,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "A Ontario Government Name",
           "raw_value": "rico:CorporateBodyType",
-          "tokens": [
-            "rico:CorporateBodyType"
-          ]
+          "tokens": ["rico:CorporateBodyType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-7": {
           "identifier": null,
@@ -664,9 +638,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Web Ready: Y",
           "raw_value": "rico:RecordState",
-          "tokens": [
-            "rico:RecordState"
-          ]
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-13": {
           "identifier": null,
@@ -680,9 +652,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Status: Approved",
           "raw_value": "rico:RecordState",
-          "tokens": [
-            "rico:RecordState"
-          ]
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-15": {
           "identifier": null,
@@ -717,9 +687,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
           "raw_value": "rico:Mandate",
-          "tokens": [
-            "rico:Mandate"
-          ]
+          "tokens": ["rico:Mandate"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-3": {
           "identifier": null,
@@ -747,9 +715,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Ministry of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-7": {
           "identifier": null,
@@ -891,18 +857,14 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "List pnnpni",
           "raw_value": "rico:Item%201",
-          "tokens": [
-            "rico:Item%201"
-          ]
+          "tokens": ["rico:Item%201"]
         },
         "EUA9VVVl7iRi0US9AbU_-4": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "List pnnpni",
           "raw_value": "rdf:Item%202",
-          "tokens": [
-            "rdf:Item%202"
-          ]
+          "tokens": ["rdf:Item%202"]
         },
         "EUA9VVVl7iRi0US9AbU_-5": {
           "identifier": null,
@@ -993,9 +955,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Authority Record",
           "raw_value": "rico:DocumentaryFormType",
-          "tokens": [
-            "rico:DocumentaryFormType"
-          ]
+          "tokens": ["rico:DocumentaryFormType"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-37": {
           "identifier": null,
@@ -1023,9 +983,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Rules for Archival Description",
           "raw_value": "rico:Rule",
-          "tokens": [
-            "rico:Rule"
-          ]
+          "tokens": ["rico:Rule"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-41": {
           "identifier": null,
@@ -1053,9 +1011,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Authority Record Creation",
           "raw_value": "rico:Activity",
-          "tokens": [
-            "rico:Activity"
-          ]
+          "tokens": ["rico:Activity"]
         },
         "I4GB3cVhTv-sTvJ7h0Jz-45": {
           "identifier": null,
@@ -1083,9 +1039,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "R. Anger",
           "raw_value": "rico:Person",
-          "tokens": [
-            "rico:Person"
-          ]
+          "tokens": ["rico:Person"]
         },
         "I4bDPw6PqqAUihyiD4HI-1": {
           "identifier": null,
@@ -1155,9 +1109,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "Tc_GIQojTk6pTu17JZoE-23": {
           "identifier": null,
@@ -1171,9 +1123,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Provincial Board of Health of Ontario",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "_-RjwaxhbeTWfwVWe4ke-13": {
           "identifier": null,
@@ -1229,9 +1179,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "AA37",
           "raw_value": "rico:Identifier",
-          "tokens": [
-            "rico:Identifier"
-          ]
+          "tokens": ["rico:Identifier"]
         },
         "gmwnegnUR_CNORKRYM6Y-16": {
           "identifier": null,
@@ -1273,9 +1221,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Agent Identifier",
           "raw_value": "rico:IdentifierType",
-          "tokens": [
-            "rico:IdentifierType"
-          ]
+          "tokens": ["rico:IdentifierType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-1": {
           "identifier": null,
@@ -1303,9 +1249,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "1924",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-17": {
           "identifier": null,
@@ -1333,18 +1277,14 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Dept. of Health",
           "raw_value": "rico:AgentName",
-          "tokens": [
-            "rico:AgentName"
-          ]
+          "tokens": ["rico:AgentName"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-20": {
           "identifier": null,
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "1972",
           "raw_value": "rico:Date",
-          "tokens": [
-            "rico:Date"
-          ]
+          "tokens": ["rico:Date"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-3": {
           "identifier": null,
@@ -1372,9 +1312,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "A Ontario Government Name",
           "raw_value": "rico:CorporateBodyType",
-          "tokens": [
-            "rico:CorporateBodyType"
-          ]
+          "tokens": ["rico:CorporateBodyType"]
         },
         "iiJ8OJKaNMLrSCaLO3TT-7": {
           "identifier": null,
@@ -1437,9 +1375,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Web Ready: Y",
           "raw_value": "rico:RecordState",
-          "tokens": [
-            "rico:RecordState"
-          ]
+          "tokens": ["rico:RecordState"]
         },
         "lTHjRTAcClQ9bYR0I0Gv-13": {
           "identifier": "https://example.com",
@@ -1488,9 +1424,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "The Health Department Act, Statutes of Ontario 1924, Chap. 69",
           "raw_value": "rico:Mandate",
-          "tokens": [
-            "rico:Mandate"
-          ]
+          "tokens": ["rico:Mandate"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-3": {
           "identifier": null,
@@ -1518,9 +1452,7 @@
           "kind": "TYPED_INDIVIDUAL",
           "parent_identifier": "Ontario. Ministry of Health",
           "raw_value": "rico:CorporateBody",
-          "tokens": [
-            "rico:CorporateBody"
-          ]
+          "tokens": ["rico:CorporateBody"]
         },
         "ysJAvTtuVAxGOwe6Rh7X-7": {
           "identifier": null,
@@ -1538,7 +1470,7 @@
         }
       },
       "csv_path": "/mock/path/to/file.csv",
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -1546,11 +1478,11 @@
         ],
         "ts_pipeline": [
           "TypeScript pipeline graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2200, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21014912,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2200, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21014912,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ],
         "ts_plugin": [
           "TypeScript plugin graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2146, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23091976,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2200, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21014912,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2200, in _build_graph_from_raw_xml\n    raise NotInKnownException(\n        f\"The node '{individual_identifier}' declares rdf:type '{raw_value}', whose prefix '{prefix_head}' is not defined by the available prefixes.\"\n    )\ndraw_io_parser.rdf_data_core.NotInKnownException: The node 'Ontario. Dept. of Health\u00a0Authority Record' declares rdf:type 'lol:individual', whose prefix 'lol' is not defined by the available prefixes.\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21014912,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ]
       },
       "format": "turtle",

--- a/src/main/webapp/plugins/rdfexport/debug/scenarios/aa37-with-metadata-even-more-severely-mocked.yml
+++ b/src/main/webapp/plugins/rdfexport/debug/scenarios/aa37-with-metadata-even-more-severely-mocked.yml
@@ -1,5 +1,5 @@
 slug: aa37-with-metadata-even-more-severely-mocked
-drawio: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio
+drawio: AA37-with-metadata-even-more-severely-mocked.drawio
 csv_path: /mock/path/to/file.csv
 base_uri: ontology://generated-from-draw-io/mock#
 prefixes:

--- a/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
@@ -2094,6 +2094,18 @@ class internal_control_core:
                 graph.add((subject_uri, prop_uri, Literal(raw_value)))
 
         draw_io_xml_tree = DrawIOXMLTree(working_xml, prefixes)
+        connected_literal_ids: set[str] = set()
+        for arrow_cell, *_ in getattr(draw_io_xml_tree, "arrow_cells", []):
+            target_id = arrow_cell.attrib.get("target")
+            if target_id:
+                connected_literal_ids.add(target_id)
+        classifier_cls = getattr(pipeline.core.xml.data, "DrawIOCellClassifier", None)
+        classifier = (
+            classifier_cls(draw_io_xml_tree, prefixes) if classifier_cls else None
+        )
+        processed_cell_ids: set[str] = set()
+        candidate_cell_ids: set[str] = set()
+        decoration_notes: list[str] = []
         literal_replacements: list[tuple[str, str, str, str]] = []
         if not strip_html_preference:
             literal_replacements = _gather_literal_replacements(draw_io_xml_tree)
@@ -2107,6 +2119,10 @@ class internal_control_core:
                     f"Could not parse XML tree: expecting an element with tag 'mxCell', but had tag '{cell.tag}'"
                 )
             if cell.attrib.get("edge") == "1":
+                cell_id = cell.attrib.get("id")
+                if cell_id:
+                    processed_cell_ids.add(cell_id)
+                    candidate_cell_ids.add(cell_id)
                 continue
             try:
                 cell_value = draw_io_xml_tree._value_of(cell)
@@ -2114,6 +2130,44 @@ class internal_control_core:
                 continue
             if not cell_value:
                 continue
+            cell_id = cell.attrib.get("id")
+            if cell_id:
+                candidate_cell_ids.add(cell_id)
+            if classifier is not None:
+                classification = classifier.classify(cell, cell_value)
+                kind_name = getattr(classification.kind, "name", "")
+                if kind_name == "ARROW_LABEL":
+                    if cell_id:
+                        processed_cell_ids.add(cell_id)
+                elif kind_name == "TYPED_INDIVIDUAL":
+                    if cell_id:
+                        processed_cell_ids.add(cell_id)
+                    parent_cell = getattr(classification, "parent_cell", None)
+                    if parent_cell is not None:
+                        parent_id = parent_cell.attrib.get("id")
+                        if parent_id:
+                            processed_cell_ids.add(parent_id)
+                            candidate_cell_ids.add(parent_id)
+                elif kind_name == "STANDALONE_INDIVIDUAL":
+                    if cell_id:
+                        processed_cell_ids.add(cell_id)
+                elif kind_name == "LITERAL":
+                    if cell_id:
+                        processed_cell_ids.add(cell_id)
+                        style = cell.attrib.get("style", "")
+                        is_text_shape = (
+                            style.startswith("text")
+                            or "text;" in style
+                            or "shape=text" in style
+                        )
+                        if (
+                            is_text_shape
+                            and cell_id not in connected_literal_ids
+                            and classification.raw_value.strip()
+                        ):
+                            decoration_notes.append(classification.raw_value.strip())
+            elif cell_id:
+                processed_cell_ids.add(cell_id)
             raw_value = cell_value.strip()
             has_separator = ":" in raw_value
             prefix_head = raw_value.split(":", 1)[0] if has_separator else raw_value
@@ -2166,6 +2220,30 @@ class internal_control_core:
             graph_cls=DrawIOParserGraph,
             graph_kwargs={"csv_path": csv_path},
         )
+        if decoration_notes:
+            from rdflib import BNode
+            from rdflib.namespace import SKOS
+
+            decoration_values = list(dict.fromkeys(decoration_notes))
+            if serialisation_config.ontology_iri:
+                decoration_subject = URIRef(serialisation_config.ontology_iri)
+            else:
+                decoration_subject = BNode()
+            for note in decoration_values:
+                graph.add((decoration_subject, SKOS.note, Literal(note)))
+        if hasattr(draw_io_xml_tree, "literal_cells"):
+            for literal_cell, _ in getattr(draw_io_xml_tree, "literal_cells", []):
+                literal_id = literal_cell.attrib.get("id")
+                if literal_id:
+                    processed_cell_ids.add(literal_id)
+                    candidate_cell_ids.add(literal_id)
+        for arrow_cell, *_ in getattr(draw_io_xml_tree, "arrow_cells", []):
+            arrow_id = arrow_cell.attrib.get("id")
+            if arrow_id:
+                processed_cell_ids.add(arrow_id)
+                candidate_cell_ids.add(arrow_id)
+        graph._drawio_processed_cells = processed_cell_ids
+        graph._drawio_candidate_cells = candidate_cell_ids
         if not strip_html_preference:
             _restore_literal_markup(graph, literal_replacements)
         if base_uri:

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
@@ -220,6 +220,17 @@ def _build_graph_from_raw_xml(
             graph.add((subject_uri, prop_uri, Literal(raw_value)))
 
     draw_io_xml_tree = DrawIOXMLTree(working_xml, prefixes)
+    connected_literal_ids: set[str] = set()
+    for arrow_cell, *_ in getattr(draw_io_xml_tree, "arrow_cells", []):
+        target_id = arrow_cell.attrib.get("target")
+        if target_id:
+            connected_literal_ids.add(target_id)
+
+    classifier_cls = getattr(pipeline.core.xml.data, "DrawIOCellClassifier", None)
+    classifier = classifier_cls(draw_io_xml_tree, prefixes) if classifier_cls else None
+    processed_cell_ids: set[str] = set()
+    candidate_cell_ids: set[str] = set()
+    decoration_notes: list[str] = []
     literal_replacements: list[tuple[str, str, str, str]] = []
     if not strip_html_preference:
         literal_replacements = _gather_literal_replacements(draw_io_xml_tree)
@@ -236,6 +247,10 @@ def _build_graph_from_raw_xml(
             )
 
         if cell.attrib.get("edge") == "1":
+            cell_id = cell.attrib.get("id")
+            if cell_id:
+                processed_cell_ids.add(cell_id)
+                candidate_cell_ids.add(cell_id)
             continue
 
         try:
@@ -245,6 +260,47 @@ def _build_graph_from_raw_xml(
 
         if not cell_value:
             continue
+
+        cell_id = cell.attrib.get("id")
+        if cell_id:
+            candidate_cell_ids.add(cell_id)
+
+        if classifier is not None:
+            classification = classifier.classify(cell, cell_value)
+            kind_name = getattr(classification.kind, "name", "")
+            if kind_name == "ARROW_LABEL":
+                if cell_id:
+                    processed_cell_ids.add(cell_id)
+            elif kind_name == "TYPED_INDIVIDUAL":
+                if cell_id:
+                    processed_cell_ids.add(cell_id)
+                parent_cell = getattr(classification, "parent_cell", None)
+                if parent_cell is not None:
+                    parent_id = parent_cell.attrib.get("id")
+                    if parent_id:
+                        processed_cell_ids.add(parent_id)
+                        candidate_cell_ids.add(parent_id)
+            elif kind_name == "STANDALONE_INDIVIDUAL":
+                if cell_id:
+                    processed_cell_ids.add(cell_id)
+            elif kind_name == "LITERAL":
+                if cell_id:
+                    processed_cell_ids.add(cell_id)
+                    style = cell.attrib.get("style", "")
+                    is_text_shape = (
+                        style.startswith("text")
+                        or "text;" in style
+                        or "shape=text" in style
+                    )
+                    if (
+                        is_text_shape
+                        and cell_id not in connected_literal_ids
+                        and classification.raw_value.strip()
+                    ):
+                        decoration_notes.append(classification.raw_value.strip())
+        else:
+            if cell_id:
+                processed_cell_ids.add(cell_id)
 
         raw_value = cell_value.strip()
         has_separator = ":" in raw_value
@@ -319,6 +375,34 @@ def _build_graph_from_raw_xml(
         graph_cls=DrawIOParserGraph,
         graph_kwargs={"csv_path": csv_path},
     )
+
+    if decoration_notes:
+        from rdflib import BNode
+        from rdflib.namespace import SKOS
+
+        decoration_values = list(dict.fromkeys(decoration_notes))
+        if serialisation_config.ontology_iri:
+            decoration_subject = URIRef(serialisation_config.ontology_iri)
+        else:
+            decoration_subject = BNode()
+        for note in decoration_values:
+            graph.add((decoration_subject, SKOS.note, Literal(note)))
+
+    if hasattr(draw_io_xml_tree, "literal_cells"):
+        for literal_cell, _ in getattr(draw_io_xml_tree, "literal_cells", []):
+            literal_id = literal_cell.attrib.get("id")
+            if literal_id:
+                processed_cell_ids.add(literal_id)
+                candidate_cell_ids.add(literal_id)
+
+    for arrow_cell, *_ in getattr(draw_io_xml_tree, "arrow_cells", []):
+        arrow_id = arrow_cell.attrib.get("id")
+        if arrow_id:
+            processed_cell_ids.add(arrow_id)
+            candidate_cell_ids.add(arrow_id)
+
+    graph._drawio_processed_cells = processed_cell_ids
+    graph._drawio_candidate_cells = candidate_cell_ids
 
     if not strip_html_preference:
         _restore_literal_markup(graph, literal_replacements)

--- a/src/main/webapp/plugins/rdfexport/legacy/tests/test_fixture_accounting.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/tests/test_fixture_accounting.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+import pytest
+
+import legacy.draw_io_parser as parser
+from pyodide_pipeline.drawio_pipeline import _default_parser_config
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "tests" / "fixtures"
+
+EXPECTED_FAILURES: dict[str, type[Exception]] = {
+    "AA37-with-metadata-severely-mocked": parser.rdf_data_core.NotInKnownException,
+    "General_Authority_bleep_mock": parser.rdf_data_core.NotInKnownException,
+}
+
+
+def _expected_candidate_ids(raw_xml: str) -> set[str]:
+    metadata_module = parser.pipeline.pre.xml.metadata  # type: ignore[attr-defined]
+    _, _, _, parsed_root = metadata_module._extract_drawio_metadata(raw_xml)
+    working_xml = metadata_module._strip_metadata_user_object(raw_xml, parsed_root)
+
+    candidate_ids: set[str] = set()
+    document = ET.fromstring(working_xml)
+    for cell in document.findall(".//mxCell"):
+        cell_id = cell.attrib.get("id")
+        if not cell_id:
+            continue
+        if cell.attrib.get("edge") == "1":
+            candidate_ids.add(cell_id)
+            continue
+        value = cell.attrib.get("value", "").strip()
+        if value:
+            candidate_ids.add(cell_id)
+    return candidate_ids
+
+
+@pytest.mark.parametrize(
+    "fixture_path",
+    sorted(FIXTURE_DIR.glob("*.drawio")),
+    ids=lambda path: path.stem,
+)
+def test_all_mxcell_accounted_for(fixture_path: Path) -> None:
+    xml = fixture_path.read_text(encoding="utf-8")
+    failure_exc = EXPECTED_FAILURES.get(fixture_path.stem)
+    if failure_exc is not None:
+        with pytest.raises(failure_exc):
+            parser._build_graph_from_raw_xml(xml, _default_parser_config())
+        return
+
+    config = _default_parser_config()
+    graph = parser._build_graph_from_raw_xml(xml, config)
+
+    processed = getattr(graph, "_drawio_processed_cells", set())
+    candidate = getattr(graph, "_drawio_candidate_cells", set())
+
+    assert candidate, "Expected candidate mxCell identifiers to be captured"
+    assert processed == candidate
+
+    expected = _expected_candidate_ids(xml)
+    assert candidate == expected

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,13 +1,12 @@
-Script started on Mon Oct 20 16:40:14 2025
-Command: bun run test
+Script started on 2025-10-20 21:27:21+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 [0m[2m[35m$[0m [2m[1mpython -m meta_builder -o legacy/draw_io_parser.py && bun run lint:fix:py && bun run format:py[0m
 [metabuilder] Wrote legacy/draw_io_parser.py ( overrides on; replacements=8 [NodeHTMLParser, _build_graph_from_raw_xml, _cell_is_literal, _ensure_known_curie, _extract_individual_and_arrow_and_literal_cells, _split_curie, individual_blocks, serialise_to_graph] additions=3 [CellClassification, CellKind, DrawIOCellClassifier] )
-[metabuilder] Loaded override modules from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
+[metabuilder] Loaded override modules from /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
 [0m[2m[35m$[0m [2m[1mruff check --fix .[0m
 Found 15 errors (15 fixed, 0 remaining).
 [0m[2m[35m$[0m [2m[1mruff format .[0m
-1 file reformatted, 22 files left unchanged
+1 file reformatted, 23 files left unchanged
 Attempting to regenerate baselines from 1 commit(s)...
 Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
 
@@ -53,307 +52,136 @@ Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
      An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
 
 🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
-[1m============================================== test session starts ===============================================[0m
-platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0 -- /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
+[1m===================================================== test session starts ======================================================[0m
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
 cachedir: .pytest_cache
-rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
+rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 39 items                                                                                               [0m
-
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  2%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m [  5%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[32m [  7%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[dangling_curie] [32mPASSED[0m[32m [ 10%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[colon_only] [32mPASSED[0m[32m [ 12%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[no_prefix] [32mPASSED[0m[32m [ 15%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[32m [ 17%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[32m [ 20%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[32m [ 23%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[32m [ 25%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[32m [ 28%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[32m [ 30%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[32m [ 33%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[32m [ 35%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[32m [ 38%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[32m [ 41%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[32m [ 43%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[32m [ 46%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[32m [ 48%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[32m [ 51%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[32m [ 53%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[32m [ 56%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[32m [ 58%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[32m [ 61%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[32m [ 64%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[32m [ 66%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[32m [ 69%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[32m [ 71%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[32m [ 74%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[32m [ 76%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[32m [ 79%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[32m [ 82%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[32m [ 84%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [32mPASSED[0m[32m [ 87%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [32mPASSED[0m[32m [ 89%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[32m [ 92%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m [ 94%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m [ 97%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m [100%][0m
-
-[32m=============================================== [32m[1m39 passed[0m[32m in 1.59s[0m[32m ===============================================[0m
-[1m============================================== test session starts ===============================================[0m
-platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0
-rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
-configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 59 items                                                                                               [0m
-
-legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                               [ 11%][0m
-legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[32m                                                                   [ 16%][0m
-legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                [ 83%][0m
-legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                 [ 89%][0m
-meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                      [100%][0m
-
-[32m=============================================== [32m[1m59 passed[0m[32m in 2.04s[0m[32m ===============================================[0m
-[0m[1mbun test [0m[2mv1.2.21 (7c45ed97)[0m
-[0m
-tests/rdfexport.test.ts:
-[BLACKBOX] Received serialized payload (36445 characters)
-[PIPELINE] Initializing Pyodide runtime from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
-[PIPELINE] Pyodide runtime ready
-[PIPELINE] Preparing Pyodide Python environment
-[PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/__init__.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/drawio_pipeline.py
-[PIPELINE] Syncing Python wheel to virtual FS: /app/wheels/rdflib-7.2.1-py3-none-any.whl
-[PIPELINE] Pyodide Python environment ready
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
-[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
-[BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m1391.65ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[0.62ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m21.26ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (61829 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
-[PIPELINE] DrawIO parser produced graph graph-1 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (7040 characters)
-[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-2 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (7040 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
-[PIPELINE] DrawIO parser produced graph graph-3 with 127 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 127 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (7106 characters)
-[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m227.33ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44261 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
-[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
-[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-5 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (5497 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
-[PIPELINE] DrawIO parser produced graph graph-6 with 94 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 94 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (5563 characters)
-[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m123.24ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23410 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
-[PIPELINE] DrawIO parser produced graph graph-7 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (3002 characters)
-[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-8 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (3002 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
-[PIPELINE] DrawIO parser produced graph graph-9 with 54 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 54 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (3068 characters)
-[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m67.60ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23546 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
-[PIPELINE] DrawIO parser produced graph graph-10 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (3738 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-11 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (3738 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
-[PIPELINE] DrawIO parser produced graph graph-12 with 51 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 51 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (3804 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m70.38ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39399 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
-[PIPELINE] DrawIO parser produced graph graph-13 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-14 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
-[PIPELINE] DrawIO parser produced graph graph-15 with 78 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 78 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (4656 characters)
-[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m102.02ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44795 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
-[PIPELINE] DrawIO parser produced graph graph-16 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-17 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (5458 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
-[PIPELINE] DrawIO parser produced graph graph-18 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5524 characters)
-[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m133.09ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39329 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
-[PIPELINE] DrawIO parser produced graph graph-19 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (5053 characters)
-[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-20 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (5053 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
-[PIPELINE] DrawIO parser produced graph graph-21 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (5119 characters)
-[PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m102.54ms[0m[2m][0m
+[1mcollecting ... [0m[1mcollected 39 items                                                                                                             [0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m   [  5%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[32m      [ 17%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[32m      [ 84%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [32mPASSED[0m[32m        [ 87%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [32mPASSED[0m[32m      [ 89%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[32m     [ 94%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[32m       [ 97%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[32m         [100%][0m
+[32m===================================================== [32m[1m39 passed[0m[32m in 13.45s[0m[32m ======================================================[0m
+[1m===================================================== test session starts ======================================================[0m
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
+[1mcollecting ... [0m[1mcollected 88 items                                                                                                             [0m
+legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                             [  7%][0m
+legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[32m                                                                                 [ 11%][0m
+legacy/tests/test_fixture_accounting.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                    [ 44%][0m
+legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                              [ 88%][0m
+legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                               [ 93%][0m
+meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m                                                                    [100%][0m
+[32m===================================================== [32m[1m88 passed[0m[32m in 19.94s[0m[32m ======================================================[0m
+[0m[1mbun test [0m[2mv1.2.14 (6a363a38)[0m
+[PIPELINE] Initializing Pyodide runtime from /workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[0m[33m13131.80ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[3.82ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m333.68ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[PIPELINE] DrawIO parser produced graph graph-1 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (5497 characters)
+[PIPELINE] DrawIO parser produced graph graph-2 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (5497 characters)
+[PIPELINE] DrawIO parser produced graph graph-3 with 94 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 94 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5563 characters)
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m1525.05ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (54132 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
+[PIPELINE] DrawIO parser produced graph graph-4 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (6195 characters)
+[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
+[PIPELINE] DrawIO parser produced graph graph-5 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (6195 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
+[PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
+[PIPELINE] DrawIO parser produced graph graph-6 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (6261 characters)
+[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m1108.66ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (32209 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (32209 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32209)
+[PIPELINE] DrawIO parser produced graph graph-7 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (3931 characters)
+[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
+[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
+[PIPELINE] DrawIO parser produced graph graph-8 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (3931 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
+[PIPELINE] Generated DrawIO XML payload (32227 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (32227 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32227)
+[PIPELINE] DrawIO parser produced graph graph-9 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (3997 characters)
+[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
+[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m671.22ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (34895 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
+[PIPELINE] DrawIO parser produced graph graph-10 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (5761 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-11 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (5761 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
+[PIPELINE] DrawIO parser produced graph graph-12 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (5827 characters)
+[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m602.14ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (73837 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
-[PIPELINE] DrawIO parser produced graph graph-22 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (9086 characters)
+[PIPELINE] DrawIO parser produced graph graph-13 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (9086 characters)
 [PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
 [PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-23 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (9086 characters)
+[PIPELINE] DrawIO parser produced graph graph-14 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (9086 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
@@ -362,60 +190,147 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (73855 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (73855 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 73855)
-[PIPELINE] DrawIO parser produced graph graph-24 with 137 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 137 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (9152 characters)
+[PIPELINE] DrawIO parser produced graph graph-15 with 137 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 137 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (9152 characters)
 [PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
 [PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m201.83ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m1298.16ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (80881 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
-[PIPELINE] DrawIO parser produced graph graph-25 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (11220 characters)
-[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-26 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (11220 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
+[PIPELINE] Generated DrawIO XML payload (49944 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (49944 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49944)
+[PIPELINE] DrawIO parser produced graph graph-16 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (6443 characters)
+[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
+[PIPELINE] DrawIO parser produced graph graph-17 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (6443 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
-[PIPELINE] DrawIO parser produced graph graph-27 with 173 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 173 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (11286 characters)
-[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m232.98ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (49962 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (49962 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49962)
+[PIPELINE] DrawIO parser produced graph graph-18 with 99 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 99 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (6509 characters)
+[PIPELINE] Saving RML export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m1001.71ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (61829 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
+[PIPELINE] DrawIO parser produced graph graph-19 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (7040 characters)
+[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
+[PIPELINE] DrawIO parser produced graph graph-20 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (7040 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
+[PIPELINE] DrawIO parser produced graph graph-21 with 127 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 127 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (7106 characters)
+[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m1285.26ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (48162 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (48162 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48162)
+[PIPELINE] DrawIO parser produced graph graph-22 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (5721 characters)
+[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
+[PIPELINE] DrawIO parser produced graph graph-23 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (5721 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (48180 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (48180 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48180)
+[PIPELINE] DrawIO parser produced graph graph-24 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (5787 characters)
+[PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m807.37ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[PIPELINE] DrawIO parser produced graph graph-25 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (5458 characters)
+[PIPELINE] DrawIO parser produced graph graph-26 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (5458 characters)
+[PIPELINE] DrawIO parser produced graph graph-27 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (5524 characters)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m732.58ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (37299 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37299 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37299)
+[PIPELINE] DrawIO parser produced graph graph-28 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (4369 characters)
+[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-29 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (4369 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[PIPELINE] Generated DrawIO XML payload (37317 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37317 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37317)
+[PIPELINE] DrawIO parser produced graph graph-30 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (4435 characters)
+[PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m684.50ms[0m[2m][0m
 [PIPELINE] Generated DrawIO XML payload (37618 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
-[PIPELINE] DrawIO parser produced graph graph-28 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-28 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-28 (4345 characters)
+[PIPELINE] DrawIO parser produced graph graph-31 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (4345 characters)
 [PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
 [PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-29 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-29 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-29 (4345 characters)
+[PIPELINE] DrawIO parser produced graph graph-32 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (4345 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
@@ -424,149 +339,235 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
-[PIPELINE] DrawIO parser produced graph graph-30 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-30 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-30 (4411 characters)
+[PIPELINE] DrawIO parser produced graph graph-33 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (4411 characters)
 [PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m96.51ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m620.76ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (95213 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
-[PIPELINE] DrawIO parser produced graph graph-31 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-31 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-31 (9826 characters)
-[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-32 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-32 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-32 (9826 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
+[PIPELINE] Generated DrawIO XML payload (23546 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
+[PIPELINE] DrawIO parser produced graph graph-34 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (3738 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-35 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (3738 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
-[PIPELINE] DrawIO parser produced graph graph-33 with 144 triples
-[BLACKBOX] Parsed DrawIO graph graph-33 with 144 triples
-[BLACKBOX] Returning Turtle payload for graph graph-33 (9892 characters)
-[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m236.74ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
+[PIPELINE] DrawIO parser produced graph graph-36 with 51 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 51 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (3804 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m398.68ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (54132 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
-[PIPELINE] DrawIO parser produced graph graph-34 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (6195 characters)
-[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-35 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (6195 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
+[PIPELINE] Generated DrawIO XML payload (30823 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (30823 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30823)
+[PIPELINE] DrawIO parser produced graph graph-37 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (4952 characters)
+[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
+[PIPELINE] DrawIO parser produced graph graph-38 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (4952 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 64 vs 64
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
-[PIPELINE] DrawIO parser produced graph graph-36 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (6261 characters)
-[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m130.30ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (30841 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (30841 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30841)
+[PIPELINE] DrawIO parser produced graph graph-39 with 65 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 65 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (5018 characters)
+[PIPELINE] Saving RML export payload to BA619 Walkerton Inquiry.rml.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m532.15ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (58348 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
-[PIPELINE] DrawIO parser produced graph graph-37 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-37 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-37 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-40 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (9207 characters)
 [PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
 [PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-38 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-38 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-38 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-41 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (9207 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
-[PIPELINE] DrawIO parser produced graph graph-39 with 104 triples
-[BLACKBOX] Parsed DrawIO graph graph-39 with 104 triples
-[BLACKBOX] Returning Turtle payload for graph graph-39 (9273 characters)
+[PIPELINE] DrawIO parser produced graph graph-42 with 104 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 104 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (9273 characters)
 [PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
 [PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m138.56ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (34895 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
-[PIPELINE] DrawIO parser produced graph graph-40 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-40 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-40 (5761 characters)
-[PIPELINE] Saving export payload to AA37 Department of Health.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-41 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-41 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-41 (5761 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m898.09ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-43 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-44 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-44 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-44 (11220 characters)
+[PIPELINE] DrawIO parser produced graph graph-45 with 173 triples
+[BLACKBOX] Parsed DrawIO graph graph-45 with 173 triples
+[BLACKBOX] Returning Turtle payload for graph graph-45 (11286 characters)
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m1607.66ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (39399 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
+[PIPELINE] DrawIO parser produced graph graph-46 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-46 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-46 (4590 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-47 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-47 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-47 (4590 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
+[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
+[PIPELINE] DrawIO parser produced graph graph-48 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-48 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-48 (4656 characters)
+[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m661.09ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[PIPELINE] DrawIO parser produced graph graph-49 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-49 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-49 (9826 characters)
+[PIPELINE] DrawIO parser produced graph graph-50 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-50 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-50 (9826 characters)
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[PIPELINE] DrawIO parser produced graph graph-51 with 144 triples
+[BLACKBOX] Parsed DrawIO graph graph-51 with 144 triples
+[BLACKBOX] Returning Turtle payload for graph graph-51 (9892 characters)
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m1560.62ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (23410 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
+[PIPELINE] DrawIO parser produced graph graph-52 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-52 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-52 (3002 characters)
+[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
+[PIPELINE] DrawIO parser produced graph graph-53 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-53 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-53 (3002 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
+[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
+[PIPELINE] DrawIO parser produced graph graph-54 with 54 triples
+[BLACKBOX] Parsed DrawIO graph graph-54 with 54 triples
+[BLACKBOX] Returning Turtle payload for graph graph-54 (3068 characters)
+[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m446.15ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-55 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-55 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-55 (5715 characters)
+[PIPELINE] DrawIO parser produced graph graph-56 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-56 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-56 (5715 characters)
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
-[PIPELINE] DrawIO parser produced graph graph-42 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-42 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-42 (5827 characters)
-[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m89.14ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-57 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-57 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-57 (5781 characters)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m726.33ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-58 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-58 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-58 (6307 characters)
+[PIPELINE] DrawIO parser produced graph graph-59 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-59 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-59 (6307 characters)
+[PIPELINE] DrawIO parser produced graph graph-60 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-60 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-60 (6373 characters)
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m630.44ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (49944 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (49944 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49944)
-[PIPELINE] DrawIO parser produced graph graph-43 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-43 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-43 (6443 characters)
-[PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-44 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-44 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-44 (6443 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
+[PIPELINE] Generated DrawIO XML payload (39329 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
+[PIPELINE] DrawIO parser produced graph graph-61 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-61 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-61 (5053 characters)
+[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
+[PIPELINE] DrawIO parser produced graph graph-62 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-62 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-62 (5053 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (49962 characters) for RML export
+[PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
+[PIPELINE] DrawIO parser produced graph graph-63 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-63 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-63 (5119 characters)
+[PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m616.53ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m130.53ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m299.04ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m134.12ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m154.40ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m35.11ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+ 693 expect() calls
+Ran 37 tests across 1 files. [0m[2m[[1m32.94s[0m[2m][0m
+Script done on 2025-10-20 21:28:32+00:00 [COMMAND_EXIT_CODE="0"]
 [BLACKBOX] Generating Turtle payload for serialized input (49962 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49962)
 [PIPELINE] DrawIO parser produced graph graph-45 with 99 triples


### PR DESCRIPTION
## Summary
- restore decoration text as SKOS notes while tracking processed vs candidate DrawIO cells through the parser override and regenerated module
- point the AA37 severe mock debug scenario at the repository fixture and refresh the debug inventory formatting
- add a regression pytest that sweeps all DrawIO fixtures to verify mxCell coverage, update the changelog, and refresh the Bun test log

## Testing
- python -m debug --scenario debug/scenarios/aa37-with-metadata-even-more-severely-mocked.yml
- bun run check
- bun run test
- bun run test:log:linux

------
https://chatgpt.com/codex/tasks/task_e_68f68bfe50e0832da9af3b8db6a854fa