### PR TITLE
Align debug CLI scenario resolution with parser configuration

### DIFF
--- a/src/main/webapp/plugins/rdfexport/debug/__main__.py
+++ b/src/main/webapp/plugins/rdfexport/debug/__main__.py
@@ -388,7 +388,7 @@ class Debugger:
 
         try:
             py_legacy_graph = self._generate_py_legacy_graph(
-                temp_file_path, config.legacy_commit
+                temp_file_path, config.legacy_commit, config
             )
             py_legacy_error = None
         except Exception as exc:
@@ -541,7 +541,9 @@ class Debugger:
     # ------------------------------------------------------------------
     # Graph generation helpers
     # ------------------------------------------------------------------
-    def _generate_py_legacy_graph(self, drawio_path: Path, commit: str) -> Graph:
+    def _generate_py_legacy_graph(
+        self, drawio_path: Path, commit: str, config: ScenarioConfig
+    ) -> Graph:
         with (
             PreviousParserLoader(commit) as py_legacy_parser,
             PreviousParserLoader("HEAD") as py_current_parser,
@@ -556,16 +558,35 @@ class Debugger:
             if current_get_prefixes is not None:
                 setattr(py_legacy_parser, "get_prefixes", current_get_prefixes)
 
-            get_ontology_iri = getattr(py_current_parser, "get_ontology_iri", None)
-            ontology_iri = None
-            if get_ontology_iri is not None:
-                ontology_iri = get_ontology_iri("mock")
+            parser_overrides: dict[str, object] = dict(config.parser_config)
 
-            graph = parse_drawio(
-                str(drawio_path),
-                ontology_iri=ontology_iri,
-                metacharacter_substitute=list(DEFAULT_METACHARACTER_SUBSTITUTE),
+            # Normalise ontology IRI so legacy parser honours scenario overrides
+            get_ontology_iri = getattr(py_current_parser, "get_ontology_iri", None)
+            ontology_iri_override = parser_overrides.get("ontology_iri")
+            if ontology_iri_override:
+                parser_overrides["ontology_iri"] = str(ontology_iri_override)
+            elif get_ontology_iri is not None:
+                parser_overrides["ontology_iri"] = get_ontology_iri("mock")
+
+            # Mirror base URI semantics so prefix IRIs line up with the pipeline
+            base_uri = config.base_uri
+            prefix_iri_override = parser_overrides.get("prefix_iri")
+            if prefix_iri_override:
+                parser_overrides["prefix_iri"] = str(prefix_iri_override)
+            elif base_uri:
+                parser_overrides["prefix_iri"] = base_uri
+            else:
+                get_prefix_iri = getattr(py_current_parser, "get_prefix_iri", None)
+                if get_prefix_iri is not None:
+                    parser_overrides["prefix_iri"] = get_prefix_iri(
+                        parser_overrides.get("ontology_iri")
+                    )
+
+            parser_overrides.setdefault(
+                "metacharacter_substitute", list(DEFAULT_METACHARACTER_SUBSTITUTE)
             )
+
+            graph = parse_drawio(str(drawio_path), **parser_overrides)
 
             if not isinstance(graph, Graph):
                 raise TypeError("Legacy Python parser did not return an rdflib Graph")
@@ -919,12 +940,56 @@ class Debugger:
         return self._resolve_drawio_path(choice)
 
     def _resolve_drawio_path(self, value: str | Path) -> Path:
-        path = Path(value)
+        """Resolve ``value`` to a concrete ``.drawio`` path.
+
+        Scenarios historically captured absolute paths from contributor
+        workstations (for example ``/Volumes/home/...``). When those
+        scenarios run in a different environment, the files are unavailable
+        even though the fixture exists locally. To keep the debug tool
+        portable, fall back to matching fixtures by filename inside the
+        repository whenever the provided path cannot be opened.
+        """
+
+        raw_value = str(value).strip()
+        path = Path(raw_value)
+
+        # First honour the caller's path if it already exists.
+        if path.exists():
+            return path.resolve()
+
+        # Support relative paths with respect to the fixtures directory.
         if not path.is_absolute():
             fixture_candidate = self.fixtures_dir / path
             if fixture_candidate.exists():
                 return fixture_candidate.resolve()
-            path = Path(value).expanduser().resolve()
+
+            expanded = Path(raw_value).expanduser()
+            if expanded.exists():
+                return expanded.resolve()
+            path = expanded if expanded.is_absolute() else path
+        else:
+            expanded = path.expanduser()
+            if expanded.exists():
+                return expanded.resolve()
+            path = expanded
+
+        # Fallback: try resolving by filename within the fixtures inventory.
+        fixture_name = Path(raw_value).name
+        if fixture_name:
+            fixture_candidate = self.fixtures_dir / fixture_name
+            if fixture_candidate.exists():
+                return fixture_candidate.resolve()
+
+            fixtures = self._map_data.get("fixtures", {})
+            lowered_name = fixture_name.lower()
+            for info in fixtures.values():
+                rel_path = info.get("path")
+                if not rel_path:
+                    continue
+                candidate = self.fixtures_dir / rel_path
+                if candidate.exists() and candidate.name.lower() == lowered_name:
+                    return candidate.resolve()
+
         return path
 
     def _normalise_format(self, fmt: str | None) -> str:

--- a/src/main/webapp/plugins/rdfexport/debug/map.json
+++ b/src/main/webapp/plugins/rdfexport/debug/map.json
@@ -1667,11 +1667,11 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 4711 Orville Wood fonds.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 4711 Orville Wood fonds.drawio",
       "format": "turtle",
       "isomorphism": {
-        "py_legacy_vs_ts_pipeline": false,
-        "py_legacy_vs_ts_plugin": false,
+        "py_legacy_vs_ts_pipeline": true,
+        "py_legacy_vs_ts_plugin": true,
         "ts_pipeline_vs_ts_plugin": true
       },
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
@@ -1690,19 +1690,19 @@
       ],
       "results": {
         "py_legacy": {
-          "nt_sha256": "479fe1452b058998510ffeb0cb5e1d89831ad76e40d8d7b3ee2ed2c1d7a469b5",
+          "nt_sha256": "b7759ed59a07961760eed5fdca4adfb62148d5a32c468f78fa833c7e277ae733",
           "path": "results/f-4711-orville-wood-fonds/py_legacy.ttl",
           "triples": 141
         },
         "ts_pipeline": {
-          "nt_sha256": "9d8f403adcb26adda36c2a52600b8f19a2c7c45b2361f2855262ece93e761cc2",
+          "nt_sha256": "b7759ed59a07961760eed5fdca4adfb62148d5a32c468f78fa833c7e277ae733",
           "path": "results/f-4711-orville-wood-fonds/ts_pipeline.ttl",
-          "triples": 107
+          "triples": 141
         },
         "ts_plugin": {
-          "nt_sha256": "9d8f403adcb26adda36c2a52600b8f19a2c7c45b2361f2855262ece93e761cc2",
+          "nt_sha256": "b7759ed59a07961760eed5fdca4adfb62148d5a32c468f78fa833c7e277ae733",
           "path": "results/f-4711-orville-wood-fonds/ts_plugin.ttl",
-          "triples": 107
+          "triples": 141
         }
       }
     },
@@ -2197,7 +2197,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -2215,19 +2215,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "940ad1dc15c1b4b2d9cb6d7975159f3cd794b3fb8c35e57885f7dc7917610e31",
+          "nt_sha256": "e647ba9d0fc62fd6acb7f5f14a43f795c16b3e8d957ec1fba4a64f00ed692645",
           "path": "results/pytest-aa37-department-of-health/py_legacy.ttl",
           "triples": 87
         },
         "ts_pipeline": {
-          "nt_sha256": "fce56fc617d44f626db710b26ce033905d329b143a6e2ab8cd5af12686f33d36",
+          "nt_sha256": "e647ba9d0fc62fd6acb7f5f14a43f795c16b3e8d957ec1fba4a64f00ed692645",
           "path": "results/pytest-aa37-department-of-health/ts_pipeline.ttl",
-          "triples": 72
+          "triples": 87
         },
         "ts_plugin": {
-          "nt_sha256": "fce56fc617d44f626db710b26ce033905d329b143a6e2ab8cd5af12686f33d36",
+          "nt_sha256": "e647ba9d0fc62fd6acb7f5f14a43f795c16b3e8d957ec1fba4a64f00ed692645",
           "path": "results/pytest-aa37-department-of-health/ts_plugin.ttl",
-          "triples": 72
+          "triples": 87
         }
       }
     },
@@ -2722,7 +2722,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -2744,14 +2744,14 @@
       "preamble": [],
       "results": {
         "ts_pipeline": {
-          "nt_sha256": "fce56fc617d44f626db710b26ce033905d329b143a6e2ab8cd5af12686f33d36",
+          "nt_sha256": "e647ba9d0fc62fd6acb7f5f14a43f795c16b3e8d957ec1fba4a64f00ed692645",
           "path": "results/pytest-aa37-department-of-health-with-metadata/ts_pipeline.ttl",
-          "triples": 72
+          "triples": 87
         },
         "ts_plugin": {
-          "nt_sha256": "fce56fc617d44f626db710b26ce033905d329b143a6e2ab8cd5af12686f33d36",
+          "nt_sha256": "e647ba9d0fc62fd6acb7f5f14a43f795c16b3e8d957ec1fba4a64f00ed692645",
           "path": "results/pytest-aa37-department-of-health-with-metadata/ts_plugin.ttl",
-          "triples": 72
+          "triples": 87
         }
       }
     },
@@ -3246,17 +3246,23 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata-preserve-html.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata-preserve-html.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
           "ParseException: Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'"
+        ],
+        "ts_pipeline": [
+          "TypeScript pipeline graph is None",
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide initialization failed RuntimeError: Out of bounds memory access (evaluating '_PyRun_SimpleString(r)')\n\nRuntimeError: Out of bounds memory access (evaluating '_PyRun_SimpleString(r)')\n\nBun v1.2.14 (Linux x64 baseline)"
+        ],
+        "ts_plugin": [
+          "TypeScript plugin graph is None",
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide initialization failed RuntimeError: Out of bounds memory access (evaluating '_PyRun_SimpleString(r)')\n\nRuntimeError: Out of bounds memory access (evaluating '_PyRun_SimpleString(r)')\n\nBun v1.2.14 (Linux x64 baseline)"
         ]
       },
       "format": "turtle",
-      "isomorphism": {
-        "ts_pipeline_vs_ts_plugin": true
-      },
+      "isomorphism": {},
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
       "metadata_attributes": {
         "baseUri": "ontology://generated-from-draw-io/mock#",
@@ -3266,18 +3272,7 @@
         "ontology_iri": "mock://debug-ontology"
       },
       "preamble": [],
-      "results": {
-        "ts_pipeline": {
-          "nt_sha256": "fce56fc617d44f626db710b26ce033905d329b143a6e2ab8cd5af12686f33d36",
-          "path": "results/pytest-aa37-department-of-health-with-metadata-preserve-html/ts_pipeline.ttl",
-          "triples": 72
-        },
-        "ts_plugin": {
-          "nt_sha256": "fce56fc617d44f626db710b26ce033905d329b143a6e2ab8cd5af12686f33d36",
-          "path": "results/pytest-aa37-department-of-health-with-metadata-preserve-html/ts_plugin.ttl",
-          "triples": 72
-        }
-      }
+      "results": {}
     },
     "pytest-aa37-department-of-health-with-metadata-rml": {
       "cell_classifications": {
@@ -3770,7 +3765,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata-rml.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata-rml.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -3792,14 +3787,14 @@
       "preamble": [],
       "results": {
         "ts_pipeline": {
-          "nt_sha256": "f2654222660b9895ef41f90784489377313a555d75a809db5023e456a13837a3",
+          "nt_sha256": "cecdddfd7a2d0ca474bc1b10084ae87fb68a7cf5fc68595ff925f78d221c356d",
           "path": "results/pytest-aa37-department-of-health-with-metadata-rml/ts_pipeline.ttl",
-          "triples": 73
+          "triples": 88
         },
         "ts_plugin": {
-          "nt_sha256": "fce56fc617d44f626db710b26ce033905d329b143a6e2ab8cd5af12686f33d36",
+          "nt_sha256": "e647ba9d0fc62fd6acb7f5f14a43f795c16b3e8d957ec1fba4a64f00ed692645",
           "path": "results/pytest-aa37-department-of-health-with-metadata-rml/ts_plugin.ttl",
-          "triples": 72
+          "triples": 87
         }
       }
     },
@@ -4406,23 +4401,17 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
           "ParseException: Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'"
-        ],
-        "ts_pipeline": [
-          "TypeScript pipeline graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2322, in _build_graph_from_raw_xml\n    graph = serialise_to_graph(\n        blocks,\n    ...<5 lines>...\n        graph_kwargs={\"csv_path\": csv_path},\n    )\n  File \"/app/legacy/draw_io_parser.py\", line 2451, in serialise_to_graph\n    raise ParseException(f\"Prefix IRI '{uri}' looks invalid\")\ndraw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid\n\n       type: \"xml_data_core.ParseException\",\n __error_address: 18528368,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2322, in _build_graph_from_raw_xml\n    graph = serialise_to_graph(\n        blocks,\n    ...<5 lines>...\n        graph_kwargs={\"csv_path\": csv_path},\n    )\n  File \"/app/legacy/draw_io_parser.py\", line 2451, in serialise_to_graph\n    raise ParseException(f\"Prefix IRI '{uri}' looks invalid\")\ndraw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid\n\n       type: \"xml_data_core.ParseException\",\n __error_address: 18528368,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
-        ],
-        "ts_plugin": [
-          "TypeScript plugin graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2322, in _build_graph_from_raw_xml\n    graph = serialise_to_graph(\n        blocks,\n    ...<5 lines>...\n        graph_kwargs={\"csv_path\": csv_path},\n    )\n  File \"/app/legacy/draw_io_parser.py\", line 2451, in serialise_to_graph\n    raise ParseException(f\"Prefix IRI '{uri}' looks invalid\")\ndraw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid\n\n       type: \"xml_data_core.ParseException\",\n __error_address: 18528368,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2322, in _build_graph_from_raw_xml\n    graph = serialise_to_graph(\n        blocks,\n    ...<5 lines>...\n        graph_kwargs={\"csv_path\": csv_path},\n    )\n  File \"/app/legacy/draw_io_parser.py\", line 2451, in serialise_to_graph\n    raise ParseException(f\"Prefix IRI '{uri}' looks invalid\")\ndraw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid\n\n       type: \"xml_data_core.ParseException\",\n __error_address: 18528368,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
         ]
       },
       "format": "turtle",
-      "isomorphism": {},
+      "isomorphism": {
+        "ts_pipeline_vs_ts_plugin": true
+      },
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
       "metadata_attributes": {
         "baseUri": "ontology://generated-from-draw-io/mock#",
@@ -4432,7 +4421,18 @@
         "ontology_iri": "mock://debug-ontology"
       },
       "preamble": [],
-      "results": {}
+      "results": {
+        "ts_pipeline": {
+          "nt_sha256": "e623e99c03cc11de02240441f5e6980d566a37e377e6df1bc87b3af2d716c757",
+          "path": "results/pytest-aa37-with-metadata-even-more-severely-mocked/ts_pipeline.ttl",
+          "triples": 107
+        },
+        "ts_plugin": {
+          "nt_sha256": "e623e99c03cc11de02240441f5e6980d566a37e377e6df1bc87b3af2d716c757",
+          "path": "results/pytest-aa37-with-metadata-even-more-severely-mocked/ts_plugin.ttl",
+          "triples": 107
+        }
+      }
     },
     "pytest-aa37-with-metadata-severely-mocked": {
       "cell_classifications": {
@@ -4963,7 +4963,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -4971,11 +4971,11 @@
         ],
         "ts_pipeline": [
           "TypeScript pipeline graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 18851768,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 18851768,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21608552,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21608552,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ],
         "ts_plugin": [
           "TypeScript plugin graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 18851768,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 18851768,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21608552,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"picoL\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'picoL:' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 21608552,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ]
       },
       "format": "turtle",
@@ -5632,7 +5632,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA42 Ministry of Health.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA42 Ministry of Health.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -5650,19 +5650,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "3b246c934862ea5675dd8436696fd9b95bbe3af0979fb77a0844ec069b5c0dfc",
+          "nt_sha256": "6fd06439bfb24128894beef061aaa6f575f276c5362badcc230a2a74a85a4750",
           "path": "results/pytest-aa42-ministry-of-health/py_legacy.ttl",
           "triples": 108
         },
         "ts_pipeline": {
-          "nt_sha256": "08739f9755a9cb4b6d2d3b0e78f85d327375ce341b6a2b3d73ee06b88507bc5f",
+          "nt_sha256": "6fd06439bfb24128894beef061aaa6f575f276c5362badcc230a2a74a85a4750",
           "path": "results/pytest-aa42-ministry-of-health/ts_pipeline.ttl",
-          "triples": 93
+          "triples": 108
         },
         "ts_plugin": {
-          "nt_sha256": "08739f9755a9cb4b6d2d3b0e78f85d327375ce341b6a2b3d73ee06b88507bc5f",
+          "nt_sha256": "6fd06439bfb24128894beef061aaa6f575f276c5362badcc230a2a74a85a4750",
           "path": "results/pytest-aa42-ministry-of-health/ts_plugin.ttl",
-          "triples": 93
+          "triples": 108
         }
       }
     },
@@ -6107,11 +6107,11 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/BA619 Walkerton Inquiry.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/BA619 Walkerton Inquiry.drawio",
       "format": "turtle",
       "isomorphism": {
-        "py_legacy_vs_ts_pipeline": false,
-        "py_legacy_vs_ts_plugin": false,
+        "py_legacy_vs_ts_pipeline": true,
+        "py_legacy_vs_ts_plugin": true,
         "ts_pipeline_vs_ts_plugin": true
       },
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
@@ -6125,19 +6125,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "fecc19f23903b2b62cde94b6bcadc86632dc5f9561538e28dba7a3bb3d252eb1",
+          "nt_sha256": "d036731df1a0d1f48b0d7a2e6adac1d313be50204b2bbd5cec4b4976db0bf6aa",
           "path": "results/pytest-ba619-walkerton-inquiry/py_legacy.ttl",
           "triples": 79
         },
         "ts_pipeline": {
-          "nt_sha256": "a0b0e86fb7d4da4952725ca7e06ef833ad2c81d7908291816edc40e8015d5694",
+          "nt_sha256": "d036731df1a0d1f48b0d7a2e6adac1d313be50204b2bbd5cec4b4976db0bf6aa",
           "path": "results/pytest-ba619-walkerton-inquiry/ts_pipeline.ttl",
-          "triples": 59
+          "triples": 79
         },
         "ts_plugin": {
-          "nt_sha256": "a0b0e86fb7d4da4952725ca7e06ef833ad2c81d7908291816edc40e8015d5694",
+          "nt_sha256": "d036731df1a0d1f48b0d7a2e6adac1d313be50204b2bbd5cec4b4976db0bf6aa",
           "path": "results/pytest-ba619-walkerton-inquiry/ts_plugin.ttl",
-          "triples": 59
+          "triples": 79
         }
       }
     },
@@ -6689,7 +6689,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/CA1853 Chest Disease Service.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/CA1853 Chest Disease Service.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -6707,19 +6707,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "1d87b3d92ce7e6467cdbbe728e85e1c2cbf6b16efbe4a60e6e04a07a12006de8",
+          "nt_sha256": "1fd6ea0e42be66ed6456919701d7624d6ca4b14ddb12b2e0f71ba3e82243e3be",
           "path": "results/pytest-ca1853-chest-disease-service/py_legacy.ttl",
           "triples": 90
         },
         "ts_pipeline": {
-          "nt_sha256": "020cff3b6ff5ff2c0d6c4b058ca8a83b5ecfc20f889c828bf0ce073ee944a73e",
+          "nt_sha256": "1fd6ea0e42be66ed6456919701d7624d6ca4b14ddb12b2e0f71ba3e82243e3be",
           "path": "results/pytest-ca1853-chest-disease-service/ts_pipeline.ttl",
-          "triples": 75
+          "triples": 90
         },
         "ts_plugin": {
-          "nt_sha256": "020cff3b6ff5ff2c0d6c4b058ca8a83b5ecfc20f889c828bf0ce073ee944a73e",
+          "nt_sha256": "1fd6ea0e42be66ed6456919701d7624d6ca4b14ddb12b2e0f71ba3e82243e3be",
           "path": "results/pytest-ca1853-chest-disease-service/ts_plugin.ttl",
-          "triples": 75
+          "triples": 90
         }
       }
     },
@@ -7464,7 +7464,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/CA1934 Division of Tuberculosis Prevention.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/CA1934 Division of Tuberculosis Prevention.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -7482,19 +7482,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "4ecea48ab1e965defad71bcd2b7c97672f26e96799c5936dd047bfd99bb39fda",
+          "nt_sha256": "865108c4729c21af0e2b0c0c6142c475a6636a09128e34bdbd3bb9856a694887",
           "path": "results/pytest-ca1934-division-of-tuberculosis-prevention/py_legacy.ttl",
           "triples": 112
         },
         "ts_pipeline": {
-          "nt_sha256": "f8f96e1061d4b6e1e37126684fbbc01dec429f8d2ec4de9976629359e55f247c",
+          "nt_sha256": "865108c4729c21af0e2b0c0c6142c475a6636a09128e34bdbd3bb9856a694887",
           "path": "results/pytest-ca1934-division-of-tuberculosis-prevention/ts_pipeline.ttl",
-          "triples": 97
+          "triples": 112
         },
         "ts_plugin": {
-          "nt_sha256": "f8f96e1061d4b6e1e37126684fbbc01dec429f8d2ec4de9976629359e55f247c",
+          "nt_sha256": "865108c4729c21af0e2b0c0c6142c475a6636a09128e34bdbd3bb9856a694887",
           "path": "results/pytest-ca1934-division-of-tuberculosis-prevention/ts_plugin.ttl",
-          "triples": 97
+          "triples": 112
         }
       }
     },
@@ -7836,7 +7836,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -7854,19 +7854,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "7d83dc2dfb497e1a59f2616d3207513d6f2743b808354a55219128076f66ad5c",
+          "nt_sha256": "3eddf9b5fedca53ae8c63357d90c0886f082ae7dbb77e3322db2b9d7058f5fb0",
           "path": "results/pytest-f-47-11-1-0-1/py_legacy.ttl",
           "triples": 65
         },
         "ts_pipeline": {
-          "nt_sha256": "c77461db2e086c9b9eb1fcadcd347d779d4b84d71aff92ff705dd0b5912bcb21",
+          "nt_sha256": "3eddf9b5fedca53ae8c63357d90c0886f082ae7dbb77e3322db2b9d7058f5fb0",
           "path": "results/pytest-f-47-11-1-0-1/ts_pipeline.ttl",
-          "triples": 50
+          "triples": 65
         },
         "ts_plugin": {
-          "nt_sha256": "c77461db2e086c9b9eb1fcadcd347d779d4b84d71aff92ff705dd0b5912bcb21",
+          "nt_sha256": "3eddf9b5fedca53ae8c63357d90c0886f082ae7dbb77e3322db2b9d7058f5fb0",
           "path": "results/pytest-f-47-11-1-0-1/ts_plugin.ttl",
-          "triples": 50
+          "triples": 65
         }
       }
     },
@@ -8457,7 +8457,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1 (VDB test).drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1 (VDB test).drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -8475,19 +8475,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "2d5689ebb0fc43ed63239da3de516825a2870b3362485a2e276a958f90f3d5e2",
+          "nt_sha256": "72489c883f568a345875fb805e31cdc3c0f30b531e1826c94fab28f429fda972",
           "path": "results/pytest-f-47-11-1-0-1-vdb-test/py_legacy.ttl",
           "triples": 101
         },
         "ts_pipeline": {
-          "nt_sha256": "8d485384fbeaa9ceac39879032fb19dca06b8491c139f06f018d8fc9f58a1ef1",
+          "nt_sha256": "72489c883f568a345875fb805e31cdc3c0f30b531e1826c94fab28f429fda972",
           "path": "results/pytest-f-47-11-1-0-1-vdb-test/ts_pipeline.ttl",
-          "triples": 86
+          "triples": 101
         },
         "ts_plugin": {
-          "nt_sha256": "8d485384fbeaa9ceac39879032fb19dca06b8491c139f06f018d8fc9f58a1ef1",
+          "nt_sha256": "72489c883f568a345875fb805e31cdc3c0f30b531e1826c94fab28f429fda972",
           "path": "results/pytest-f-47-11-1-0-1-vdb-test/ts_plugin.ttl",
-          "triples": 86
+          "triples": 101
         }
       }
     },
@@ -9055,7 +9055,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-1 Elizabeth Simcoe loose sketches.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-1 Elizabeth Simcoe loose sketches.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -9073,19 +9073,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "c3b89867943272de844d89c43580708953cfb2e0e9f2d142f728d433ba62b46c",
+          "nt_sha256": "82ee4d64dca10f013758ce0ae5221a71afe5db44c0e614f4617ef29761346640",
           "path": "results/pytest-f-47-11-1-elizabeth-simcoe-loose-sketches/py_legacy.ttl",
           "triples": 90
         },
         "ts_pipeline": {
-          "nt_sha256": "d4a1416f3fab98f5eec6e58efe16b3ae8e4513eeac455e9482abd62b621dd382",
+          "nt_sha256": "82ee4d64dca10f013758ce0ae5221a71afe5db44c0e614f4617ef29761346640",
           "path": "results/pytest-f-47-11-1-elizabeth-simcoe-loose-sketches/ts_pipeline.ttl",
-          "triples": 75
+          "triples": 90
         },
         "ts_plugin": {
-          "nt_sha256": "d4a1416f3fab98f5eec6e58efe16b3ae8e4513eeac455e9482abd62b621dd382",
+          "nt_sha256": "82ee4d64dca10f013758ce0ae5221a71afe5db44c0e614f4617ef29761346640",
           "path": "results/pytest-f-47-11-1-elizabeth-simcoe-loose-sketches/ts_plugin.ttl",
-          "triples": 75
+          "triples": 90
         }
       }
     },
@@ -9625,7 +9625,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-2 Elizabeth Simcoe sketchbook.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-2 Elizabeth Simcoe sketchbook.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -9643,19 +9643,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "ccc0f388cf8ecb18fecf37bc70676604e0d6d7f08a12c21d272701f492e21ed8",
+          "nt_sha256": "ec4b0821d05210b0c46752d6cf179f02253fc753bf6c33b57f1fed229c04bb61",
           "path": "results/pytest-f-47-11-2-elizabeth-simcoe-sketchbook/py_legacy.ttl",
           "triples": 88
         },
         "ts_pipeline": {
-          "nt_sha256": "a94903ff83833335691d4a1cdde450356238fd8b5d5fb109c555ed7d9d025ebf",
+          "nt_sha256": "ec4b0821d05210b0c46752d6cf179f02253fc753bf6c33b57f1fed229c04bb61",
           "path": "results/pytest-f-47-11-2-elizabeth-simcoe-sketchbook/ts_pipeline.ttl",
-          "triples": 73
+          "triples": 88
         },
         "ts_plugin": {
-          "nt_sha256": "a94903ff83833335691d4a1cdde450356238fd8b5d5fb109c555ed7d9d025ebf",
+          "nt_sha256": "ec4b0821d05210b0c46752d6cf179f02253fc753bf6c33b57f1fed229c04bb61",
           "path": "results/pytest-f-47-11-2-elizabeth-simcoe-sketchbook/ts_plugin.ttl",
-          "triples": 73
+          "triples": 88
         }
       }
     },
@@ -10209,7 +10209,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -10227,19 +10227,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "10634f1ac671ca4a3a1945af7f674ecf14f8dfb6ac48a61127e53eaafac535bd",
+          "nt_sha256": "e9d9d87e584c179df78e08853757e88b2d8c0a957d97feb79a6e8afbc431960e",
           "path": "results/pytest-f-47-11-3-elizabeth-simcoe-miscellaneous-sketches-and-fragments/py_legacy.ttl",
           "triples": 89
         },
         "ts_pipeline": {
-          "nt_sha256": "dec1818deafae2676b72f667121ec327b256c6142396a1708c5407b8ee3767ba",
+          "nt_sha256": "e9d9d87e584c179df78e08853757e88b2d8c0a957d97feb79a6e8afbc431960e",
           "path": "results/pytest-f-47-11-3-elizabeth-simcoe-miscellaneous-sketches-and-fragments/ts_pipeline.ttl",
-          "triples": 74
+          "triples": 89
         },
         "ts_plugin": {
-          "nt_sha256": "dec1818deafae2676b72f667121ec327b256c6142396a1708c5407b8ee3767ba",
+          "nt_sha256": "e9d9d87e584c179df78e08853757e88b2d8c0a957d97feb79a6e8afbc431960e",
           "path": "results/pytest-f-47-11-3-elizabeth-simcoe-miscellaneous-sketches-and-fragments/ts_plugin.ttl",
-          "triples": 74
+          "triples": 89
         }
       }
     },
@@ -10804,7 +10804,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -10822,19 +10822,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "f35121c58e9f4ecaf2eb3b56e0be03ae3e0210efe363069bbec69d956582245f",
+          "nt_sha256": "3aa5aefe7c445be7d54f7210d697eea796c936e8c49dadb83b9f0b686acefdb0",
           "path": "results/pytest-f-47-11-4-notes-on-elizabeth-simcoe-sketches/py_legacy.ttl",
           "triples": 92
         },
         "ts_pipeline": {
-          "nt_sha256": "f5109f278fdd106c33f3a7fc101a59374954bb41fc4fc0d6775641a892faeefe",
+          "nt_sha256": "3aa5aefe7c445be7d54f7210d697eea796c936e8c49dadb83b9f0b686acefdb0",
           "path": "results/pytest-f-47-11-4-notes-on-elizabeth-simcoe-sketches/ts_pipeline.ttl",
-          "triples": 77
+          "triples": 92
         },
         "ts_plugin": {
-          "nt_sha256": "f5109f278fdd106c33f3a7fc101a59374954bb41fc4fc0d6775641a892faeefe",
+          "nt_sha256": "3aa5aefe7c445be7d54f7210d697eea796c936e8c49dadb83b9f0b686acefdb0",
           "path": "results/pytest-f-47-11-4-notes-on-elizabeth-simcoe-sketches/ts_plugin.ttl",
-          "triples": 77
+          "triples": 92
         }
       }
     },
@@ -11463,7 +11463,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11 Elizabeth Simcoe sketches.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47-11 Elizabeth Simcoe sketches.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -11481,19 +11481,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "1da2ee06f48119f2623c2a207361496d73a8ecafb5dc0afdfa8904f4569d903f",
+          "nt_sha256": "7a2b1647c49dbdcb2977b54b8a567874836008076843c4f8eb64f52f00f4dc8d",
           "path": "results/pytest-f-47-11-elizabeth-simcoe-sketches/py_legacy.ttl",
           "triples": 101
         },
         "ts_pipeline": {
-          "nt_sha256": "e2200138384e595f9d3dc987bce53b474a881582776a40a0bc5b992438828454",
+          "nt_sha256": "7a2b1647c49dbdcb2977b54b8a567874836008076843c4f8eb64f52f00f4dc8d",
           "path": "results/pytest-f-47-11-elizabeth-simcoe-sketches/ts_pipeline.ttl",
-          "triples": 86
+          "triples": 101
         },
         "ts_plugin": {
-          "nt_sha256": "e2200138384e595f9d3dc987bce53b474a881582776a40a0bc5b992438828454",
+          "nt_sha256": "7a2b1647c49dbdcb2977b54b8a567874836008076843c4f8eb64f52f00f4dc8d",
           "path": "results/pytest-f-47-11-elizabeth-simcoe-sketches/ts_plugin.ttl",
-          "triples": 86
+          "triples": 101
         }
       }
     },
@@ -12267,7 +12267,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47 Simcoe Family fonds.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 47 Simcoe Family fonds.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -12285,19 +12285,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "ab46413883f06dbf869cd74edac3a92135f686679ed2d21a30440b3df4fce9f8",
+          "nt_sha256": "3d7d4f309932eccd66ee0834c3d533bd012b0bdf8c866427229a297fc75bd157",
           "path": "results/pytest-f-47-simcoe-family-fonds/py_legacy.ttl",
           "triples": 118
         },
         "ts_pipeline": {
-          "nt_sha256": "21e23dfdf69d00bb33dd84fad26f90cffc336e0e870e0b07992ebc8fb55d490e",
+          "nt_sha256": "3d7d4f309932eccd66ee0834c3d533bd012b0bdf8c866427229a297fc75bd157",
           "path": "results/pytest-f-47-simcoe-family-fonds/ts_pipeline.ttl",
-          "triples": 103
+          "triples": 118
         },
         "ts_plugin": {
-          "nt_sha256": "21e23dfdf69d00bb33dd84fad26f90cffc336e0e870e0b07992ebc8fb55d490e",
+          "nt_sha256": "3d7d4f309932eccd66ee0834c3d533bd012b0bdf8c866427229a297fc75bd157",
           "path": "results/pytest-f-47-simcoe-family-fonds/ts_plugin.ttl",
-          "triples": 103
+          "triples": 118
         }
       }
     },
@@ -13160,11 +13160,11 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 4711 Orville Wood fonds.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 4711 Orville Wood fonds.drawio",
       "format": "turtle",
       "isomorphism": {
-        "py_legacy_vs_ts_pipeline": false,
-        "py_legacy_vs_ts_plugin": false,
+        "py_legacy_vs_ts_pipeline": true,
+        "py_legacy_vs_ts_plugin": true,
         "ts_pipeline_vs_ts_plugin": true
       },
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
@@ -13178,19 +13178,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "479fe1452b058998510ffeb0cb5e1d89831ad76e40d8d7b3ee2ed2c1d7a469b5",
+          "nt_sha256": "cfac9579dc9051042f769457eea64a4b6fe007d6bfe92e9f543d530a2d933418",
           "path": "results/pytest-f-4711-orville-wood-fonds/py_legacy.ttl",
           "triples": 141
         },
         "ts_pipeline": {
-          "nt_sha256": "35adf8135f89acfc2c5ef5543e410b26b72503234f1fac50708983ccbe1482bb",
+          "nt_sha256": "cfac9579dc9051042f769457eea64a4b6fe007d6bfe92e9f543d530a2d933418",
           "path": "results/pytest-f-4711-orville-wood-fonds/ts_pipeline.ttl",
-          "triples": 107
+          "triples": 141
         },
         "ts_plugin": {
-          "nt_sha256": "35adf8135f89acfc2c5ef5543e410b26b72503234f1fac50708983ccbe1482bb",
+          "nt_sha256": "cfac9579dc9051042f769457eea64a4b6fe007d6bfe92e9f543d530a2d933418",
           "path": "results/pytest-f-4711-orville-wood-fonds/ts_plugin.ttl",
-          "triples": 107
+          "triples": 141
         }
       }
     },
@@ -14349,7 +14349,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -14367,19 +14367,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "cd19e67fc7ea081305fd50187337db3862aafdccc3c051622d4f6c9efbc66ee6",
+          "nt_sha256": "f289044225903f3659a58771e7a4c6133ca304f2289d18bbc06145ef8c13a373",
           "path": "results/pytest-general-add-descriptions-and-listings-to-ric-o-model-2025-06-20-pz/py_legacy.ttl",
           "triples": 147
         },
         "ts_pipeline": {
-          "nt_sha256": "c1e4afff669b5fa18aac460ad602374a5a03b791525705d31f044e75822381c5",
+          "nt_sha256": "f289044225903f3659a58771e7a4c6133ca304f2289d18bbc06145ef8c13a373",
           "path": "results/pytest-general-add-descriptions-and-listings-to-ric-o-model-2025-06-20-pz/ts_pipeline.ttl",
-          "triples": 143
+          "triples": 147
         },
         "ts_plugin": {
-          "nt_sha256": "c1e4afff669b5fa18aac460ad602374a5a03b791525705d31f044e75822381c5",
+          "nt_sha256": "f289044225903f3659a58771e7a4c6133ca304f2289d18bbc06145ef8c13a373",
           "path": "results/pytest-general-add-descriptions-and-listings-to-ric-o-model-2025-06-20-pz/ts_plugin.ttl",
-          "triples": 143
+          "triples": 147
         }
       }
     },
@@ -15348,7 +15348,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/General_Authority_bleep_mock.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/General_Authority_bleep_mock.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -15356,11 +15356,11 @@
         ],
         "ts_pipeline": [
           "TypeScript pipeline graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23329808,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23329808,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 20809776,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 20809776,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ],
         "ts_plugin": [
           "TypeScript plugin graph is None",
-          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23329808,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2233, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2314, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2235, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 23329808,\n\n      at new PythonError (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.21 (macOS arm64)"
+          "RuntimeError: Bun scenario execution failed: [PIPELINE] Pyodide DrawIO parser invocation failed 3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 20809776,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\n3 |   var _scriptName = typeof document != 'undefined' ? document.currentScript?.src : undefined;\n4 |   return (\n5 | async function(moduleArg = {}) {\n6 |   var moduleRtn;\n7 | \n8 | var Module=moduleArg;var readyPromiseResolve,readyPromiseReject;var readyPromise=new Promise((resolve,reject)=>{readyPromiseResolve=resolve;readyPromiseReject=reject});var ENVIRONMENT_IS_WEB=typeof window==\"object\";var ENVIRONMENT_IS_WORKER=typeof WorkerGlobalScope!=\"undefined\";var ENVIRONMENT_IS_NODE=typeof process==\"object\"&&process.versions?.node&&process.type!=\"renderer\";var ENVIRONMENT_IS_SHELL=!ENVIRONMENT_IS_WEB&&!ENVIRONMENT_IS_NODE&&!ENVIRONMENT_IS_WORKER;if(ENVIRONMENT_IS_NODE){}var arguments_=[];var thisProgram=\"./this.program\";var quit_=(status,toThrow)=>{throw toThrow};if(typeof __filename!=\"undefined\"){_scriptName=__filename}else if(ENVIRONMENT_IS_WORKER){_scriptName=self.location.href}var scriptDirectory=\"\";function locateFile(path){if(Module[\"locateFile\"]){return Module[\"locateFile\"](path,scriptDirectory)}return scriptDirectory+path}var readAsync,readBinary;if(ENVIRONMENT_IS_NODE){var fs=require(\"fs\");var nodePath=require(\"path\");scriptDirectory=__dirname+\"/\";readBinary=filename=>{filename=isF\n\nPythonError: Traceback (most recent call last):\n  File \"/app/legacy/draw_io_parser.py\", line 2434, in individual_blocks\n    manager.expand_curie(literal_candidate)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^\n  File \"/app/packages/rdflib/namespace/__init__.py\", line 726, in expand_curie\n    raise ValueError(\n        f\"Prefix \\\"{curie.split(':')[0]}\\\" not bound to any namespace.\"\n    )\nValueError: Prefix \"bleep\" not bound to any namespace.\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 597, in eval_code_async\n    await CodeRunner(\n    ...<9 lines>...\n    .run_async(globals, locals)\n  File \"/lib/python313.zip/_pyodide/_base.py\", line 411, in run_async\n    coroutine = eval(self.code, globals, locals)\n  File \"<exec>\", line 3, in <module>\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 312, in parse_drawio_xml_to_json\n    graph_id, graph = parse_drawio_xml(serialized_xml, parser_config)\n                      ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/app/pyodide_pipeline/drawio_pipeline.py\", line 303, in parse_drawio_xml\n    graph = _build_graph_from_raw_xml(normalized_xml, config)\n  File \"/app/legacy/draw_io_parser.py\", line 2548, in _build_graph_from_raw_xml\n    internal_control_core.individual_blocks(\n    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^\n        classifier.get_graph_elements(),\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n        prefixes,\n        ^^^^^^^^^\n    )\n    ^\n  File \"/app/legacy/draw_io_parser.py\", line 2436, in individual_blocks\n    raise NotInKnownException(\n        f\"The literal value '{literal_candidate}' does not correspond to a known CURIE\"\n    ) from exc\ndraw_io_parser.rdf_data_core.NotInKnownException: The literal value 'bleep:RecordState' does not correspond to a known CURIE\n\n       type: \"rdf_data_core.NotInKnownException\",\n __error_address: 20809776,\n\n      at new PythonError (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:620533)\n      at new_error (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:578922)\n      at callPyObjectKwargs (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:632622)\n      at <anonymous> (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:633781)\n      at wrapper (/workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/pyodide.asm.js:8:596545)\n\nBun v1.2.14 (Linux x64 baseline)"
         ]
       },
       "format": "turtle",
@@ -16328,11 +16328,11 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/General Authority to RiC-O Model_2025-06-25_PZ.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/General Authority to RiC-O Model_2025-06-25_PZ.drawio",
       "format": "turtle",
       "isomorphism": {
-        "py_legacy_vs_ts_pipeline": false,
-        "py_legacy_vs_ts_plugin": false,
+        "py_legacy_vs_ts_pipeline": true,
+        "py_legacy_vs_ts_plugin": true,
         "ts_pipeline_vs_ts_plugin": true
       },
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
@@ -16346,19 +16346,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "b9c76e52f29cf04f712638884e45d01e9ce6e322a72aa187707f7dc91e0f0db1",
+          "nt_sha256": "a00cf8a446c92ca60c6ca9fbd2f6a21b31b0211b057b865aa3caee0691d8cdb2",
           "path": "results/pytest-general-authority-to-ric-o-model-2025-06-25-pz/py_legacy.ttl",
           "triples": 147
         },
         "ts_pipeline": {
-          "nt_sha256": "68b4cafd3151be4e995d466d612ee79b375f4e1b33cd505c64e4a4c38c4bf013",
+          "nt_sha256": "a00cf8a446c92ca60c6ca9fbd2f6a21b31b0211b057b865aa3caee0691d8cdb2",
           "path": "results/pytest-general-authority-to-ric-o-model-2025-06-25-pz/ts_pipeline.ttl",
-          "triples": 136
+          "triples": 147
         },
         "ts_plugin": {
-          "nt_sha256": "68b4cafd3151be4e995d466d612ee79b375f4e1b33cd505c64e4a4c38c4bf013",
+          "nt_sha256": "a00cf8a446c92ca60c6ca9fbd2f6a21b31b0211b057b865aa3caee0691d8cdb2",
           "path": "results/pytest-general-authority-to-ric-o-model-2025-06-25-pz/ts_plugin.ttl",
-          "triples": 136
+          "triples": 147
         }
       }
     },
@@ -16958,7 +16958,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/knut_olborgs_forskningsnotater.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/knut_olborgs_forskningsnotater.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -16980,14 +16980,14 @@
       "preamble": [],
       "results": {
         "ts_pipeline": {
-          "nt_sha256": "543741d03eefdd45e99dfa4097ceb69a8f933273f570ad45a31e0ed8e2ab8350",
+          "nt_sha256": "a41cd1c4917f2c8102c0c82adb6c40ae897d9b78309f6d62037d29685f35ecdb",
           "path": "results/pytest-knut-olborgs-forskningsnotater/ts_pipeline.ttl",
-          "triples": 98
+          "triples": 113
         },
         "ts_plugin": {
-          "nt_sha256": "543741d03eefdd45e99dfa4097ceb69a8f933273f570ad45a31e0ed8e2ab8350",
+          "nt_sha256": "a41cd1c4917f2c8102c0c82adb6c40ae897d9b78309f6d62037d29685f35ecdb",
           "path": "results/pytest-knut-olborgs-forskningsnotater/ts_plugin.ttl",
-          "triples": 98
+          "triples": 113
         }
       }
     },
@@ -17405,7 +17405,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/koronakommisjonen.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/koronakommisjonen.drawio",
       "errors": {
         "py_legacy": [
           "Legacy Python graph is None",
@@ -17427,14 +17427,14 @@
       "preamble": [],
       "results": {
         "ts_pipeline": {
-          "nt_sha256": "add6e6a02b4c8b88de74a28b1573cb39d6702e6ef5f8e940fb28c21f1db28bec",
+          "nt_sha256": "127e28af247aabdd8dc8c84af4c227af3cb3b920010d949dcedaaa87c2a9847e",
           "path": "results/pytest-koronakommisjonen/ts_pipeline.ttl",
-          "triples": 69
+          "triples": 84
         },
         "ts_plugin": {
-          "nt_sha256": "add6e6a02b4c8b88de74a28b1573cb39d6702e6ef5f8e940fb28c21f1db28bec",
+          "nt_sha256": "127e28af247aabdd8dc8c84af4c227af3cb3b920010d949dcedaaa87c2a9847e",
           "path": "results/pytest-koronakommisjonen/ts_plugin.ttl",
-          "triples": 69
+          "triples": 84
         }
       }
     },
@@ -17787,11 +17787,11 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio",
       "format": "turtle",
       "isomorphism": {
-        "py_legacy_vs_ts_pipeline": false,
-        "py_legacy_vs_ts_plugin": false,
+        "py_legacy_vs_ts_pipeline": true,
+        "py_legacy_vs_ts_plugin": true,
         "ts_pipeline_vs_ts_plugin": true
       },
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
@@ -17805,19 +17805,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "6fe69e40acc069e42cfa1032072ad89132ec7241aa9beacf093da85b0a484075",
+          "nt_sha256": "bc9d347f01240fa27cc3fe685132510a4d4fce5b0e7763dcc29d22d4630b0b6c",
           "path": "results/pytest-rg-1-659-northern-pike-lamprey-mark-rondeau-park-april-20-1955/py_legacy.ttl",
           "triples": 68
         },
         "ts_pipeline": {
-          "nt_sha256": "b6110762a000dfdb5fdc068ca9cab783cdc017cfd2cd05b648a34e951c6d6104",
+          "nt_sha256": "bc9d347f01240fa27cc3fe685132510a4d4fce5b0e7763dcc29d22d4630b0b6c",
           "path": "results/pytest-rg-1-659-northern-pike-lamprey-mark-rondeau-park-april-20-1955/ts_pipeline.ttl",
-          "triples": 52
+          "triples": 68
         },
         "ts_plugin": {
-          "nt_sha256": "b6110762a000dfdb5fdc068ca9cab783cdc017cfd2cd05b648a34e951c6d6104",
+          "nt_sha256": "bc9d347f01240fa27cc3fe685132510a4d4fce5b0e7763dcc29d22d4630b0b6c",
           "path": "results/pytest-rg-1-659-northern-pike-lamprey-mark-rondeau-park-april-20-1955/ts_plugin.ttl",
-          "triples": 52
+          "triples": 68
         }
       }
     },
@@ -18496,7 +18496,7 @@
           ]
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -18514,19 +18514,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "d5061ddb127cac297191ab313036b5c6d83506247c7d0476147db85ddee0e3dc",
+          "nt_sha256": "5b20a61c35697cf2376e89c7d825919cc8082fda827ad935eec55d43d0cce631",
           "path": "results/pytest-rg-10-142-correspondence-of-the-chief-of-the-chest-disease-service/py_legacy.ttl",
           "triples": 103
         },
         "ts_pipeline": {
-          "nt_sha256": "5073b7891d8853e74e9a7ad895f0e753bc7fb8050f3e0e70620230a2cb1609c5",
+          "nt_sha256": "5b20a61c35697cf2376e89c7d825919cc8082fda827ad935eec55d43d0cce631",
           "path": "results/pytest-rg-10-142-correspondence-of-the-chief-of-the-chest-disease-service/ts_pipeline.ttl",
-          "triples": 88
+          "triples": 103
         },
         "ts_plugin": {
-          "nt_sha256": "5073b7891d8853e74e9a7ad895f0e753bc7fb8050f3e0e70620230a2cb1609c5",
+          "nt_sha256": "5b20a61c35697cf2376e89c7d825919cc8082fda827ad935eec55d43d0cce631",
           "path": "results/pytest-rg-10-142-correspondence-of-the-chief-of-the-chest-disease-service/ts_plugin.ttl",
-          "triples": 88
+          "triples": 103
         }
       }
     },
@@ -18988,7 +18988,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -19006,19 +19006,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "2a4fb11a64703e2cf79384fdff06b2ba8d587b14d8fa518329b85dff17910d11",
+          "nt_sha256": "fdd6e86fe41ea377ea424debc922851afa102fa348a23f051c9bb8711de1469c",
           "path": "results/pytest-rg-10-145-mobile-tuberculosis-testing-clinic-photographs/py_legacy.ttl",
           "triples": 78
         },
         "ts_pipeline": {
-          "nt_sha256": "12b243a0d490d50be262e4e4ba014a31f7bac5fd5558fefea095d57b51e374b8",
+          "nt_sha256": "fdd6e86fe41ea377ea424debc922851afa102fa348a23f051c9bb8711de1469c",
           "path": "results/pytest-rg-10-145-mobile-tuberculosis-testing-clinic-photographs/ts_pipeline.ttl",
-          "triples": 63
+          "triples": 78
         },
         "ts_plugin": {
-          "nt_sha256": "12b243a0d490d50be262e4e4ba014a31f7bac5fd5558fefea095d57b51e374b8",
+          "nt_sha256": "fdd6e86fe41ea377ea424debc922851afa102fa348a23f051c9bb8711de1469c",
           "path": "results/pytest-rg-10-145-mobile-tuberculosis-testing-clinic-photographs/ts_plugin.ttl",
-          "triples": 63
+          "triples": 78
         }
       }
     },
@@ -19715,7 +19715,7 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio",
       "format": "turtle",
       "isomorphism": {
         "py_legacy_vs_ts_pipeline": true,
@@ -19733,19 +19733,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "b79332c9d459e3fdd9a078c2cda0624a013e35068a3998757ff406aec5d59f22",
+          "nt_sha256": "e1f62d85851c3d7582661761a38006e3a7e570062e0813568f90318521aa23fc",
           "path": "results/pytest-rg-18-210-records-of-the-walkerton-inquiry-revised-to-add-mapping/py_legacy.ttl",
           "triples": 113
         },
         "ts_pipeline": {
-          "nt_sha256": "3d69c1c663882240fa821add721372f27550b1249b8184fde365cff56e18af96",
+          "nt_sha256": "e1f62d85851c3d7582661761a38006e3a7e570062e0813568f90318521aa23fc",
           "path": "results/pytest-rg-18-210-records-of-the-walkerton-inquiry-revised-to-add-mapping/ts_pipeline.ttl",
-          "triples": 98
+          "triples": 113
         },
         "ts_plugin": {
-          "nt_sha256": "3d69c1c663882240fa821add721372f27550b1249b8184fde365cff56e18af96",
+          "nt_sha256": "e1f62d85851c3d7582661761a38006e3a7e570062e0813568f90318521aa23fc",
           "path": "results/pytest-rg-18-210-records-of-the-walkerton-inquiry-revised-to-add-mapping/ts_plugin.ttl",
-          "triples": 98
+          "triples": 113
         }
       }
     },
@@ -20876,11 +20876,11 @@
           "tokens": []
         }
       },
-      "drawio": "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Walkerton Inquiry in RiC-O (original).drawio",
+      "drawio": "/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Walkerton Inquiry in RiC-O (original).drawio",
       "format": "turtle",
       "isomorphism": {
-        "py_legacy_vs_ts_pipeline": false,
-        "py_legacy_vs_ts_plugin": false,
+        "py_legacy_vs_ts_pipeline": true,
+        "py_legacy_vs_ts_plugin": true,
         "ts_pipeline_vs_ts_plugin": true
       },
       "legacy_commit": "cf8f84bb84ff83843b6726ac96aff3a2055f4275",
@@ -20894,19 +20894,19 @@
       "preamble": [],
       "results": {
         "py_legacy": {
-          "nt_sha256": "99757e76004b6df6987eee16641dfa5bdc5a39caf66f0d8436344ef09efc339d",
+          "nt_sha256": "872fa0abe056819e4bb67e6c26f88a895640557a81924437bb3ffe9b779b391e",
           "path": "results/pytest-rg-18-210-walkerton-inquiry-in-ric-o-original/py_legacy.ttl",
           "triples": 187
         },
         "ts_pipeline": {
-          "nt_sha256": "37099e4c873ec33ebdca1fab64f4dab6da0597aae7c411abfa3ac2651c448089",
+          "nt_sha256": "872fa0abe056819e4bb67e6c26f88a895640557a81924437bb3ffe9b779b391e",
           "path": "results/pytest-rg-18-210-walkerton-inquiry-in-ric-o-original/ts_pipeline.ttl",
-          "triples": 148
+          "triples": 187
         },
         "ts_plugin": {
-          "nt_sha256": "37099e4c873ec33ebdca1fab64f4dab6da0597aae7c411abfa3ac2651c448089",
+          "nt_sha256": "872fa0abe056819e4bb67e6c26f88a895640557a81924437bb3ffe9b779b391e",
           "path": "results/pytest-rg-18-210-walkerton-inquiry-in-ric-o-original/ts_plugin.ttl",
-          "triples": 148
+          "triples": 187
         }
       }
     },

--- a/src/main/webapp/plugins/rdfexport/debug/results/f-4711-orville-wood-fonds/py_legacy.ttl
+++ b/src/main/webapp/plugins/rdfexport/debug/results/f-4711-orville-wood-fonds/py_legacy.ttl
@@ -34,157 +34,157 @@ add:privateNote a owl:DatatypeProperty .
 
 add:relatedMaterial a owl:DatatypeProperty .
 
-<ontology://generated-from-draw-io/mock> a owl:Ontology ;
+<ontology://generated-from-draw-io/2025-10-21T22-20-31> a owl:Ontology ;
     owl:imports rico: .
 
-<ontology://generated-from-draw-io/mock#Orville%20Alan%20Wood> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Alan%20Wood> a owl:NamedIndividual,
         rico:AgentName,
         rico:Person ;
     rdfs:label "Orville Alan Wood" ;
-    rico:hasBirthDate <ontology://generated-from-draw-io/mock#1912> ;
-    rico:hasBirthPlace <ontology://generated-from-draw-io/mock#South%20River%2C%20Ontario> ;
-    rico:hasDeathDate <ontology://generated-from-draw-io/mock#2006> ;
+    rico:hasBirthDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> ;
+    rico:hasBirthPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#South%20River%2C%20Ontario> ;
+    rico:hasDeathDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#2006> ;
     rico:history "Orville Wood was born in South River, Ontario, in 1912. He served in the Navy, stationed in Halifax, during World War II, after which he became president of the Fort York Construction Company Ltd. (Source note: correspondence with donor and Ancestry.ca)." ;
-    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/mock#Halifax%2C%20Nova%20Scotia> ;
-    rico:isCreatorOf <ontology://generated-from-draw-io/mock#Orville%20Wood%20Fonds> ;
-    rico:isOrWasLeaderOf <ontology://generated-from-draw-io/mock#Fort%20York%20Construction%20Company%20Ltd.> ;
-    rico:occupiesOrOccupied <ontology://generated-from-draw-io/mock#President> .
+    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> ;
+    rico:isCreatorOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Wood%20Fonds> ;
+    rico:isOrWasLeaderOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> ;
+    rico:occupiesOrOccupied <ontology://generated-from-draw-io/2025-10-21T22-20-31#President> .
 
-<ontology://generated-from-draw-io/mock#%5B194-%5D-1953> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#%5B194-%5D-1953> a owl:NamedIndividual,
         rico:Date ;
     rdfs:label "[194-]-1953" ;
     rico:normalizedDateValue "194X/1953" .
 
-<ontology://generated-from-draw-io/mock#1912> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> a owl:NamedIndividual,
         rico:Date ;
     rdfs:label "1912" .
 
-<ontology://generated-from-draw-io/mock#2006> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#2006> a owl:NamedIndividual,
         rico:Date ;
     rdfs:label "2006" .
 
-<ontology://generated-from-draw-io/mock#City> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#City> a owl:NamedIndividual,
         rico:PlaceType ;
     rdfs:label "City" .
 
-<ontology://generated-from-draw-io/mock#F%204711> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#F%204711> a owl:NamedIndividual,
         rico:Identifier ;
     rdfs:label "F 4711" ;
-    rico:hasIdentifierType <ontology://generated-from-draw-io/mock#Archives%20Of%20Ontario%20Reference%20Code> .
+    rico:hasIdentifierType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Archives%20Of%20Ontario%20Reference%20Code> .
 
-<ontology://generated-from-draw-io/mock#Fonds> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Fonds> a owl:NamedIndividual,
         rico:RecordSetType ;
     rdfs:label "Fonds" .
 
-<ontology://generated-from-draw-io/mock#Graphic%20Material> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material> a owl:NamedIndividual,
         rico:ContentType ;
     rdfs:label "Graphic material" .
 
-<ontology://generated-from-draw-io/mock#Halifax%2C%20Nova%20Scotia> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Halifax,  Nova Scotia" ;
-    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/mock#City> .
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#City> .
 
-<ontology://generated-from-draw-io/mock#Ontario> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Ontario" ;
-    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/mock#Province> .
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> .
 
-<ontology://generated-from-draw-io/mock#Orville%20Wood%20Fonds> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Wood%20Fonds> a owl:NamedIndividual,
         rico:RecordSet ;
     rdfs:label "Orville Wood fonds" ;
     rico:accruals "No further accruals are expected." ;
     rico:conditionsOfAccess "No restrictions on access." ;
     rico:conditionsOfUse "Copyright has been transferred to the Archives of Ontario   by the donor. There are no restrictions on reproduction for research and private study. If you wish to use any of this material for a purpose other than research and private study, submit a Request for Permission to Publish, Exhibit or Broadcast Form." ;
-    rico:hasCreationDate <ontology://generated-from-draw-io/mock#%5B194-%5D-1953> ;
-    rico:hasGeneticLinkToRecordResource <ontology://generated-from-draw-io/mock#Highway%20Historical%20Collection%20-%20Photographs>,
-        <ontology://generated-from-draw-io/mock#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> ;
-    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/mock#F%204711> ;
-    rico:hasOrHadSomeMembersWithContentType <ontology://generated-from-draw-io/mock#Graphic%20Material>,
-        <ontology://generated-from-draw-io/mock#Textual%20Records> ;
-    rico:hasOrHadSubject <ontology://generated-from-draw-io/mock#Atikokan%2C%20Ontario>,
-        <ontology://generated-from-draw-io/mock#Terrace%20Bay%2C%20Ontario> ;
-    rico:hasRecordSetType <ontology://generated-from-draw-io/mock#Fonds> ;
+    rico:hasCreationDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#%5B194-%5D-1953> ;
+    rico:hasGeneticLinkToRecordResource <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> ;
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#F%204711> ;
+    rico:hasOrHadSomeMembersWithContentType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Textual%20Records> ;
+    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Terrace%20Bay%2C%20Ontario> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fonds> ;
     rico:history "The Orville Wood fonds was donated to the Archives of Ontario by his son, Bruce Arthur Wood, in 2018." ;
     rico:recordResourceExtent "0.1 centimetres of textual records;   98 photographs : black and white prints;   2 photographs : colour prints;   143 photographs : black and white negatives" ;
     rico:scopeAndContent "Fonds consists primarily of photographs of the construction of the Atikokan   Highway between Shabaqua Corners and Atikokan, Ontario. The highway was later named Highway 120, and is currently designated as Highway 11. Wood's company,   Fort York Construction Company Ltd., was contracted to undertake the construction of the highway starting in 1951 and completed the work in 1953.     Fonds also includes photographs of a project undertaken by Fort York Construction Company Ltd. at Terrace Bay, Ontario.     Also included are a news clipping about Fort York Construction Company Ltd., Orville Wood's business card, photographs of an unidentified historic fort, and photographs   of Wood's family and business partners." .
 
-<ontology://generated-from-draw-io/mock#President> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#President> a owl:NamedIndividual,
         rico:Position ;
     rdfs:label "President" ;
-    rico:isOrWasOwnerOf <ontology://generated-from-draw-io/mock#Fort%20York%20Construction%20Company%20Ltd.> .
+    rico:isOrWasOwnerOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> .
 
-<ontology://generated-from-draw-io/mock#Province> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> a owl:NamedIndividual,
         rico:PlaceType ;
     rdfs:label "Province" .
 
-<ontology://generated-from-draw-io/mock#RG%2014-162-2> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-2> a owl:NamedIndividual,
         rico:Identifier ;
     rdfs:label "RG 14-162-2" ;
-    rico:hasIdentifierType <ontology://generated-from-draw-io/mock#Archives%20Of%20Ontario%20Reference%20Code> .
+    rico:hasIdentifierType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Archives%20Of%20Ontario%20Reference%20Code> .
 
-<ontology://generated-from-draw-io/mock#RG%2014-162-5> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-5> a owl:NamedIndividual,
         rico:Identifier ;
     rdfs:label "RG 14-162-5" ;
-    rico:hasIdentifierType <ontology://generated-from-draw-io/mock#Archives%20Of%20Ontario%20Reference%20Code> .
+    rico:hasIdentifierType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Archives%20Of%20Ontario%20Reference%20Code> .
 
-<ontology://generated-from-draw-io/mock#South%20River%2C%20Ontario> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#South%20River%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "South River, Ontario" ;
-    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/mock#Village> .
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Village> .
 
-<ontology://generated-from-draw-io/mock#Terrace%20Bay%2C%20Ontario> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Terrace%20Bay%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Terrace Bay, Ontario" ;
-    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/mock#Township> .
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Township> .
 
-<ontology://generated-from-draw-io/mock#Textual%20Records> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Textual%20Records> a owl:NamedIndividual,
         rico:ContentType ;
     rdfs:label "Textual records" .
 
-<ontology://generated-from-draw-io/mock#Town> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> a owl:NamedIndividual,
         rico:PlaceType ;
     rdfs:label "Town" .
 
-<ontology://generated-from-draw-io/mock#Township> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Township> a owl:NamedIndividual,
         rico:PlaceType ;
     rdfs:label "Township" .
 
-<ontology://generated-from-draw-io/mock#Village> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Village> a owl:NamedIndividual,
         rico:PlaceType ;
     rdfs:label "Village" .
 
-<ontology://generated-from-draw-io/mock#Atikokan%2C%20Ontario> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Atikokan, Ontario" ;
-    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/mock#Town> .
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> .
 
-<ontology://generated-from-draw-io/mock#Highway%20Historical%20Collection%20-%20Photographs> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs> a owl:NamedIndividual,
         rico:RecordSet ;
     rdfs:label "Highway historical collection - photographs" ;
-    rico:hasCreator <ontology://generated-from-draw-io/mock#Fort%20York%20Construction%20Company%20Ltd.> ;
-    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/mock#RG%2014-162-2> ;
-    rico:hasRecordSetType <ontology://generated-from-draw-io/mock#Sub-series> .
+    rico:hasCreator <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> ;
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-2> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> .
 
-<ontology://generated-from-draw-io/mock#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> a owl:NamedIndividual,
         rico:RecordSet ;
     rdfs:label "Highways historical collection - historical research binders" ;
-    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/mock#RG%2014-162-5> ;
-    rico:hasOrHadSubject <ontology://generated-from-draw-io/mock#Atikokan%2C%20Ontario> ;
-    rico:hasRecordSetType <ontology://generated-from-draw-io/mock#Sub-series> .
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-5> ;
+    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> .
 
-<ontology://generated-from-draw-io/mock#Sub-series> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> a owl:NamedIndividual,
         rico:RecordSetType ;
     rdfs:label "Sub-series" .
 
-<ontology://generated-from-draw-io/mock#Archives%20Of%20Ontario%20Reference%20Code> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Archives%20Of%20Ontario%20Reference%20Code> a owl:NamedIndividual,
         rico:IdentifierType ;
     rdfs:label "Archives of Ontario reference code" .
 
-<ontology://generated-from-draw-io/mock#Fort%20York%20Construction%20Company%20Ltd.> a owl:NamedIndividual,
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> a owl:NamedIndividual,
         rico:CorporateBody ;
     rdfs:label "Fort York Construction Company Ltd." ;
-    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/mock#Ontario> ;
-    rico:isRelatedTo <ontology://generated-from-draw-io/mock#Highway%20Historical%20Collection%20-%20Photographs>,
-        <ontology://generated-from-draw-io/mock#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> .
+    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Ontario> ;
+    rico:isRelatedTo <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> .
 

--- a/src/main/webapp/plugins/rdfexport/debug/results/f-4711-orville-wood-fonds/ts_pipeline.ttl
+++ b/src/main/webapp/plugins/rdfexport/debug/results/f-4711-orville-wood-fonds/ts_pipeline.ttl
@@ -1,18 +1,63 @@
+@prefix add: <https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/> .
+@prefix auth: <https://data.archives.gov.on.test.gbad.ca/Schema/Authority/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix rico: <https://www.ica.org/standards/RiC/ontology#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+rdfs:label a owl:DatatypeProperty .
+
+rdfs:subPropertyOf a owl:ObjectProperty .
+
+auth:functionNote a owl:DatatypeProperty .
+
+auth:privateNote a owl:DatatypeProperty .
+
+auth:sourceNote a owl:DatatypeProperty .
+
+add:accumulationDate a owl:DatatypeProperty .
+
+add:associatedMaterial a owl:DatatypeProperty .
+
+add:availabilityOfOtherFormats a owl:DatatypeProperty .
+
+add:custodialHistory a owl:DatatypeProperty .
+
+add:findingAidNote a owl:DatatypeProperty .
+
+add:howToOrder a owl:DatatypeProperty .
+
+add:immediateSourceOfAcquisition a owl:DatatypeProperty .
+
+add:notes a owl:DatatypeProperty .
+
+add:privateNote a owl:DatatypeProperty .
+
+add:relatedMaterial a owl:DatatypeProperty .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31> a owl:Ontology ;
-    owl:imports rico: ;
-    skos:note "194X/1953",
-        "No further accruals are expected.",
-        "No restrictions on access.",
-        "The Orville Wood fonds was donated to the Archives of Ontario by his son, Bruce Arthur Wood, in 2018." .
+    owl:imports rico: .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Alan%20Wood> a owl:NamedIndividual,
+        rico:AgentName,
+        rico:Person ;
+    rdfs:label "Orville Alan Wood" ;
+    rico:hasBirthDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> ;
+    rico:hasBirthPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#South%20River%2C%20Ontario> ;
+    rico:hasDeathDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#2006> ;
+    rico:history "Orville Wood was born in South River, Ontario, in 1912. He served in the Navy, stationed in Halifax, during World War II, after which he became president of the Fort York Construction Company Ltd. (Source note: correspondence with donor and Ancestry.ca)." ;
+    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> ;
+    rico:isCreatorOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Wood%20Fonds> ;
+    rico:isOrWasLeaderOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> ;
+    rico:occupiesOrOccupied <ontology://generated-from-draw-io/2025-10-21T22-20-31#President> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#%5B194-%5D-1953> a owl:NamedIndividual,
         rico:Date ;
-    rdfs:label "[194-]-1953" .
+    rdfs:label "[194-]-1953" ;
+    rico:normalizedDateValue "194X/1953" .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> a owl:NamedIndividual,
+        rico:Date ;
+    rdfs:label "1912" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#2006> a owl:NamedIndividual,
         rico:Date ;
@@ -31,26 +76,36 @@
         rico:RecordSetType ;
     rdfs:label "Fonds" .
 
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material> a owl:NamedIndividual,
+        rico:ContentType ;
+    rdfs:label "Graphic material" .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> a owl:NamedIndividual,
+        rico:Place ;
+    rdfs:label "Halifax,  Nova Scotia" ;
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#City> .
+
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Ontario" ;
     rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Alan%20Wood> a owl:NamedIndividual,
-        rico:AgentName,
-        rico:Person ;
-    rdfs:label "Orville Alan Wood" ;
-    rico:hasBirthDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> ;
-    rico:history "Orville Wood was born in South River, Ontario, in 1912. He served in the Navy, stationed in Halifax, during World War II, after which he became president of the Fort York Construction Company Ltd. (Source note: correspondence with donor and Ancestry.ca)." ;
-    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> ;
-    rico:isOrWasLeaderOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> .
-
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Wood%20Fonds> a owl:NamedIndividual,
         rico:RecordSet ;
     rdfs:label "Orville Wood fonds" ;
+    rico:accruals "No further accruals are expected." ;
+    rico:conditionsOfAccess "No restrictions on access." ;
     rico:conditionsOfUse "Copyright has been transferred to the Archives of Ontario   by the donor. There are no restrictions on reproduction for research and private study. If you wish to use any of this material for a purpose other than research and private study, submit a Request for Permission to Publish, Exhibit or Broadcast Form." ;
-    rico:hasGeneticLinkToRecordResource <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs> ;
-    rico:hasOrHadSomeMembersWithContentType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material> ;
+    rico:hasCreationDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#%5B194-%5D-1953> ;
+    rico:hasGeneticLinkToRecordResource <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> ;
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#F%204711> ;
+    rico:hasOrHadSomeMembersWithContentType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Textual%20Records> ;
+    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Terrace%20Bay%2C%20Ontario> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fonds> ;
+    rico:history "The Orville Wood fonds was donated to the Archives of Ontario by his son, Bruce Arthur Wood, in 2018." ;
     rico:recordResourceExtent "0.1 centimetres of textual records;   98 photographs : black and white prints;   2 photographs : colour prints;   143 photographs : black and white negatives" ;
     rico:scopeAndContent "Fonds consists primarily of photographs of the construction of the Atikokan   Highway between Shabaqua Corners and Atikokan, Ontario. The highway was later named Highway 120, and is currently designated as Highway 11. Wood's company,   Fort York Construction Company Ltd., was contracted to undertake the construction of the highway starting in 1951 and completed the work in 1953.     Fonds also includes photographs of a project undertaken by Fort York Construction Company Ltd. at Terrace Bay, Ontario.     Also included are a news clipping about Fort York Construction Company Ltd., Orville Wood's business card, photographs of an unidentified historic fort, and photographs   of Wood's family and business partners." .
 
@@ -58,6 +113,10 @@
         rico:Position ;
     rdfs:label "President" ;
     rico:isOrWasOwnerOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> a owl:NamedIndividual,
+        rico:PlaceType ;
+    rdfs:label "Province" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-2> a owl:NamedIndividual,
         rico:Identifier ;
@@ -71,19 +130,21 @@
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#South%20River%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
-    rdfs:label "South River, Ontario" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> a owl:NamedIndividual,
-        rico:RecordSetType ;
-    rdfs:label "Sub-series" .
+    rdfs:label "South River, Ontario" ;
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Village> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Terrace%20Bay%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
-    rdfs:label "Terrace Bay, Ontario" .
+    rdfs:label "Terrace Bay, Ontario" ;
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Township> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Textual%20Records> a owl:NamedIndividual,
         rico:ContentType ;
     rdfs:label "Textual records" .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> a owl:NamedIndividual,
+        rico:PlaceType ;
+    rdfs:label "Town" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Township> a owl:NamedIndividual,
         rico:PlaceType ;
@@ -93,40 +154,28 @@
         rico:PlaceType ;
     rdfs:label "Village" .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> a owl:NamedIndividual,
-        rico:Date ;
-    rdfs:label "1912" .
-
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Atikokan, Ontario" ;
     rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material> a owl:NamedIndividual,
-        rico:ContentType ;
-    rdfs:label "Graphic material" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> a owl:NamedIndividual,
-        rico:Place ;
-    rdfs:label "Halifax,  Nova Scotia" .
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs> a owl:NamedIndividual,
+        rico:RecordSet ;
+    rdfs:label "Highway historical collection - photographs" ;
+    rico:hasCreator <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> ;
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-2> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> a owl:NamedIndividual,
         rico:RecordSet ;
     rdfs:label "Highways historical collection - historical research binders" ;
-    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> .
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-5> ;
+    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> a owl:NamedIndividual,
-        rico:PlaceType ;
-    rdfs:label "Province" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> a owl:NamedIndividual,
-        rico:PlaceType ;
-    rdfs:label "Town" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs> a owl:NamedIndividual,
-        rico:RecordSet ;
-    rdfs:label "Highway historical collection - photographs" ;
-    rico:hasCreator <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> .
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> a owl:NamedIndividual,
+        rico:RecordSetType ;
+    rdfs:label "Sub-series" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Archives%20Of%20Ontario%20Reference%20Code> a owl:NamedIndividual,
         rico:IdentifierType ;
@@ -135,6 +184,7 @@
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> a owl:NamedIndividual,
         rico:CorporateBody ;
     rdfs:label "Fort York Construction Company Ltd." ;
+    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Ontario> ;
     rico:isRelatedTo <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs>,
         <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> .
 

--- a/src/main/webapp/plugins/rdfexport/debug/results/f-4711-orville-wood-fonds/ts_plugin.ttl
+++ b/src/main/webapp/plugins/rdfexport/debug/results/f-4711-orville-wood-fonds/ts_plugin.ttl
@@ -1,18 +1,63 @@
+@prefix add: <https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/> .
+@prefix auth: <https://data.archives.gov.on.test.gbad.ca/Schema/Authority/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix rico: <https://www.ica.org/standards/RiC/ontology#> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+rdfs:label a owl:DatatypeProperty .
+
+rdfs:subPropertyOf a owl:ObjectProperty .
+
+auth:functionNote a owl:DatatypeProperty .
+
+auth:privateNote a owl:DatatypeProperty .
+
+auth:sourceNote a owl:DatatypeProperty .
+
+add:accumulationDate a owl:DatatypeProperty .
+
+add:associatedMaterial a owl:DatatypeProperty .
+
+add:availabilityOfOtherFormats a owl:DatatypeProperty .
+
+add:custodialHistory a owl:DatatypeProperty .
+
+add:findingAidNote a owl:DatatypeProperty .
+
+add:howToOrder a owl:DatatypeProperty .
+
+add:immediateSourceOfAcquisition a owl:DatatypeProperty .
+
+add:notes a owl:DatatypeProperty .
+
+add:privateNote a owl:DatatypeProperty .
+
+add:relatedMaterial a owl:DatatypeProperty .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31> a owl:Ontology ;
-    owl:imports rico: ;
-    skos:note "194X/1953",
-        "No further accruals are expected.",
-        "No restrictions on access.",
-        "The Orville Wood fonds was donated to the Archives of Ontario by his son, Bruce Arthur Wood, in 2018." .
+    owl:imports rico: .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Alan%20Wood> a owl:NamedIndividual,
+        rico:AgentName,
+        rico:Person ;
+    rdfs:label "Orville Alan Wood" ;
+    rico:hasBirthDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> ;
+    rico:hasBirthPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#South%20River%2C%20Ontario> ;
+    rico:hasDeathDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#2006> ;
+    rico:history "Orville Wood was born in South River, Ontario, in 1912. He served in the Navy, stationed in Halifax, during World War II, after which he became president of the Fort York Construction Company Ltd. (Source note: correspondence with donor and Ancestry.ca)." ;
+    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> ;
+    rico:isCreatorOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Wood%20Fonds> ;
+    rico:isOrWasLeaderOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> ;
+    rico:occupiesOrOccupied <ontology://generated-from-draw-io/2025-10-21T22-20-31#President> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#%5B194-%5D-1953> a owl:NamedIndividual,
         rico:Date ;
-    rdfs:label "[194-]-1953" .
+    rdfs:label "[194-]-1953" ;
+    rico:normalizedDateValue "194X/1953" .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> a owl:NamedIndividual,
+        rico:Date ;
+    rdfs:label "1912" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#2006> a owl:NamedIndividual,
         rico:Date ;
@@ -31,26 +76,36 @@
         rico:RecordSetType ;
     rdfs:label "Fonds" .
 
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material> a owl:NamedIndividual,
+        rico:ContentType ;
+    rdfs:label "Graphic material" .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> a owl:NamedIndividual,
+        rico:Place ;
+    rdfs:label "Halifax,  Nova Scotia" ;
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#City> .
+
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Ontario" ;
     rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Alan%20Wood> a owl:NamedIndividual,
-        rico:AgentName,
-        rico:Person ;
-    rdfs:label "Orville Alan Wood" ;
-    rico:hasBirthDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> ;
-    rico:history "Orville Wood was born in South River, Ontario, in 1912. He served in the Navy, stationed in Halifax, during World War II, after which he became president of the Fort York Construction Company Ltd. (Source note: correspondence with donor and Ancestry.ca)." ;
-    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> ;
-    rico:isOrWasLeaderOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> .
-
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Orville%20Wood%20Fonds> a owl:NamedIndividual,
         rico:RecordSet ;
     rdfs:label "Orville Wood fonds" ;
+    rico:accruals "No further accruals are expected." ;
+    rico:conditionsOfAccess "No restrictions on access." ;
     rico:conditionsOfUse "Copyright has been transferred to the Archives of Ontario   by the donor. There are no restrictions on reproduction for research and private study. If you wish to use any of this material for a purpose other than research and private study, submit a Request for Permission to Publish, Exhibit or Broadcast Form." ;
-    rico:hasGeneticLinkToRecordResource <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs> ;
-    rico:hasOrHadSomeMembersWithContentType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material> ;
+    rico:hasCreationDate <ontology://generated-from-draw-io/2025-10-21T22-20-31#%5B194-%5D-1953> ;
+    rico:hasGeneticLinkToRecordResource <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> ;
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#F%204711> ;
+    rico:hasOrHadSomeMembersWithContentType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Textual%20Records> ;
+    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario>,
+        <ontology://generated-from-draw-io/2025-10-21T22-20-31#Terrace%20Bay%2C%20Ontario> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fonds> ;
+    rico:history "The Orville Wood fonds was donated to the Archives of Ontario by his son, Bruce Arthur Wood, in 2018." ;
     rico:recordResourceExtent "0.1 centimetres of textual records;   98 photographs : black and white prints;   2 photographs : colour prints;   143 photographs : black and white negatives" ;
     rico:scopeAndContent "Fonds consists primarily of photographs of the construction of the Atikokan   Highway between Shabaqua Corners and Atikokan, Ontario. The highway was later named Highway 120, and is currently designated as Highway 11. Wood's company,   Fort York Construction Company Ltd., was contracted to undertake the construction of the highway starting in 1951 and completed the work in 1953.     Fonds also includes photographs of a project undertaken by Fort York Construction Company Ltd. at Terrace Bay, Ontario.     Also included are a news clipping about Fort York Construction Company Ltd., Orville Wood's business card, photographs of an unidentified historic fort, and photographs   of Wood's family and business partners." .
 
@@ -58,6 +113,10 @@
         rico:Position ;
     rdfs:label "President" ;
     rico:isOrWasOwnerOf <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> a owl:NamedIndividual,
+        rico:PlaceType ;
+    rdfs:label "Province" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-2> a owl:NamedIndividual,
         rico:Identifier ;
@@ -71,19 +130,21 @@
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#South%20River%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
-    rdfs:label "South River, Ontario" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> a owl:NamedIndividual,
-        rico:RecordSetType ;
-    rdfs:label "Sub-series" .
+    rdfs:label "South River, Ontario" ;
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Village> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Terrace%20Bay%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
-    rdfs:label "Terrace Bay, Ontario" .
+    rdfs:label "Terrace Bay, Ontario" ;
+    rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Township> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Textual%20Records> a owl:NamedIndividual,
         rico:ContentType ;
     rdfs:label "Textual records" .
+
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> a owl:NamedIndividual,
+        rico:PlaceType ;
+    rdfs:label "Town" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Township> a owl:NamedIndividual,
         rico:PlaceType ;
@@ -93,40 +154,28 @@
         rico:PlaceType ;
     rdfs:label "Village" .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#1912> a owl:NamedIndividual,
-        rico:Date ;
-    rdfs:label "1912" .
-
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> a owl:NamedIndividual,
         rico:Place ;
     rdfs:label "Atikokan, Ontario" ;
     rico:hasOrHadPlaceType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Graphic%20Material> a owl:NamedIndividual,
-        rico:ContentType ;
-    rdfs:label "Graphic material" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Halifax%2C%20Nova%20Scotia> a owl:NamedIndividual,
-        rico:Place ;
-    rdfs:label "Halifax,  Nova Scotia" .
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs> a owl:NamedIndividual,
+        rico:RecordSet ;
+    rdfs:label "Highway historical collection - photographs" ;
+    rico:hasCreator <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> ;
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-2> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> a owl:NamedIndividual,
         rico:RecordSet ;
     rdfs:label "Highways historical collection - historical research binders" ;
-    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> .
+    rico:hasOrHadIdentifier <ontology://generated-from-draw-io/2025-10-21T22-20-31#RG%2014-162-5> ;
+    rico:hasOrHadSubject <ontology://generated-from-draw-io/2025-10-21T22-20-31#Atikokan%2C%20Ontario> ;
+    rico:hasRecordSetType <ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> .
 
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Province> a owl:NamedIndividual,
-        rico:PlaceType ;
-    rdfs:label "Province" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Town> a owl:NamedIndividual,
-        rico:PlaceType ;
-    rdfs:label "Town" .
-
-<ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs> a owl:NamedIndividual,
-        rico:RecordSet ;
-    rdfs:label "Highway historical collection - photographs" ;
-    rico:hasCreator <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> .
+<ontology://generated-from-draw-io/2025-10-21T22-20-31#Sub-series> a owl:NamedIndividual,
+        rico:RecordSetType ;
+    rdfs:label "Sub-series" .
 
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Archives%20Of%20Ontario%20Reference%20Code> a owl:NamedIndividual,
         rico:IdentifierType ;
@@ -135,6 +184,7 @@
 <ontology://generated-from-draw-io/2025-10-21T22-20-31#Fort%20York%20Construction%20Company%20Ltd.> a owl:NamedIndividual,
         rico:CorporateBody ;
     rdfs:label "Fort York Construction Company Ltd." ;
+    rico:isAgentAssociatedWithPlace <ontology://generated-from-draw-io/2025-10-21T22-20-31#Ontario> ;
     rico:isRelatedTo <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highway%20Historical%20Collection%20-%20Photographs>,
         <ontology://generated-from-draw-io/2025-10-21T22-20-31#Highways%20Historical%20Collection%20-%20Historical%20Research%20Binders> .
 

--- a/src/main/webapp/plugins/rdfexport/debug/scenarios/f-4711-orville-wood-fonds.yml
+++ b/src/main/webapp/plugins/rdfexport/debug/scenarios/f-4711-orville-wood-fonds.yml
@@ -7,7 +7,7 @@ format: turtle
 metadata:
   attributes:
     csvPath: /mock/path/to/file.csv
-    baseUri: 
+    baseUri:
   preamble:
     - prefix: mock1
       iri: http://mock-uri.com

--- a/src/main/webapp/plugins/rdfexport/debug/scenarios/rg-1-659-northern-pike-lamprey-mark-rondeau-park-april-20-1955.yml
+++ b/src/main/webapp/plugins/rdfexport/debug/scenarios/rg-1-659-northern-pike-lamprey-mark-rondeau-park-april-20-1955.yml
@@ -1,5 +1,6 @@
 slug: rg-1-659-northern-pike-lamprey-mark-rondeau-park-april-20-1955
-drawio: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG
+drawio:
+  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG
   1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio
 legacy_commit: cf8f84bb84ff83843b6726ac96aff3a2055f4275
 format: turtle
@@ -8,7 +9,7 @@ metadata:
     csvPath: /mock/path/to/file.csv
     baseUri: ontology://generated-from-draw-io/mock#
   preamble:
-  - prefix: mock1
-    iri: http://mock-uri.com
+    - prefix: mock1
+      iri: http://mock-uri.com
 parser_config:
   ontology_iri: mock://debug-ontology

--- a/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
@@ -88,7 +88,14 @@ class pipeline:
                     DECORATION_REGISTRY_ATTR = "__drawio_literal_registry"
                     DEFAULT_STANDALONE_TYPE = "owl:NamedIndividual"
 
-                    def __init__(self, raw_xml: typing.Any, prefixes: dict[str, str]):
+                    def __init__(
+                        self,
+                        raw_xml: typing.Any,
+                        prefixes: dict[str, str],
+                        *,
+                        strict_mode: bool = False,
+                        max_gap: float | None = None,
+                    ):
                         source_tree = getattr(raw_xml, "draw_io_xml_tree", None)
                         if isinstance(source_tree, Element):
                             self.draw_io_xml_tree = source_tree
@@ -102,6 +109,16 @@ class pipeline:
                         self._namespace_manager = Graph().namespace_manager
                         for prefix, iri in prefixes.items():
                             self._namespace_manager.bind(prefix, iri, replace=True)
+                        self._strict_mode = bool(strict_mode)
+                        default_gap = 10.0
+                        gap_candidate = default_gap if max_gap is None else max_gap
+                        try:
+                            coerced_gap = float(gap_candidate)
+                        except (TypeError, ValueError):
+                            coerced_gap = float(default_gap)
+                        if coerced_gap != coerced_gap or coerced_gap < 0.0:
+                            coerced_gap = float(default_gap)
+                        self._max_gap = coerced_gap
                         self._html_parser = NodeHTMLParser()
                         self._edge_incidence = self._build_edge_incidence()
                         self._child_token_cache: dict[str, list[str]] = {}
@@ -323,6 +340,56 @@ class pipeline:
                             float(geom.attrib.get("height", 0.0)),
                         )
 
+                    def _absolute_dimensions(self, cell: Element) -> Dimensions:
+                        geom = self._geometry(cell)
+                        width = float(geom.attrib.get("width", 0.0))
+                        height = float(geom.attrib.get("height", 0.0))
+                        coordinates = self._start_or_end(cell, None)
+                        if coordinates is None:
+                            x = float(geom.attrib.get("x", 0.0))
+                            y = float(geom.attrib.get("y", 0.0))
+                        else:
+                            x, y = coordinates
+                        return (x, y, width, height)
+
+                    def _close_enough(
+                        self, arrow_point: tuple[float, float], cell: Element
+                    ) -> bool:
+                        try:
+                            x, y, width, height = self._absolute_dimensions(cell)
+                        except ParseException:
+                            return False
+                        arrow_x, arrow_y = arrow_point
+                        return (
+                            x - self._max_gap <= arrow_x <= x + width + self._max_gap
+                            and y - self._max_gap
+                            <= arrow_y
+                            <= y + height + self._max_gap
+                        )
+
+                    def _resolve_nearby_cell(
+                        self,
+                        arrow_point: tuple[float, float] | None,
+                        *,
+                        require_individual: bool,
+                    ) -> tuple[Element, str, bool]:
+                        if arrow_point is None:
+                            raise _NoCellCloseEnoughException
+                        for cell_id, (cell, individual) in self._nodes_by_id.items():
+                            if self._close_enough(arrow_point, cell):
+                                return (cell, individual.identifier, False)
+                        if require_individual:
+                            raise _NoCellCloseEnoughException
+                        for cell_id, literal_cell in self._literals_by_id.items():
+                            if not self._close_enough(arrow_point, literal_cell):
+                                continue
+                            try:
+                                literal_value = self._value_of(literal_cell)
+                            except _NoValueException as exc:
+                                raise _NoCellCloseEnoughException from exc
+                            return (literal_cell, literal_value, True)
+                        raise _NoCellCloseEnoughException
+
                     def _start_or_end(
                         self, cell: Element, as_attribute: str | None
                     ) -> tuple[float, float] | None:
@@ -368,6 +435,8 @@ class pipeline:
                         arrow_id = arrow_cell.attrib["id"]
                         source_id = arrow_cell.attrib.get("source")
                         target_id = arrow_cell.attrib.get("target")
+                        arrow_start = self._start_or_end(arrow_cell, "sourcePoint")
+                        arrow_end = self._start_or_end(arrow_cell, "targetPoint")
                         if source_id and source_id in self._nodes_by_id:
                             source_cell, source_individual = self._nodes_by_id[
                                 source_id
@@ -378,9 +447,18 @@ class pipeline:
                                 f"Arrow '{arrow_label}' ({arrow_id}) has a literal as source."
                             )
                         else:
-                            raise NoSourceException(
-                                f"Arrow '{arrow_label}' ({arrow_id}) has no valid source."
-                            )
+                            if self._strict_mode:
+                                raise NoSourceException(
+                                    f"Arrow '{arrow_label}' ({arrow_id}) has no valid source."
+                                )
+                            try:
+                                _, source_identifier, _ = self._resolve_nearby_cell(
+                                    arrow_start, require_individual=True
+                                )
+                            except _NoCellCloseEnoughException as exc:
+                                raise NoSourceException(
+                                    f"Arrow '{arrow_label}' ({arrow_id}) has no valid source."
+                                ) from exc
                         target_cell = None
                         is_datatype = False
                         if target_id:
@@ -394,13 +472,37 @@ class pipeline:
                                 target_identifier = self._value_of(target_cell)
                                 is_datatype = True
                             else:
-                                raise NoSourceException(
-                                    f"Arrow '{arrow_label}' ({arrow_id}) target '{target_id}' could not be found."
-                                )
+                                if self._strict_mode:
+                                    raise NoSourceException(
+                                        f"Arrow '{arrow_label}' ({arrow_id}) target '{target_id}' could not be found."
+                                    )
+                                try:
+                                    candidate_cell, target_identifier, is_datatype = (
+                                        self._resolve_nearby_cell(
+                                            arrow_end, require_individual=False
+                                        )
+                                    )
+                                    target_cell = candidate_cell
+                                except _NoCellCloseEnoughException as exc:
+                                    raise NoSourceException(
+                                        f"Arrow '{arrow_label}' ({arrow_id}) target '{target_id}' could not be found."
+                                    ) from exc
                         else:
-                            raise NoSourceException(
-                                f"Arrow '{arrow_label}' ({arrow_id}) has no target."
-                            )
+                            if self._strict_mode:
+                                raise NoSourceException(
+                                    f"Arrow '{arrow_label}' ({arrow_id}) has no target."
+                                )
+                            try:
+                                candidate_cell, target_identifier, is_datatype = (
+                                    self._resolve_nearby_cell(
+                                        arrow_end, require_individual=False
+                                    )
+                                )
+                                target_cell = candidate_cell
+                            except _NoCellCloseEnoughException as exc:
+                                raise NoSourceException(
+                                    f"Arrow '{arrow_label}' ({arrow_id}) has no target."
+                                ) from exc
                         if (
                             target_cell
                             and target_cell.attrib.get("id") in self.decorations
@@ -2278,6 +2380,12 @@ class internal_control_core:
         DrawIOCellClassifier = getattr(
             pipeline.core.xml.data, "DrawIOCellClassifier", None
         )
+
+        def _is_flag_enabled(value: Any) -> bool:
+            if isinstance(value, str):
+                return value.strip().lower() in {"true", "1", "yes", "on"}
+            return bool(value)
+
         metadata_prefixes, base_uri, csv_path, parsed_root = (
             pipeline.pre.xml.metadata._extract_drawio_metadata(raw_xml)
         )
@@ -2301,7 +2409,14 @@ class internal_control_core:
             include_label=not config_args.get("label_disable", False),
         )
         _parse_capitalisation_scheme(config_args["capitalisation_scheme"])
-        classifier = DrawIOCellClassifier(working_xml, prefixes)
+        strict_mode = _is_flag_enabled(config_args.get("strict_mode"))
+        try:
+            max_gap = float(config_args.get("max_gap", DEFAULT_MAX_GAP))
+        except (TypeError, ValueError):
+            max_gap = float(DEFAULT_MAX_GAP)
+        classifier = DrawIOCellClassifier(
+            working_xml, prefixes, strict_mode=strict_mode, max_gap=max_gap
+        )
         space_substitute = internal_control_core._parse_space_substitute(
             config_args["metacharacter_substitute"]
         )
@@ -2330,12 +2445,6 @@ class internal_control_core:
         )
         if base_uri:
             graph.namespace_manager.bind("", Namespace(base_uri), replace=True)
-
-        def _is_flag_enabled(value: Any) -> bool:
-            if isinstance(value, str):
-                return value.strip().lower() in {"true", "1", "yes", "on"}
-            return bool(value)
-
         rml_enabled = _is_flag_enabled(config_args.get("rml_enabled")) or (
             parsed_root
             and _is_flag_enabled(

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/cell_classifier.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/cell_classifier.py
@@ -40,7 +40,14 @@ class DrawIOCellClassifier:
     DECORATION_REGISTRY_ATTR = "__drawio_literal_registry"
     DEFAULT_STANDALONE_TYPE = "owl:NamedIndividual"
 
-    def __init__(self, raw_xml: typing.Any, prefixes: dict[str, str]):
+    def __init__(
+        self,
+        raw_xml: typing.Any,
+        prefixes: dict[str, str],
+        *,
+        strict_mode: bool = False,
+        max_gap: float | None = None,
+    ):
         source_tree = getattr(raw_xml, "draw_io_xml_tree", None)
         if isinstance(source_tree, Element):
             self.draw_io_xml_tree = source_tree
@@ -54,6 +61,17 @@ class DrawIOCellClassifier:
         self._namespace_manager = Graph().namespace_manager
         for prefix, iri in prefixes.items():
             self._namespace_manager.bind(prefix, iri, replace=True)
+
+        self._strict_mode = bool(strict_mode)
+        default_gap = 10.0
+        gap_candidate = default_gap if max_gap is None else max_gap
+        try:
+            coerced_gap = float(gap_candidate)
+        except (TypeError, ValueError):
+            coerced_gap = float(default_gap)
+        if coerced_gap != coerced_gap or coerced_gap < 0.0:  # NaN or negative
+            coerced_gap = float(default_gap)
+        self._max_gap = coerced_gap
 
         self._html_parser = NodeHTMLParser()
         self._edge_incidence = self._build_edge_incidence()
@@ -282,6 +300,56 @@ class DrawIOCellClassifier:
             float(geom.attrib.get("height", 0.0)),
         )
 
+    def _absolute_dimensions(self, cell: Element) -> Dimensions:
+        geom = self._geometry(cell)
+        width = float(geom.attrib.get("width", 0.0))
+        height = float(geom.attrib.get("height", 0.0))
+        coordinates = self._start_or_end(cell, None)
+        if coordinates is None:
+            x = float(geom.attrib.get("x", 0.0))
+            y = float(geom.attrib.get("y", 0.0))
+        else:
+            x, y = coordinates
+        return x, y, width, height
+
+    def _close_enough(self, arrow_point: tuple[float, float], cell: Element) -> bool:
+        try:
+            x, y, width, height = self._absolute_dimensions(cell)
+        except ParseException:
+            return False
+        arrow_x, arrow_y = arrow_point
+        return (
+            x - self._max_gap <= arrow_x <= x + width + self._max_gap
+            and y - self._max_gap <= arrow_y <= y + height + self._max_gap
+        )
+
+    def _resolve_nearby_cell(
+        self,
+        arrow_point: tuple[float, float] | None,
+        *,
+        require_individual: bool,
+    ) -> tuple[Element, str, bool]:
+        if arrow_point is None:
+            raise _NoCellCloseEnoughException
+
+        for cell_id, (cell, individual) in self._nodes_by_id.items():
+            if self._close_enough(arrow_point, cell):
+                return cell, individual.identifier, False
+
+        if require_individual:
+            raise _NoCellCloseEnoughException
+
+        for cell_id, literal_cell in self._literals_by_id.items():
+            if not self._close_enough(arrow_point, literal_cell):
+                continue
+            try:
+                literal_value = self._value_of(literal_cell)
+            except _NoValueException as exc:
+                raise _NoCellCloseEnoughException from exc
+            return literal_cell, literal_value, True
+
+        raise _NoCellCloseEnoughException
+
     def _start_or_end(
         self, cell: Element, as_attribute: str | None
     ) -> tuple[float, float] | None:
@@ -328,6 +396,8 @@ class DrawIOCellClassifier:
         arrow_id = arrow_cell.attrib["id"]
         source_id = arrow_cell.attrib.get("source")
         target_id = arrow_cell.attrib.get("target")
+        arrow_start = self._start_or_end(arrow_cell, "sourcePoint")
+        arrow_end = self._start_or_end(arrow_cell, "targetPoint")
 
         # Resolve source
         if source_id and source_id in self._nodes_by_id:
@@ -338,9 +408,18 @@ class DrawIOCellClassifier:
                 f"Arrow '{arrow_label}' ({arrow_id}) has a literal as source."
             )
         else:
-            raise NoSourceException(
-                f"Arrow '{arrow_label}' ({arrow_id}) has no valid source."
-            )
+            if self._strict_mode:
+                raise NoSourceException(
+                    f"Arrow '{arrow_label}' ({arrow_id}) has no valid source."
+                )
+            try:
+                _, source_identifier, _ = self._resolve_nearby_cell(
+                    arrow_start, require_individual=True
+                )
+            except _NoCellCloseEnoughException as exc:
+                raise NoSourceException(
+                    f"Arrow '{arrow_label}' ({arrow_id}) has no valid source."
+                ) from exc
 
         # Resolve target
         target_cell = None
@@ -354,13 +433,33 @@ class DrawIOCellClassifier:
                 target_identifier = self._value_of(target_cell)
                 is_datatype = True
             else:
-                raise NoSourceException(
-                    f"Arrow '{arrow_label}' ({arrow_id}) target '{target_id}' could not be found."
-                )
+                if self._strict_mode:
+                    raise NoSourceException(
+                        f"Arrow '{arrow_label}' ({arrow_id}) target '{target_id}' could not be found."
+                    )
+                try:
+                    candidate_cell, target_identifier, is_datatype = (
+                        self._resolve_nearby_cell(arrow_end, require_individual=False)
+                    )
+                    target_cell = candidate_cell
+                except _NoCellCloseEnoughException as exc:
+                    raise NoSourceException(
+                        f"Arrow '{arrow_label}' ({arrow_id}) target '{target_id}' could not be found."
+                    ) from exc
         else:
-            raise NoSourceException(
-                f"Arrow '{arrow_label}' ({arrow_id}) has no target."
-            )
+            if self._strict_mode:
+                raise NoSourceException(
+                    f"Arrow '{arrow_label}' ({arrow_id}) has no target."
+                )
+            try:
+                candidate_cell, target_identifier, is_datatype = (
+                    self._resolve_nearby_cell(arrow_end, require_individual=False)
+                )
+                target_cell = candidate_cell
+            except _NoCellCloseEnoughException as exc:
+                raise NoSourceException(
+                    f"Arrow '{arrow_label}' ({arrow_id}) has no target."
+                ) from exc
 
         if target_cell and target_cell.attrib.get("id") in self.decorations:
             self.decorations[target_cell.attrib["id"]]["connected"] = True

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/rml_export.py
@@ -16,6 +16,11 @@ def _build_graph_from_raw_xml(
     """
     DrawIOCellClassifier = getattr(pipeline.core.xml.data, "DrawIOCellClassifier", None)
 
+    def _is_flag_enabled(value: Any) -> bool:
+        if isinstance(value, str):
+            return value.strip().lower() in {"true", "1", "yes", "on"}
+        return bool(value)
+
     # 1. Initial Setup and Configuration
     metadata_prefixes, base_uri, csv_path, parsed_root = (
         pipeline.pre.xml.metadata._extract_drawio_metadata(raw_xml)
@@ -43,7 +48,18 @@ def _build_graph_from_raw_xml(
 
     # 2. Instantiate Classifier to process the entire XML
     # All parsing logic is now encapsulated here.
-    classifier = DrawIOCellClassifier(working_xml, prefixes)
+    strict_mode = _is_flag_enabled(config_args.get("strict_mode"))
+    try:
+        max_gap = float(config_args.get("max_gap", DEFAULT_MAX_GAP))
+    except (TypeError, ValueError):
+        max_gap = float(DEFAULT_MAX_GAP)
+
+    classifier = DrawIOCellClassifier(
+        working_xml,
+        prefixes,
+        strict_mode=strict_mode,
+        max_gap=max_gap,
+    )
 
     # 3. Generate Intermediate Blocks from Classifier's results
     space_substitute = internal_control_core._parse_space_substitute(
@@ -79,11 +95,6 @@ def _build_graph_from_raw_xml(
     # 5. Final post-processing (e.g., RML, base URI)
     if base_uri:
         graph.namespace_manager.bind("", Namespace(base_uri), replace=True)
-
-    def _is_flag_enabled(value: Any) -> bool:
-        if isinstance(value, str):
-            return value.strip().lower() in {"true", "1", "yes", "on"}
-        return bool(value)
 
     rml_enabled = _is_flag_enabled(config_args.get("rml_enabled")) or (
         parsed_root

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,9 +1,8 @@
-Script started on Tue Oct 21 22:13:44 2025
-Command: bun run test
+Script started on 2025-10-22 04:19:29+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 [0m[2m[35m$[0m [2m[1mpython -m meta_builder -o legacy/draw_io_parser.py && bun run lint:fix:py && bun run format:py[0m
 [metabuilder] Wrote legacy/draw_io_parser.py ( overrides on; replacements=8 [NodeHTMLParser, _build_graph_from_raw_xml, _cell_is_literal, _ensure_known_curie, _extract_individual_and_arrow_and_literal_cells, _split_curie, individual_blocks, serialise_to_graph] additions=1 [DrawIOCellClassifier] )
-[metabuilder] Loaded override modules from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
+[metabuilder] Loaded override modules from /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
 [0m[2m[35m$[0m [2m[1mruff check --fix .[0m
 Found 2 errors (2 fixed, 0 remaining).
 [0m[2m[35m$[0m [2m[1mruff format .[0m
@@ -53,880 +52,75 @@ Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
      An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
 
 🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
-[1m============================================== test session starts ===============================================[0m
-platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0 -- /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
+[1m===================================================== test session starts ======================================================[0m
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0 -- /workspace/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
 cachedir: .pytest_cache
-rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
+rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
 configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 41 items                                                                                               [0m
-
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  2%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m [  4%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_preserves_literal_targets [31mFAILED[0m[31m [  7%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_serialise_to_graph_falls_back_for_relative_prefixes [31mFAILED[0m[31m [  9%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[31m [ 12%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[dangling_curie] [31mFAILED[0m[31m [ 14%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[colon_only] [31mFAILED[0m[31m [ 17%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[no_prefix] [31mFAILED[0m[31m [ 19%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [31mFAILED[0m[31m [ 21%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[31m [ 24%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[31m [ 26%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [31mFAILED[0m[31m [ 29%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[31m [ 31%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[31m [ 34%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[31m [ 36%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[31m [ 39%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[31m [ 41%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[31m [ 43%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[31m [ 46%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[31m [ 48%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[31m [ 51%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[31m [ 53%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [31mFAILED[0m[31m [ 56%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[31m [ 58%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [31mFAILED[0m[31m [ 60%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [31mFAILED[0m[31m [ 63%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[31m [ 65%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[31m [ 68%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[31m [ 70%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [31mFAILED[0m[31m [ 73%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[31m [ 75%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[31m [ 78%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[31m [ 80%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[31m [ 82%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[31m [ 85%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [31mFAILED[0m[31m [ 87%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [31mFAILED[0m[31m [ 90%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[31m [ 92%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[31m [ 95%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[31m [ 97%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [31mFAILED[0m[31m [100%][0m
-
-==================================================== FAILURES ====================================================
-[31m[1m__________________________________ test_parse_drawio_preserves_literal_targets ___________________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_preserves_literal_targets[39;49;00m():[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(FIXTURES_DIR / [33m"[39;49;00m[33mAA37-with-metadata-even-more-severely-mocked.drawio[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:140: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('A%20Ontario%20Government%20...e'}}, ('AA37', 'AA37'): {'Types': {'rico:Identifier'}, 'rico:hasIdentifierType': {('Agent%20Identifier', False)}}, ...}
-object_properties = {'hellow:there', 'rdf:type', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', ...}
-datatype_properties = {'hellow:there', 'rdf:some-predicate', 'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-13-45', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m____________________________ test_serialise_to_graph_falls_back_for_relative_prefixes ____________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_serialise_to_graph_falls_back_for_relative_prefixes[39;49;00m():[90m[39;49;00m
-        prefixes = draw_io_parser.get_prefixes().copy()[90m[39;49;00m
-        prefixes[[33m"[39;49;00m[33mbad[39;49;00m[33m"[39;49;00m] = [33m"[39;49;00m[33mrelative-prefix[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        items = [96miter[39;49;00m([90m[39;49;00m
-            [[90m[39;49;00m
-                draw_io_parser.Individual([33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mowl:NamedIndividual[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-                draw_io_parser.Arrow([90m[39;49;00m
-                    identifier=[33m"[39;49;00m[33mbad:prop[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    source=[33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    target=[33m"[39;49;00m[33mliteral value[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    is_datatype=[94mTrue[39;49;00m,[90m[39;49;00m
-                ),[90m[39;49;00m
-            ][90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        blocks, object_props, datatype_props = draw_io_parser.individual_blocks([90m[39;49;00m
-            items,[90m[39;49;00m
-            [],[90m[39;49;00m
-            [94mNone[39;49;00m,[90m[39;49;00m
-            draw_io_parser.DEFAULT_CAPITALISATION_SCHEME,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        config = draw_io_parser.SerialisationConfig([90m[39;49;00m
-            infer_type_of_literals=[94mTrue[39;49;00m,[90m[39;49;00m
-            include_preamble=[94mFalse[39;49;00m,[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33mhttp://example.com/ontology[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix=[33m"[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix_iri=[33m"[39;49;00m[33mhttp://example.com/[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            indentation=[94m2[39;49;00m,[90m[39;49;00m
-            include_label=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
->       graph = draw_io_parser.serialise_to_graph([90m[39;49;00m
-            blocks,[90m[39;49;00m
-            object_props,[90m[39;49;00m
-            datatype_props,[90m[39;49;00m
-            config,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:185: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('Source', 'Source'): {'Types': {'owl:NamedIndividual'}, 'bad:prop': {('literal value', True)}}}
-object_properties = set(), datatype_properties = {'bad:prop'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=False, ontology_iri='http://example.com/ontology', prefix='', prefix_iri='http://example.com/', indentation=2, include_label=False)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...gbad.ca/Schema/Authority/', 'bad': 'relative-prefix', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', ...}
-graph_cls = <class 'rdflib.graph.Graph'>, graph_kwargs = {}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'relative-prefix' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m_______________________ test_parse_drawio_rejects_malformed_type_variants[dangling_curie] ________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-442/test_parse_drawio_rejects_malf1')
-case_key = 'dangling_curie'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-13-45', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m_________________________ test_parse_drawio_rejects_malformed_type_variants[colon_only] __________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-442/test_parse_drawio_rejects_malf2')
-case_key = 'colon_only'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-13-45', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m__________________________ test_parse_drawio_rejects_malformed_type_variants[no_prefix] __________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-442/test_parse_drawio_rejects_malf3')
-case_key = 'no_prefix'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-13-45', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m_________________________________ test_parse_drawio_accepts_corrected_mock_types _________________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-442/test_parse_drawio_accepts_corr0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_accepts_corrected_mock_types[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, [94mNone[39;49;00m)[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:215: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-13-45', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path2] ____________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/BA619 Walkerton Inquiry.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=Ncc7b7f59feda4009b0fb9b109d3501ca (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=N3b73a36b98264b9db4636c4ff50ed664 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedValue' (gmwnegnUR_CNORKRYM6Y-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (gmwnegnUR_CNORKRYM6Y-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasIdentifierType' (gmwnegnUR_CNORKRYM6Y-18) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadAgentName' (iiJ8OJKaNMLrSCaLO3TT-3) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:resultsOrResultedFrom' (I4GB3cVhTv-sTvJ7h0Jz-41) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordState' (lTHjRTAcClQ9bYR0I0Gv-15) has no valid source.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path13] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/F 4711 Orville Wood fonds.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=N785b3d1d3f6e42a1af78a278f6ce2fa2 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=Nedc772f2799341f986c79243ad91dbcc (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path15] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/General Authority to RiC-O Model_2025-06-25_PZ.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=N68ab2407f14a4294a54c77bdf5f43c46 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=N66989eb69ccd42a8a41a28a152bb3619 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path16] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=Ndb1bf58efd7c4513a75539fdf54254c8 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=Nf749e281f98b423d81e2af9555a1c61a (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path20] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/RG 18-210 Walkerton Inquiry in RiC-O (original).nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=N1c7ec11028f14d558c95bdef1babfa9e (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=N8e89aca256134100adba97899ca34eb2 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-46) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-54) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-58) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-66) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-88) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-94) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-107) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:occurredAtDate' (0Zy0miyS0KUs_HnzcUTQ-3) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:authorizedBy' (0Zy0miyS0KUs_HnzcUTQ-9) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:regulatesOrRegulated' (0Zy0miyS0KUs_HnzcUTQ-11) has no valid source.
-[31m[1m__________________________________ test_parse_drawio_respects_strip_html_config __________________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_respects_strip_html_config[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            strip_html=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:361: AssertionError
-[31m[1m_________________________________ test_parse_drawio_metadata_strip_html_override _________________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_metadata_strip_html_override[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:388: AssertionError
-[31m[1m__________________________________ test_generated_metadata_fixtures_round_trip ___________________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-442/test_generated_metadata_fixtur0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_generated_metadata_fixtures_round_trip[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_paths = [96msorted[39;49;00m([90m[39;49;00m
-            path[90m[39;49;00m
-            [94mfor[39;49;00m path [95min[39;49;00m FIXTURES_DIR.glob([33m"[39;49;00m[33m*.drawio[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-            [94mif[39;49;00m [33m"[39;49;00m[33m-with-metadata[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m path.stem [95mand[39;49;00m [95mnot[39;49;00m _fixture_contains_metadata(path)[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m fixture_paths, [33m"[39;49;00m[33mExpected drawio fixtures to patch[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        [94mfor[39;49;00m index, fixture_path [95min[39;49;00m [96menumerate[39;49;00m(fixture_paths):[90m[39;49;00m
-            metadata_options = _build_metadata_options(index, fixture_path)[90m[39;49;00m
-            patched_path = tmp_path / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mfixture_path.stem[33m}[39;49;00m[33m-with-metadata.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            _run_drawio_metadata_patcher(fixture_path, patched_path, metadata_options)[90m[39;49;00m
-    [90m[39;49;00m
-            original_graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-                prefix_iri=metadata_options[[33m"[39;49;00m[33mbaseUri[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-            patched_graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(patched_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-    [90m[39;49;00m
-            [94massert[39;49;00m [96misinstance[39;49;00m(patched_graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-            [94massert[39;49;00m patched_graph.csv_path == metadata_options[[33m"[39;49;00m[33mcsvPath[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-            [94massert[39;49;00m patched_graph.base [95mis[39;49;00m [94mNone[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            namespace_map = {[90m[39;49;00m
-                prefix: [96mstr[39;49;00m(uri)[90m[39;49;00m
-                [94mfor[39;49;00m prefix, uri [95min[39;49;00m patched_graph.namespace_manager.namespaces()[90m[39;49;00m
-            }[90m[39;49;00m
-            [94mfor[39;49;00m preamble_entry [95min[39;49;00m metadata_options[[33m"[39;49;00m[33mpreamble[39;49;00m[33m"[39;49;00m]:[90m[39;49;00m
-                [94massert[39;49;00m ([90m[39;49;00m
-                    namespace_map.get(preamble_entry[[33m"[39;49;00m[33mrdfPrefix[39;49;00m[33m"[39;49;00m])[90m[39;49;00m
-                    == preamble_entry[[33m"[39;49;00m[33mrdfIRI[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-                )[90m[39;49;00m
-            [94massert[39;49;00m namespace_map.get([33m"[39;49;00m[33m"[39;49;00m) == metadata_options[[33m"[39;49;00m[33mbaseUri[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-    [90m[39;49;00m
->           [94massert[39;49;00m _normalise_graph(patched_graph).isomorphic([90m[39;49;00m
-                _normalise_graph(original_graph)[90m[39;49;00m
-            )[90m[39;49;00m
-[1m[31mE           AssertionError: assert False[0m
-[1m[31mE            +  where False = isomorphic(<Graph identifier=Nae13fe3f38dd4123b3aefc4ec805131f (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE            +    where isomorphic = <Graph identifier=N110ef4c0e35c4ffdb80b33868de0d4e8 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-[1m[31mE            +      where <Graph identifier=N110ef4c0e35c4ffdb80b33868de0d4e8 (<class 'rdflib.graph.Graph'>)> = _normalise_graph(<Graph identifier=Nae07f6dbb6844f27a9fdeb01f0a54148 (<class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>)>)[0m
-[1m[31mE            +    and   <Graph identifier=Nae13fe3f38dd4123b3aefc4ec805131f (<class 'rdflib.graph.Graph'>)> = _normalise_graph(<Graph identifier=Nffa1b2ab18444fdba037449819f8a1d5 (<class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>)>)[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:531: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedValue' (gmwnegnUR_CNORKRYM6Y-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (gmwnegnUR_CNORKRYM6Y-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasIdentifierType' (gmwnegnUR_CNORKRYM6Y-18) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadAgentName' (iiJ8OJKaNMLrSCaLO3TT-3) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:resultsOrResultedFrom' (I4GB3cVhTv-sTvJ7h0Jz-41) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordState' (lTHjRTAcClQ9bYR0I0Gv-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedValue' (gmwnegnUR_CNORKRYM6Y-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (gmwnegnUR_CNORKRYM6Y-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasIdentifierType' (gmwnegnUR_CNORKRYM6Y-18) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadAgentName' (iiJ8OJKaNMLrSCaLO3TT-3) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:resultsOrResultedFrom' (I4GB3cVhTv-sTvJ7h0Jz-41) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordState' (lTHjRTAcClQ9bYR0I0Gv-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-46) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-54) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-58) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-66) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-88) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-94) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-107) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:occurredAtDate' (0Zy0miyS0KUs_HnzcUTQ-3) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:authorizedBy' (0Zy0miyS0KUs_HnzcUTQ-9) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:regulatesOrRegulated' (0Zy0miyS0KUs_HnzcUTQ-11) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
+[1mcollecting ... [0m[1mcollected 41 items                                                                                                             [0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m   [  4%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_preserves_literal_targets [32mPASSED[0m[32m         [  7%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_serialise_to_graph_falls_back_for_relative_prefixes [32mPASSED[0m[33m [  9%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[33m [ 12%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [32mPASSED[0m[31m      [ 21%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[31m [ 29%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[31m [ 56%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[31m [ 60%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[31m [ 63%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[31m [ 73%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[31m      [ 85%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [32mPASSED[0m[31m        [ 87%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [32mPASSED[0m[31m      [ 90%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[31m     [ 95%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[31m       [ 97%][0m
+webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [32mPASSED[0m[31m         [100%][0m
+=========================================================== FAILURES ===========================================================
+[31m[1m______________________________ test_parse_drawio_rejects_malformed_type_variants[dangling_curie] _______________________________[0m
+tmp_path = PosixPath('/tmp/pytest-of-root/pytest-4/test_parse_drawio_rejects_malf1'), case_key = 'dangling_curie'
+>       [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
+[1m[31mE       Failed: DID NOT RAISE <class 'draw_io_parser.rdf_data_core.NotInKnownException'>[0m
+[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:206: Failed
+[31m[1m________________________________ test_parse_drawio_rejects_malformed_type_variants[colon_only] _________________________________[0m
+tmp_path = PosixPath('/tmp/pytest-of-root/pytest-4/test_parse_drawio_rejects_malf2'), case_key = 'colon_only'
+>       [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
+[1m[31mE       Failed: DID NOT RAISE <class 'draw_io_parser.rdf_data_core.NotInKnownException'>[0m
+[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:206: Failed
+[31m[1m_________________________________ test_parse_drawio_rejects_malformed_type_variants[no_prefix] _________________________________[0m
+tmp_path = PosixPath('/tmp/pytest-of-root/pytest-4/test_parse_drawio_rejects_malf3'), case_key = 'no_prefix'
+>       [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
+[1m[31mE       Failed: DID NOT RAISE <class 'draw_io_parser.rdf_data_core.NotInKnownException'>[0m
+[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:206: Failed
+[33m======================================================= warnings summary =======================================================[0m
+legacy/tests/test_patched_parser.py: 2169 warnings
+  /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:606: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
+legacy/tests/test_patched_parser.py: 79 warnings
+  /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2568: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
+legacy/tests/test_patched_parser.py: 32 warnings
+  /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2571: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
+[36m[1m=================================================== short test summary info ====================================================[0m
+[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[dangling_curie][0m - Failed: DID NOT RAISE <class 'draw_io_parser.rdf_data_core.NotInKnownException'>
+[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[colon_only][0m - Failed: DID NOT RAISE <class 'draw_io_parser.rdf_data_core.NotInKnownException'>
+[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[no_prefix][0m - Failed: DID NOT RAISE <class 'draw_io_parser.rdf_data_core.NotInKnownException'>
+[31m========================================= [31m[1m3 failed[0m, [32m38 passed[0m, [33m2280 warnings[0m[31m in 14.03s[0m[31m =========================================[0m
+  File "/workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/tests/regenerate_baselines.py", line 294, in <module>
+  File "/workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/tests/regenerate_baselines.py", line 290, in main
+  File "/workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/tests/regenerate_baselines.py", line 216, in run_pytest
+  File "/root/.pyenv/versions/3.12.10/lib/python3.12/subprocess.py", line 571, in run
+subprocess.CalledProcessError: Command '['/workspace/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python', '-m', 'pytest', 'webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py', '-v']' returned non-zero exit status 1.
+[1m===================================================== test session starts ======================================================[0m
+platform linux -- Python 3.12.10, pytest-8.4.2, pluggy-1.6.0
+rootdir: /workspace/drawio/src/main/webapp/plugins/rdfexport
+[1mcollecting ... [0m[1mcollected 91 items                                                                                                             [0m
+legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                                                            [  8%][0m
+legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[33m                                                                                 [ 12%][0m
+legacy/tests/test_debug_cli_regression.py [33ms[0m[32m.[0m[32m.[0m[32m.[0m[31mF[0m[33ms[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0mtail -n 20 /tmp/bun-test-log.log
+[32m.[0m[32m.[0m[32m.[0m^C
+=========================================================== FAILURES ===========================================================
+[31m[1m_________________________________ test_debug_cli_matches_expected_triple_counts[fixture_path4] _________________________________[0m
+fixture_path = PosixPath('/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio')
 Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
 Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
 Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
@@ -1027,10 +221,10 @@ fixture_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins
         scenario_entry = map_data[[33m"[39;49;00m[33mscenarios[39;49;00m[33m"[39;49;00m].get(slug)[90m[39;49;00m
         [94massert[39;49;00m scenario_entry [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m, [33mf[39;49;00m[33m"[39;49;00m[33mScenario [39;49;00m[33m'[39;49;00m[33m{[39;49;00mslug[33m}[39;49;00m[33m'[39;49;00m[33m not recorded[39;49;00m[33m"[39;49;00m[90m[39;49;00m
     [90m[39;49;00m
-        classifications = scenario_entry.get([33m"[39;49;00m[33mcell_classifications[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
-        xml_text = fixture_path.read_text(encoding=[33m"[39;49;00m[33mutf-8[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        results = scenario_entry.get([33m"[39;49;00m[33mresults[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+graph = <Graph identifier=Nab9d0ee7fdb542f299439fb659ae6ae2 (<class 'rdflib.graph.Graph'>)>
+classifications = {'EUA9VVVl7iRi0US9AbU_-1': {'identifier': None, 'kind': 'LITERAL', 'parent_identifier': None, 'raw_value': 'Some node'...bU_-15': {'identifier': None, 'kind': 'ARROW_LABEL', 'parent_identifier': None, 'raw_value': 'hellow:there', ...}, ...}
+xml_text = '<mxfile host="[::]" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chr..."offset" />\n          </mxGeometry>\n        </mxCell>\n      </root>\n    </mxGraphModel>\n  </diagram>\n</mxfile>\n'
         [94mif[39;49;00m [33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m results:[90m[39;49;00m
             errors = scenario_entry.get([33m"[39;49;00m[33merrors[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
             [94massert[39;49;00m [33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m [95min[39;49;00m errors, [33m"[39;49;00m[33mts_plugin graph missing without recorded error[39;49;00m[33m"[39;49;00m[90m[39;49;00m
@@ -1088,1568 +282,50 @@ xml_text = '<mxfile host="app.diagrams.net" modified="2024-06-26T20:21:17.246Z" 
                 identifier = cell_data.get([33m"[39;49;00m[33mparent_identifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m cell_data.get([90m[39;49;00m
                     [33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m[90m[39;49;00m
                 )[90m[39;49;00m
-                [94mif[39;49;00m identifier:[90m[39;49;00m
-                    identifiers.add(identifier)[90m[39;49;00m
-    [90m[39;49;00m
-        identifier_subjects: [96mdict[39;49;00m[[96mstr[39;49;00m, [96mset[39;49;00m] = {}[90m[39;49;00m
-        [94mfor[39;49;00m identifier [95min[39;49;00m identifiers:[90m[39;49;00m
-            subjects = {[90m[39;49;00m
-                subject [94mfor[39;49;00m subject [95min[39;49;00m graph.subjects(RDFS.label, Literal(identifier))[90m[39;49;00m
-            }[90m[39;49;00m
-            identifier_subjects[identifier] = subjects[90m[39;49;00m
-            [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mMissing label triple for identifier [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        [94mfor[39;49;00m cell_id, cell_data [95min[39;49;00m classifications.items():[90m[39;49;00m
-            raw_value = (cell_data.get([33m"[39;49;00m[33mraw_value[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m [33m"[39;49;00m[33m"[39;49;00m).strip()[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m raw_value:[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            kind = cell_data.get([33m"[39;49;00m[33mkind[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mSTANDALONE_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m raw_value[90m[39;49;00m
-                subjects = identifier_subjects.get(identifier, [96mset[39;49;00m())[90m[39;49;00m
-                [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mNo subjects found for standalone [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                tokens = [token [94mfor[39;49;00m token [95min[39;49;00m cell_data.get([33m"[39;49;00m[33mtokens[39;49;00m[33m"[39;49;00m, []) [94mif[39;49;00m token][90m[39;49;00m
-                [94mif[39;49;00m [95mnot[39;49;00m tokens:[90m[39;49;00m
-                    tokens = [default_type][90m[39;49;00m
-                [94mfor[39;49;00m token [95min[39;49;00m tokens:[90m[39;49;00m
-                    expanded = namespace_manager.expand_curie(token)[90m[39;49;00m
-                    [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                        (subject, RDF.type, URIRef(expanded)) [95min[39;49;00m graph[90m[39;49;00m
-                        [94mfor[39;49;00m subject [95min[39;49;00m subjects[90m[39;49;00m
-                    ), [33mf[39;49;00m[33m"[39;49;00m[33mMissing rdf:type [39;49;00m[33m'[39;49;00m[33m{[39;49;00mtoken[33m}[39;49;00m[33m'[39;49;00m[33m for [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mTYPED_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33mparent_identifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m cell_data.get([90m[39;49;00m
-                    [33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                )[90m[39;49;00m
-                [94mif[39;49;00m [95mnot[39;49;00m identifier:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                subjects = identifier_subjects.get(identifier, [96mset[39;49;00m())[90m[39;49;00m
-                [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mNo subjects found for typed [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mfor[39;49;00m token [95min[39;49;00m cell_data.get([33m"[39;49;00m[33mtokens[39;49;00m[33m"[39;49;00m, []):[90m[39;49;00m
-                    [94mif[39;49;00m [95mnot[39;49;00m token:[90m[39;49;00m
-                        [94mcontinue[39;49;00m[90m[39;49;00m
-                    expanded = namespace_manager.expand_curie(token)[90m[39;49;00m
-                    [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                        (subject, RDF.type, URIRef(expanded)) [95min[39;49;00m graph[90m[39;49;00m
-                        [94mfor[39;49;00m subject [95min[39;49;00m subjects[90m[39;49;00m
-                    ), [33mf[39;49;00m[33m"[39;49;00m[33mMissing rdf:type [39;49;00m[33m'[39;49;00m[33m{[39;49;00mtoken[33m}[39;49;00m[33m'[39;49;00m[33m for [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mLITERAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    [96mstr[39;49;00m(obj) == raw_value [94mfor[39;49;00m _, _, obj [95min[39;49;00m graph.triples(([94mNone[39;49;00m, [94mNone[39;49;00m, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mLiteral [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m not found in graph[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mDECORATION[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    obj == Literal(raw_value)[90m[39;49;00m
-                    [94mfor[39;49;00m _, _, obj [95min[39;49;00m graph.triples(([94mNone[39;49;00m, SKOS.note, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mDecoration [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m missing from SKOS notes[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mARROW_LABEL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94mif[39;49;00m [33m"[39;49;00m[33m:[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m raw_value:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                prefix = raw_value.split([33m"[39;49;00m[33m:[39;49;00m[33m"[39;49;00m, [94m1[39;49;00m)[[94m0[39;49;00m][90m[39;49;00m
-                [94mif[39;49;00m prefix [95mnot[39;49;00m [95min[39;49;00m prefixes:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                expanded = namespace_manager.expand_curie(raw_value)[90m[39;49;00m
->               [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    predicate == URIRef(expanded)[90m[39;49;00m
-                    [94mfor[39;49;00m _, predicate, _ [95min[39;49;00m graph.triples(([94mNone[39;49;00m, [94mNone[39;49;00m, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mProperty [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m not used in graph[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-[1m[31mE               AssertionError: Property 'rico:resultsOrResultedFrom' not used in graph[0m
-[1m[31mE               assert False[0m
-[1m[31mE                +  where False = any(<generator object _ensure_graph_covers_classifications.<locals>.<genexpr> at 0x1062b66b0>)[0m
-
-[1m[31mlegacy/tests/test_debug_cli_regression.py[0m:139: AssertionError
-[31m[1m_________________________ test_debug_cli_matches_expected_triple_counts[fixture_path18] __________________________[0m
-
-fixture_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/F 4711 Orville Wood fonds.drawio')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mfixture_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(FIXTURES_DIR.glob([33m"[39;49;00m[33m*.drawio[39;49;00m[33m"[39;49;00m), key=[94mlambda[39;49;00m path: path.name),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_debug_cli_matches_expected_triple_counts[39;49;00m(fixture_path: Path) -> [94mNone[39;49;00m:[90m[39;49;00m
-        slug = _slugify(fixture_path.stem)[90m[39;49;00m
-        cmd = [[90m[39;49;00m
-            sys.executable,[90m[39;49;00m
-            [33m"[39;49;00m[33m-m[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [33m"[39;49;00m[33mdebug[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [33m"[39;49;00m[33m--drawio[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            [33m"[39;49;00m[33m--slug[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            slug,[90m[39;49;00m
-            [33m"[39;49;00m[33m--format[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [33m"[39;49;00m[33mturtle[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        ][90m[39;49;00m
-    [90m[39;49;00m
-        subprocess.run(cmd, cwd=RDFEXPORT_DIR, check=[94mTrue[39;49;00m, capture_output=[94mTrue[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        map_path = DEBUG_DIR / [33m"[39;49;00m[33mmap.json[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        map_data = json.loads(map_path.read_text(encoding=[33m"[39;49;00m[33mutf-8[39;49;00m[33m"[39;49;00m))[90m[39;49;00m
-        scenario_entry = map_data[[33m"[39;49;00m[33mscenarios[39;49;00m[33m"[39;49;00m].get(slug)[90m[39;49;00m
-        [94massert[39;49;00m scenario_entry [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m, [33mf[39;49;00m[33m"[39;49;00m[33mScenario [39;49;00m[33m'[39;49;00m[33m{[39;49;00mslug[33m}[39;49;00m[33m'[39;49;00m[33m not recorded[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        classifications = scenario_entry.get([33m"[39;49;00m[33mcell_classifications[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
-        xml_text = fixture_path.read_text(encoding=[33m"[39;49;00m[33mutf-8[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        results = scenario_entry.get([33m"[39;49;00m[33mresults[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
-        [94mif[39;49;00m [33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m results:[90m[39;49;00m
-            errors = scenario_entry.get([33m"[39;49;00m[33merrors[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
-            [94massert[39;49;00m [33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m [95min[39;49;00m errors, [33m"[39;49;00m[33mts_plugin graph missing without recorded error[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-            pytest.skip([33m"[39;49;00m[33mts_plugin graph unavailable for this fixture[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        ttl_path = DEBUG_DIR / results[[33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m][[33m"[39;49;00m[33mpath[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-        [94massert[39;49;00m ttl_path.exists(), [33mf[39;49;00m[33m"[39;49;00m[33mTurtle output missing for [39;49;00m[33m{[39;49;00mfixture_path.name[33m}[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        graph = Graph()[90m[39;49;00m
-        graph.parse(ttl_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mturtle[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        expected_triples = estimate_triple_count_from_classifications([90m[39;49;00m
-            xml_text, classifications, graph=graph[90m[39;49;00m
-        )[90m[39;49;00m
-        actual_triples = results[[33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m][[33m"[39;49;00m[33mtriples[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-        [94massert[39;49;00m actual_triples == expected_triples, ([90m[39;49;00m
-            [33mf[39;49;00m[33m"[39;49;00m[33mTriple count mismatch for [39;49;00m[33m{[39;49;00mfixture_path.name[33m}[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
->       _ensure_graph_covers_classifications(graph, classifications, xml_text)[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_debug_cli_regression.py[0m:193: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-graph = <Graph identifier=N71521ee247c84559b02b0f26d039acb0 (<class 'rdflib.graph.Graph'>)>
-classifications = {'3LwroSje2Ng83wTQE8dh-1': {'identifier': 'Orville Alan Wood', 'kind': 'STANDALONE_INDIVIDUAL', 'parent_identifier': N...identifier': None, 'kind': 'ARROW_LABEL', 'parent_identifier': None, 'raw_value': 'rico:hasOrHadIdentifier', ...}, ...}
-xml_text = '<mxfile host="app.diagrams.net" modified="2024-04-26T13:53:35.415Z" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) ...ometry relative="1" as="geometry" />\n        </mxCell>\n      </root>\n    </mxGraphModel>\n  </diagram>\n</mxfile>\n'
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92m_ensure_graph_covers_classifications[39;49;00m([90m[39;49;00m
-        graph: Graph,[90m[39;49;00m
-        classifications: [96mdict[39;49;00m[[96mstr[39;49;00m, [96mdict[39;49;00m],[90m[39;49;00m
-        xml_text: [96mstr[39;49;00m,[90m[39;49;00m
-    ) -> [94mNone[39;49;00m:[90m[39;49;00m
-        prefixes = _load_prefixes(xml_text)[90m[39;49;00m
-        namespace_manager = Graph().namespace_manager[90m[39;49;00m
-        [94mfor[39;49;00m prefix, iri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            namespace_manager.bind(prefix, iri, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        classifier_cls = draw_io_parser.pipeline.core.xml.data.DrawIOCellClassifier[90m[39;49;00m
-        default_type = [96mgetattr[39;49;00m([90m[39;49;00m
-            classifier_cls, [33m"[39;49;00m[33mDEFAULT_STANDALONE_TYPE[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mowl:NamedIndividual[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        identifiers: [96mset[39;49;00m[[96mstr[39;49;00m] = [96mset[39;49;00m()[90m[39;49;00m
-        [94mfor[39;49;00m cell_data [95min[39;49;00m classifications.values():[90m[39;49;00m
-            kind = cell_data.get([33m"[39;49;00m[33mkind[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-            raw_value = (cell_data.get([33m"[39;49;00m[33mraw_value[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m [33m"[39;49;00m[33m"[39;49;00m).strip()[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m raw_value:[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mSTANDALONE_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m raw_value[90m[39;49;00m
-                [94mif[39;49;00m identifier:[90m[39;49;00m
-                    identifiers.add(identifier)[90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mTYPED_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33mparent_identifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m cell_data.get([90m[39;49;00m
-                    [33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                )[90m[39;49;00m
-                [94mif[39;49;00m identifier:[90m[39;49;00m
-                    identifiers.add(identifier)[90m[39;49;00m
-    [90m[39;49;00m
-        identifier_subjects: [96mdict[39;49;00m[[96mstr[39;49;00m, [96mset[39;49;00m] = {}[90m[39;49;00m
-        [94mfor[39;49;00m identifier [95min[39;49;00m identifiers:[90m[39;49;00m
-            subjects = {[90m[39;49;00m
-                subject [94mfor[39;49;00m subject [95min[39;49;00m graph.subjects(RDFS.label, Literal(identifier))[90m[39;49;00m
-            }[90m[39;49;00m
-            identifier_subjects[identifier] = subjects[90m[39;49;00m
-            [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mMissing label triple for identifier [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        [94mfor[39;49;00m cell_id, cell_data [95min[39;49;00m classifications.items():[90m[39;49;00m
-            raw_value = (cell_data.get([33m"[39;49;00m[33mraw_value[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m [33m"[39;49;00m[33m"[39;49;00m).strip()[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m raw_value:[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            kind = cell_data.get([33m"[39;49;00m[33mkind[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mSTANDALONE_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m raw_value[90m[39;49;00m
-                subjects = identifier_subjects.get(identifier, [96mset[39;49;00m())[90m[39;49;00m
-                [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mNo subjects found for standalone [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                tokens = [token [94mfor[39;49;00m token [95min[39;49;00m cell_data.get([33m"[39;49;00m[33mtokens[39;49;00m[33m"[39;49;00m, []) [94mif[39;49;00m token][90m[39;49;00m
-                [94mif[39;49;00m [95mnot[39;49;00m tokens:[90m[39;49;00m
-                    tokens = [default_type][90m[39;49;00m
-                [94mfor[39;49;00m token [95min[39;49;00m tokens:[90m[39;49;00m
-                    expanded = namespace_manager.expand_curie(token)[90m[39;49;00m
-                    [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                        (subject, RDF.type, URIRef(expanded)) [95min[39;49;00m graph[90m[39;49;00m
-                        [94mfor[39;49;00m subject [95min[39;49;00m subjects[90m[39;49;00m
-                    ), [33mf[39;49;00m[33m"[39;49;00m[33mMissing rdf:type [39;49;00m[33m'[39;49;00m[33m{[39;49;00mtoken[33m}[39;49;00m[33m'[39;49;00m[33m for [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mTYPED_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33mparent_identifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m cell_data.get([90m[39;49;00m
-                    [33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                )[90m[39;49;00m
-                [94mif[39;49;00m [95mnot[39;49;00m identifier:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                subjects = identifier_subjects.get(identifier, [96mset[39;49;00m())[90m[39;49;00m
-                [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mNo subjects found for typed [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mfor[39;49;00m token [95min[39;49;00m cell_data.get([33m"[39;49;00m[33mtokens[39;49;00m[33m"[39;49;00m, []):[90m[39;49;00m
-                    [94mif[39;49;00m [95mnot[39;49;00m token:[90m[39;49;00m
-                        [94mcontinue[39;49;00m[90m[39;49;00m
-                    expanded = namespace_manager.expand_curie(token)[90m[39;49;00m
-                    [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                        (subject, RDF.type, URIRef(expanded)) [95min[39;49;00m graph[90m[39;49;00m
-                        [94mfor[39;49;00m subject [95min[39;49;00m subjects[90m[39;49;00m
-                    ), [33mf[39;49;00m[33m"[39;49;00m[33mMissing rdf:type [39;49;00m[33m'[39;49;00m[33m{[39;49;00mtoken[33m}[39;49;00m[33m'[39;49;00m[33m for [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mLITERAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    [96mstr[39;49;00m(obj) == raw_value [94mfor[39;49;00m _, _, obj [95min[39;49;00m graph.triples(([94mNone[39;49;00m, [94mNone[39;49;00m, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mLiteral [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m not found in graph[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mDECORATION[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    obj == Literal(raw_value)[90m[39;49;00m
-                    [94mfor[39;49;00m _, _, obj [95min[39;49;00m graph.triples(([94mNone[39;49;00m, SKOS.note, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mDecoration [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m missing from SKOS notes[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mARROW_LABEL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94mif[39;49;00m [33m"[39;49;00m[33m:[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m raw_value:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                prefix = raw_value.split([33m"[39;49;00m[33m:[39;49;00m[33m"[39;49;00m, [94m1[39;49;00m)[[94m0[39;49;00m][90m[39;49;00m
-                [94mif[39;49;00m prefix [95mnot[39;49;00m [95min[39;49;00m prefixes:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                expanded = namespace_manager.expand_curie(raw_value)[90m[39;49;00m
->               [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    predicate == URIRef(expanded)[90m[39;49;00m
-                    [94mfor[39;49;00m _, predicate, _ [95min[39;49;00m graph.triples(([94mNone[39;49;00m, [94mNone[39;49;00m, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mProperty [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m not used in graph[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-[1m[31mE               AssertionError: Property 'rico:hasOrHadIdentifier' not used in graph[0m
-[1m[31mE               assert False[0m
-[1m[31mE                +  where False = any(<generator object _ensure_graph_covers_classifications.<locals>.<genexpr> at 0x1072472e0>)[0m
-
-[1m[31mlegacy/tests/test_debug_cli_regression.py[0m:139: AssertionError
-[31m[1m_________________________ test_debug_cli_matches_expected_triple_counts[fixture_path26] __________________________[0m
-
-fixture_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Walkerton Inquiry in RiC-O (original).drawio')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mfixture_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(FIXTURES_DIR.glob([33m"[39;49;00m[33m*.drawio[39;49;00m[33m"[39;49;00m), key=[94mlambda[39;49;00m path: path.name),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_debug_cli_matches_expected_triple_counts[39;49;00m(fixture_path: Path) -> [94mNone[39;49;00m:[90m[39;49;00m
-        slug = _slugify(fixture_path.stem)[90m[39;49;00m
-        cmd = [[90m[39;49;00m
-            sys.executable,[90m[39;49;00m
-            [33m"[39;49;00m[33m-m[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [33m"[39;49;00m[33mdebug[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [33m"[39;49;00m[33m--drawio[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            [33m"[39;49;00m[33m--slug[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            slug,[90m[39;49;00m
-            [33m"[39;49;00m[33m--format[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            [33m"[39;49;00m[33mturtle[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        ][90m[39;49;00m
-    [90m[39;49;00m
-        subprocess.run(cmd, cwd=RDFEXPORT_DIR, check=[94mTrue[39;49;00m, capture_output=[94mTrue[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        map_path = DEBUG_DIR / [33m"[39;49;00m[33mmap.json[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        map_data = json.loads(map_path.read_text(encoding=[33m"[39;49;00m[33mutf-8[39;49;00m[33m"[39;49;00m))[90m[39;49;00m
-        scenario_entry = map_data[[33m"[39;49;00m[33mscenarios[39;49;00m[33m"[39;49;00m].get(slug)[90m[39;49;00m
-        [94massert[39;49;00m scenario_entry [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m, [33mf[39;49;00m[33m"[39;49;00m[33mScenario [39;49;00m[33m'[39;49;00m[33m{[39;49;00mslug[33m}[39;49;00m[33m'[39;49;00m[33m not recorded[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        classifications = scenario_entry.get([33m"[39;49;00m[33mcell_classifications[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
-        xml_text = fixture_path.read_text(encoding=[33m"[39;49;00m[33mutf-8[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        results = scenario_entry.get([33m"[39;49;00m[33mresults[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
-        [94mif[39;49;00m [33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m results:[90m[39;49;00m
-            errors = scenario_entry.get([33m"[39;49;00m[33merrors[39;49;00m[33m"[39;49;00m, {})[90m[39;49;00m
-            [94massert[39;49;00m [33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m [95min[39;49;00m errors, [33m"[39;49;00m[33mts_plugin graph missing without recorded error[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-            pytest.skip([33m"[39;49;00m[33mts_plugin graph unavailable for this fixture[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        ttl_path = DEBUG_DIR / results[[33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m][[33m"[39;49;00m[33mpath[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-        [94massert[39;49;00m ttl_path.exists(), [33mf[39;49;00m[33m"[39;49;00m[33mTurtle output missing for [39;49;00m[33m{[39;49;00mfixture_path.name[33m}[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        graph = Graph()[90m[39;49;00m
-        graph.parse(ttl_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mturtle[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        expected_triples = estimate_triple_count_from_classifications([90m[39;49;00m
-            xml_text, classifications, graph=graph[90m[39;49;00m
-        )[90m[39;49;00m
-        actual_triples = results[[33m"[39;49;00m[33mts_plugin[39;49;00m[33m"[39;49;00m][[33m"[39;49;00m[33mtriples[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-        [94massert[39;49;00m actual_triples == expected_triples, ([90m[39;49;00m
-            [33mf[39;49;00m[33m"[39;49;00m[33mTriple count mismatch for [39;49;00m[33m{[39;49;00mfixture_path.name[33m}[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
->       _ensure_graph_covers_classifications(graph, classifications, xml_text)[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_debug_cli_regression.py[0m:193: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-graph = <Graph identifier=Ncf9f6dd853c1494a98596880e0a14e17 (<class 'rdflib.graph.Graph'>)>
-classifications = {'0Zy0miyS0KUs_HnzcUTQ-1': {'identifier': 'Closing of Walkerton Inquiry', 'kind': 'STANDALONE_INDIVIDUAL', 'parent_ide... 'kind': 'TYPED_INDIVIDUAL', 'parent_identifier': 'Closing of Walkerton Inquiry', 'raw_value': 'rico:Event', ...}, ...}
-xml_text = '<mxfile host="app.diagrams.net" modified="2024-06-03T17:03:22.962Z" agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) ...ometry relative="1" as="geometry" />\n        </mxCell>\n      </root>\n    </mxGraphModel>\n  </diagram>\n</mxfile>\n'
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92m_ensure_graph_covers_classifications[39;49;00m([90m[39;49;00m
-        graph: Graph,[90m[39;49;00m
-        classifications: [96mdict[39;49;00m[[96mstr[39;49;00m, [96mdict[39;49;00m],[90m[39;49;00m
-        xml_text: [96mstr[39;49;00m,[90m[39;49;00m
-    ) -> [94mNone[39;49;00m:[90m[39;49;00m
-        prefixes = _load_prefixes(xml_text)[90m[39;49;00m
-        namespace_manager = Graph().namespace_manager[90m[39;49;00m
-        [94mfor[39;49;00m prefix, iri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            namespace_manager.bind(prefix, iri, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        classifier_cls = draw_io_parser.pipeline.core.xml.data.DrawIOCellClassifier[90m[39;49;00m
-        default_type = [96mgetattr[39;49;00m([90m[39;49;00m
-            classifier_cls, [33m"[39;49;00m[33mDEFAULT_STANDALONE_TYPE[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mowl:NamedIndividual[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        identifiers: [96mset[39;49;00m[[96mstr[39;49;00m] = [96mset[39;49;00m()[90m[39;49;00m
-        [94mfor[39;49;00m cell_data [95min[39;49;00m classifications.values():[90m[39;49;00m
-            kind = cell_data.get([33m"[39;49;00m[33mkind[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-            raw_value = (cell_data.get([33m"[39;49;00m[33mraw_value[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m [33m"[39;49;00m[33m"[39;49;00m).strip()[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m raw_value:[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mSTANDALONE_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m raw_value[90m[39;49;00m
-                [94mif[39;49;00m identifier:[90m[39;49;00m
-                    identifiers.add(identifier)[90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mTYPED_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33mparent_identifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m cell_data.get([90m[39;49;00m
-                    [33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                )[90m[39;49;00m
-                [94mif[39;49;00m identifier:[90m[39;49;00m
-                    identifiers.add(identifier)[90m[39;49;00m
-    [90m[39;49;00m
-        identifier_subjects: [96mdict[39;49;00m[[96mstr[39;49;00m, [96mset[39;49;00m] = {}[90m[39;49;00m
-        [94mfor[39;49;00m identifier [95min[39;49;00m identifiers:[90m[39;49;00m
-            subjects = {[90m[39;49;00m
-                subject [94mfor[39;49;00m subject [95min[39;49;00m graph.subjects(RDFS.label, Literal(identifier))[90m[39;49;00m
-            }[90m[39;49;00m
-            identifier_subjects[identifier] = subjects[90m[39;49;00m
-            [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mMissing label triple for identifier [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        [94mfor[39;49;00m cell_id, cell_data [95min[39;49;00m classifications.items():[90m[39;49;00m
-            raw_value = (cell_data.get([33m"[39;49;00m[33mraw_value[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m [33m"[39;49;00m[33m"[39;49;00m).strip()[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m raw_value:[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            kind = cell_data.get([33m"[39;49;00m[33mkind[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mSTANDALONE_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m raw_value[90m[39;49;00m
-                subjects = identifier_subjects.get(identifier, [96mset[39;49;00m())[90m[39;49;00m
-                [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mNo subjects found for standalone [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                tokens = [token [94mfor[39;49;00m token [95min[39;49;00m cell_data.get([33m"[39;49;00m[33mtokens[39;49;00m[33m"[39;49;00m, []) [94mif[39;49;00m token][90m[39;49;00m
-                [94mif[39;49;00m [95mnot[39;49;00m tokens:[90m[39;49;00m
-                    tokens = [default_type][90m[39;49;00m
-                [94mfor[39;49;00m token [95min[39;49;00m tokens:[90m[39;49;00m
-                    expanded = namespace_manager.expand_curie(token)[90m[39;49;00m
-                    [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                        (subject, RDF.type, URIRef(expanded)) [95min[39;49;00m graph[90m[39;49;00m
-                        [94mfor[39;49;00m subject [95min[39;49;00m subjects[90m[39;49;00m
-                    ), [33mf[39;49;00m[33m"[39;49;00m[33mMissing rdf:type [39;49;00m[33m'[39;49;00m[33m{[39;49;00mtoken[33m}[39;49;00m[33m'[39;49;00m[33m for [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mTYPED_INDIVIDUAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                identifier = cell_data.get([33m"[39;49;00m[33mparent_identifier[39;49;00m[33m"[39;49;00m) [95mor[39;49;00m cell_data.get([90m[39;49;00m
-                    [33m"[39;49;00m[33midentifier[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                )[90m[39;49;00m
-                [94mif[39;49;00m [95mnot[39;49;00m identifier:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                subjects = identifier_subjects.get(identifier, [96mset[39;49;00m())[90m[39;49;00m
-                [94massert[39;49;00m subjects, [33mf[39;49;00m[33m"[39;49;00m[33mNo subjects found for typed [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mfor[39;49;00m token [95min[39;49;00m cell_data.get([33m"[39;49;00m[33mtokens[39;49;00m[33m"[39;49;00m, []):[90m[39;49;00m
-                    [94mif[39;49;00m [95mnot[39;49;00m token:[90m[39;49;00m
-                        [94mcontinue[39;49;00m[90m[39;49;00m
-                    expanded = namespace_manager.expand_curie(token)[90m[39;49;00m
-                    [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                        (subject, RDF.type, URIRef(expanded)) [95min[39;49;00m graph[90m[39;49;00m
-                        [94mfor[39;49;00m subject [95min[39;49;00m subjects[90m[39;49;00m
-                    ), [33mf[39;49;00m[33m"[39;49;00m[33mMissing rdf:type [39;49;00m[33m'[39;49;00m[33m{[39;49;00mtoken[33m}[39;49;00m[33m'[39;49;00m[33m for [39;49;00m[33m'[39;49;00m[33m{[39;49;00midentifier[33m}[39;49;00m[33m'[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mLITERAL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    [96mstr[39;49;00m(obj) == raw_value [94mfor[39;49;00m _, _, obj [95min[39;49;00m graph.triples(([94mNone[39;49;00m, [94mNone[39;49;00m, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mLiteral [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m not found in graph[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mDECORATION[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    obj == Literal(raw_value)[90m[39;49;00m
-                    [94mfor[39;49;00m _, _, obj [95min[39;49;00m graph.triples(([94mNone[39;49;00m, SKOS.note, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mDecoration [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m missing from SKOS notes[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-                [94mcontinue[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            [94mif[39;49;00m kind == [33m"[39;49;00m[33mARROW_LABEL[39;49;00m[33m"[39;49;00m:[90m[39;49;00m
-                [94mif[39;49;00m [33m"[39;49;00m[33m:[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m raw_value:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                prefix = raw_value.split([33m"[39;49;00m[33m:[39;49;00m[33m"[39;49;00m, [94m1[39;49;00m)[[94m0[39;49;00m][90m[39;49;00m
-                [94mif[39;49;00m prefix [95mnot[39;49;00m [95min[39;49;00m prefixes:[90m[39;49;00m
-                    [94mcontinue[39;49;00m[90m[39;49;00m
-                expanded = namespace_manager.expand_curie(raw_value)[90m[39;49;00m
->               [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
-                    predicate == URIRef(expanded)[90m[39;49;00m
-                    [94mfor[39;49;00m _, predicate, _ [95min[39;49;00m graph.triples(([94mNone[39;49;00m, [94mNone[39;49;00m, [94mNone[39;49;00m))[90m[39;49;00m
-                ), [33mf[39;49;00m[33m"[39;49;00m[33mProperty [39;49;00m[33m'[39;49;00m[33m{[39;49;00mraw_value[33m}[39;49;00m[33m'[39;49;00m[33m not used in graph[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-[1m[31mE               AssertionError: Property 'rico:authorizedBy' not used in graph[0m
-[1m[31mE               assert False[0m
-[1m[31mE                +  where False = any(<generator object _ensure_graph_covers_classifications.<locals>.<genexpr> at 0x1072476a0>)[0m
-
-[1m[31mlegacy/tests/test_debug_cli_regression.py[0m:139: AssertionError
-[31m[1m__________________________________ test_parse_drawio_preserves_literal_targets ___________________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_preserves_literal_targets[39;49;00m():[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(FIXTURES_DIR / [33m"[39;49;00m[33mAA37-with-metadata-even-more-severely-mocked.drawio[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:140: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mlegacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('A%20Ontario%20Government%20...e'}}, ('AA37', 'AA37'): {'Types': {'rico:Identifier'}, 'rico:hasIdentifierType': {('Agent%20Identifier', False)}}, ...}
-object_properties = {'hellow:there', 'rdf:type', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', ...}
-datatype_properties = {'hellow:there', 'rdf:some-predicate', 'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-15-16', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m____________________________ test_serialise_to_graph_falls_back_for_relative_prefixes ____________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_serialise_to_graph_falls_back_for_relative_prefixes[39;49;00m():[90m[39;49;00m
-        prefixes = draw_io_parser.get_prefixes().copy()[90m[39;49;00m
-        prefixes[[33m"[39;49;00m[33mbad[39;49;00m[33m"[39;49;00m] = [33m"[39;49;00m[33mrelative-prefix[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        items = [96miter[39;49;00m([90m[39;49;00m
-            [[90m[39;49;00m
-                draw_io_parser.Individual([33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mowl:NamedIndividual[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-                draw_io_parser.Arrow([90m[39;49;00m
-                    identifier=[33m"[39;49;00m[33mbad:prop[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    source=[33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    target=[33m"[39;49;00m[33mliteral value[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    is_datatype=[94mTrue[39;49;00m,[90m[39;49;00m
-                ),[90m[39;49;00m
-            ][90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        blocks, object_props, datatype_props = draw_io_parser.individual_blocks([90m[39;49;00m
-            items,[90m[39;49;00m
-            [],[90m[39;49;00m
-            [94mNone[39;49;00m,[90m[39;49;00m
-            draw_io_parser.DEFAULT_CAPITALISATION_SCHEME,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        config = draw_io_parser.SerialisationConfig([90m[39;49;00m
-            infer_type_of_literals=[94mTrue[39;49;00m,[90m[39;49;00m
-            include_preamble=[94mFalse[39;49;00m,[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33mhttp://example.com/ontology[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix=[33m"[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix_iri=[33m"[39;49;00m[33mhttp://example.com/[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            indentation=[94m2[39;49;00m,[90m[39;49;00m
-            include_label=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
->       graph = draw_io_parser.serialise_to_graph([90m[39;49;00m
-            blocks,[90m[39;49;00m
-            object_props,[90m[39;49;00m
-            datatype_props,[90m[39;49;00m
-            config,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:185: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('Source', 'Source'): {'Types': {'owl:NamedIndividual'}, 'bad:prop': {('literal value', True)}}}
-object_properties = set(), datatype_properties = {'bad:prop'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=False, ontology_iri='http://example.com/ontology', prefix='', prefix_iri='http://example.com/', indentation=2, include_label=False)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...gbad.ca/Schema/Authority/', 'bad': 'relative-prefix', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', ...}
-graph_cls = <class 'rdflib.graph.Graph'>, graph_kwargs = {}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'relative-prefix' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m_______________________ test_parse_drawio_rejects_malformed_type_variants[dangling_curie] ________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-443/test_parse_drawio_rejects_malf1')
-case_key = 'dangling_curie'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mlegacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-15-17', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m_________________________ test_parse_drawio_rejects_malformed_type_variants[colon_only] __________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-443/test_parse_drawio_rejects_malf2')
-case_key = 'colon_only'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mlegacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-15-17', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m__________________________ test_parse_drawio_rejects_malformed_type_variants[no_prefix] __________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-443/test_parse_drawio_rejects_malf3')
-case_key = 'no_prefix'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mlegacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-15-17', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m_________________________________ test_parse_drawio_accepts_corrected_mock_types _________________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-443/test_parse_drawio_accepts_corr0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_accepts_corrected_mock_types[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, [94mNone[39;49;00m)[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:215: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-[1m[31mlegacy/draw_io_parser.py[0m:2632: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2322: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-21T22-15-17', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2451: ParseException
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path2] ____________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/BA619 Walkerton Inquiry.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=N41153bfd3917445faada4bca724b3106 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=N428f3eb943dc494cb52e40135547032f (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedValue' (gmwnegnUR_CNORKRYM6Y-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (gmwnegnUR_CNORKRYM6Y-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasIdentifierType' (gmwnegnUR_CNORKRYM6Y-18) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadAgentName' (iiJ8OJKaNMLrSCaLO3TT-3) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:resultsOrResultedFrom' (I4GB3cVhTv-sTvJ7h0Jz-41) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordState' (lTHjRTAcClQ9bYR0I0Gv-15) has no valid source.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path13] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/F 4711 Orville Wood fonds.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=N9baad8961d3542cf8b24b5a7de5ab736 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=Nae04306ec4524eee9e35b3b66ddb7659 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path15] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/General Authority to RiC-O Model_2025-06-25_PZ.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=Ne8bf5ca14b14429e9958be1a08b768b7 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=N7effc219999742b0966d44feaeea4ebd (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path16] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=Nc2e99f5659fb422c9350641a277e5c56 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=Ndf030d52e3a3469ca73fc2681dcee127 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-[31m[1m___________________________ test_parse_drawio_matches_baseline_graphs[baseline_path20] ___________________________[0m
-
-baseline_path = PosixPath('/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/baselines/RG 18-210 Walkerton Inquiry in RiC-O (original).nt')
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mbaseline_path[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [96msorted[39;49;00m(BASELINES_DIR.glob([33m"[39;49;00m[33m*.nt[39;49;00m[33m"[39;49;00m)),[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_matches_baseline_graphs[39;49;00m(baseline_path: Path):[90m[39;49;00m
-        fixture_path = FIXTURES_DIR / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mbaseline_path.stem[33m}[39;49;00m[33m.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        expected = Graph()[90m[39;49;00m
-        expected.parse(baseline_path, [96mformat[39;49;00m=[33m"[39;49;00m[33mnt[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-    [90m[39;49;00m
-        actual = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33montology://generated-from-draw-io/mock[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        expected_normalised = _normalise_graph(expected)[90m[39;49;00m
-        actual_normalised = _normalise_graph(actual)[90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m actual_normalised.isomorphic(expected_normalised)[90m[39;49;00m
-[1m[31mE       AssertionError: assert False[0m
-[1m[31mE        +  where False = isomorphic(<Graph identifier=N7b9d86a52245427abd8f83a64f5a6b5a (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE        +    where isomorphic = <Graph identifier=N89f52f9062ff4b2389d469d5697b51f7 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:272: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-46) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-54) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-58) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-66) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-88) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-94) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-107) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:occurredAtDate' (0Zy0miyS0KUs_HnzcUTQ-3) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:authorizedBy' (0Zy0miyS0KUs_HnzcUTQ-9) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:regulatesOrRegulated' (0Zy0miyS0KUs_HnzcUTQ-11) has no valid source.
-[31m[1m__________________________________ test_parse_drawio_respects_strip_html_config __________________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_respects_strip_html_config[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            strip_html=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:361: AssertionError
-[31m[1m_________________________________ test_parse_drawio_metadata_strip_html_override _________________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_metadata_strip_html_override[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:388: AssertionError
-[31m[1m__________________________________ test_generated_metadata_fixtures_round_trip ___________________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-443/test_generated_metadata_fixtur0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_generated_metadata_fixtures_round_trip[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_paths = [96msorted[39;49;00m([90m[39;49;00m
-            path[90m[39;49;00m
-            [94mfor[39;49;00m path [95min[39;49;00m FIXTURES_DIR.glob([33m"[39;49;00m[33m*.drawio[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-            [94mif[39;49;00m [33m"[39;49;00m[33m-with-metadata[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m path.stem [95mand[39;49;00m [95mnot[39;49;00m _fixture_contains_metadata(path)[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m fixture_paths, [33m"[39;49;00m[33mExpected drawio fixtures to patch[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        [94mfor[39;49;00m index, fixture_path [95min[39;49;00m [96menumerate[39;49;00m(fixture_paths):[90m[39;49;00m
-            metadata_options = _build_metadata_options(index, fixture_path)[90m[39;49;00m
-            patched_path = tmp_path / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mfixture_path.stem[33m}[39;49;00m[33m-with-metadata.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            _run_drawio_metadata_patcher(fixture_path, patched_path, metadata_options)[90m[39;49;00m
-    [90m[39;49;00m
-            original_graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-                prefix_iri=metadata_options[[33m"[39;49;00m[33mbaseUri[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-            patched_graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(patched_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-    [90m[39;49;00m
-            [94massert[39;49;00m [96misinstance[39;49;00m(patched_graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-            [94massert[39;49;00m patched_graph.csv_path == metadata_options[[33m"[39;49;00m[33mcsvPath[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-            [94massert[39;49;00m patched_graph.base [95mis[39;49;00m [94mNone[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-            namespace_map = {[90m[39;49;00m
-                prefix: [96mstr[39;49;00m(uri)[90m[39;49;00m
-                [94mfor[39;49;00m prefix, uri [95min[39;49;00m patched_graph.namespace_manager.namespaces()[90m[39;49;00m
-            }[90m[39;49;00m
-            [94mfor[39;49;00m preamble_entry [95min[39;49;00m metadata_options[[33m"[39;49;00m[33mpreamble[39;49;00m[33m"[39;49;00m]:[90m[39;49;00m
-                [94massert[39;49;00m ([90m[39;49;00m
-                    namespace_map.get(preamble_entry[[33m"[39;49;00m[33mrdfPrefix[39;49;00m[33m"[39;49;00m])[90m[39;49;00m
-                    == preamble_entry[[33m"[39;49;00m[33mrdfIRI[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-                )[90m[39;49;00m
-            [94massert[39;49;00m namespace_map.get([33m"[39;49;00m[33m"[39;49;00m) == metadata_options[[33m"[39;49;00m[33mbaseUri[39;49;00m[33m"[39;49;00m][90m[39;49;00m
-    [90m[39;49;00m
->           [94massert[39;49;00m _normalise_graph(patched_graph).isomorphic([90m[39;49;00m
-                _normalise_graph(original_graph)[90m[39;49;00m
-            )[90m[39;49;00m
-[1m[31mE           AssertionError: assert False[0m
-[1m[31mE            +  where False = isomorphic(<Graph identifier=N0be47297408042979bca8111bd2e9864 (<class 'rdflib.graph.Graph'>)>)[0m
-[1m[31mE            +    where isomorphic = <Graph identifier=N32ff8d0165fc42f6b80732d7c7b63972 (<class 'rdflib.graph.Graph'>)>.isomorphic[0m
-[1m[31mE            +      where <Graph identifier=N32ff8d0165fc42f6b80732d7c7b63972 (<class 'rdflib.graph.Graph'>)> = _normalise_graph(<Graph identifier=N22a64d4738ed4b4fb7346e8944603390 (<class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>)>)[0m
-[1m[31mE            +    and   <Graph identifier=N0be47297408042979bca8111bd2e9864 (<class 'rdflib.graph.Graph'>)> = _normalise_graph(<Graph identifier=Nf82c61b8c64a4350aaa9223b6325b0bd (<class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>)>)[0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:531: AssertionError
----------------------------------------------- Captured stdout call ----------------------------------------------
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedValue' (gmwnegnUR_CNORKRYM6Y-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (gmwnegnUR_CNORKRYM6Y-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasIdentifierType' (gmwnegnUR_CNORKRYM6Y-18) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadAgentName' (iiJ8OJKaNMLrSCaLO3TT-3) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:resultsOrResultedFrom' (I4GB3cVhTv-sTvJ7h0Jz-41) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordState' (lTHjRTAcClQ9bYR0I0Gv-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedValue' (gmwnegnUR_CNORKRYM6Y-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (gmwnegnUR_CNORKRYM6Y-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasIdentifierType' (gmwnegnUR_CNORKRYM6Y-18) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadAgentName' (iiJ8OJKaNMLrSCaLO3TT-3) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:resultsOrResultedFrom' (I4GB3cVhTv-sTvJ7h0Jz-41) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordState' (lTHjRTAcClQ9bYR0I0Gv-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-46) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-54) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-58) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-66) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-88) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-94) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-107) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:occurredAtDate' (0Zy0miyS0KUs_HnzcUTQ-3) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:authorizedBy' (0Zy0miyS0KUs_HnzcUTQ-9) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:regulatesOrRegulated' (0Zy0miyS0KUs_HnzcUTQ-11) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-26) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-30) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-46) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-54) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-58) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-62) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-66) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-76) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-88) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-94) has no target.
-Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-107) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:occurredAtDate' (0Zy0miyS0KUs_HnzcUTQ-3) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:authorizedBy' (0Zy0miyS0KUs_HnzcUTQ-9) has no valid source.
-Warning: Skipping arrow due to error: Arrow 'rico:regulatesOrRegulated' (0Zy0miyS0KUs_HnzcUTQ-11) has no valid source.
-[33m================================================ warnings summary ================================================[0m
-legacy/tests/test_cell_classifier.py: 3 warnings
-legacy/tests/test_patched_parser.py: 72 warnings
-legacy/tests/test_pyodide_pipeline.py: 5 warnings
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2340: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
+>                   [94massert[39;49;00m [96many[39;49;00m([90m[39;49;00m
+[1m[31mE                   AssertionError: Missing rdf:type 'picoL:j' for 'https://example.com'[0m
+[1m[31mE                   assert False[0m
+[1m[31mE                    +  where False = any(<generator object _ensure_graph_covers_classifications.<locals>.<genexpr> at 0x7f8327797790>)[0m
+
+[1m[31mlegacy/tests/test_debug_cli_regression.py[0m:95: AssertionError
+[33m======================================================= warnings summary =======================================================[0m
+legacy/tests/test_cell_classifier.py::test_decorations_serialise_to_skos_note
+legacy/tests/test_cell_classifier.py::test_connected_literal_not_treated_as_decoration
+legacy/tests/test_cell_classifier.py::test_blank_node_used_for_decorations_without_ontology
+  /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2568: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
     parsed_root
-
-legacy/tests/test_cell_classifier.py: 1 warning
-legacy/tests/test_patched_parser.py: 1992 warnings
-legacy/tests/test_pyodide_pipeline.py: 105 warnings
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:405: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
+legacy/tests/test_cell_classifier.py::test_connected_literal_not_treated_as_decoration
+  /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:606: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
     target_cell
-
-legacy/tests/test_patched_parser.py: 26 warnings
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2343: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
-    if parsed_root.find(".//UserObject[@id='0']")
-
--- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-[36m[1m============================================ short test summary info =============================================[0m
-[31mFAILED[0m legacy/tests/test_debug_cli_regression.py::[1mtest_debug_cli_matches_expected_triple_counts[fixture_path7][0m - AssertionError: Property 'rico:resultsOrResultedFrom' not used in graph
-[31mFAILED[0m legacy/tests/test_debug_cli_regression.py::[1mtest_debug_cli_matches_expected_triple_counts[fixture_path18][0m - AssertionError: Property 'rico:hasOrHadIdentifier' not used in graph
-[31mFAILED[0m legacy/tests/test_debug_cli_regression.py::[1mtest_debug_cli_matches_expected_triple_counts[fixture_path26][0m - AssertionError: Property 'rico:authorizedBy' not used in graph
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_preserves_literal_targets[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_serialise_to_graph_falls_back_for_relative_prefixes[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI 'relative-prefix' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[dangling_curie][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[colon_only][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[no_prefix][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_accepts_corrected_mock_types[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_matches_baseline_graphs[baseline_path2][0m - AssertionError: assert False
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_matches_baseline_graphs[baseline_path13][0m - AssertionError: assert False
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_matches_baseline_graphs[baseline_path15][0m - AssertionError: assert False
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_matches_baseline_graphs[baseline_path16][0m - AssertionError: assert False
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_matches_baseline_graphs[baseline_path20][0m - AssertionError: assert False
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_respects_strip_html_config[0m - assert []
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_metadata_strip_html_override[0m - assert []
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_generated_metadata_fixtures_round_trip[0m - AssertionError: assert False
-[31m======================= [31m[1m17 failed[0m, [32m71 passed[0m, [33m3 skipped[0m, [33m2204 warnings[0m[31m in 92.47s (0:01:32)[0m[31m =======================[0m
-[0m[1mbun test [0m[2mv1.2.21 (7c45ed97)[0m
-[0m
-tests/rdfexport.test.ts:
-[BLACKBOX] Received serialized payload (36445 characters)
-[PIPELINE] Initializing Pyodide runtime from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
-[PIPELINE] Pyodide runtime ready
-[PIPELINE] Preparing Pyodide Python environment
-[PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/__init__.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/drawio_pipeline.py
-[PIPELINE] Syncing Python wheel to virtual FS: /app/wheels/rdflib-7.2.1-py3-none-any.whl
-[PIPELINE] Pyodide Python environment ready
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
-[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
-[BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m2265.95ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[0.89ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m43.23ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (61829 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-[PIPELINE] DrawIO parser produced graph graph-1 with 107 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 107 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (6181 characters)
-[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasDeathDate' (8qowTDT7rcuFTGcXUesK-10) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasBirthPlace' (8qowTDT7rcuFTGcXUesK-15) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8qowTDT7rcuFTGcXUesK-19) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isCreatorOf' (8qowTDT7rcuFTGcXUesK-23) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-10) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (8iNWTTVriAF58_KymOXL-12) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-22) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasCreationDate' (8iNWTTVriAF58_KymOXL-26) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-138) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (8iNWTTVriAF58_KymOXL-30) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSomeMembersWithContentType' (8iNWTTVriAF58_KymOXL-46) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isAgentAssociatedWithPlace' (8iNWTTVriAF58_KymOXL-54) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:conditionsOfAccess' (8iNWTTVriAF58_KymOXL-62) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-70) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:accruals' (8iNWTTVriAF58_KymOXL-76) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:history' (8iNWTTVriAF58_KymOXL-79) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasGeneticLinkToRecordResource' (8iNWTTVriAF58_KymOXL-84) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-92) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (8iNWTTVriAF58_KymOXL-98) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-100) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadIdentifier' (8iNWTTVriAF58_KymOXL-102) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadSubject' (8iNWTTVriAF58_KymOXL-130) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (8iNWTTVriAF58_KymOXL-140) has no target.
-[PIPELINE] DrawIO parser produced graph graph-2 with 107 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 107 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (6181 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 107 vs 107
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[0m[1m1138 |[0m       actual_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1139 |[0m       baseline_filtered_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1140 |[0m       actual_filtered_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1141 |[0m     }[0m[2m;[0m
-[0m[1m1142 |[0m 
-[0m[1m1143 |[0m     expect(isomorphismResult.actual_filtered_triples)[0m[3m[1m.toBe[0m(
-                                                             [31m[1m^[0m
-[0m[31merror[0m[2m:[0m [1m[2mexpect([0m[31mreceived[0m[2m).[0mtoBe[2m([0m[32mexpected[0m[2m)[0m
-
-Expected: [32m124[0m
-Received: [31m105[0m
-[0m
-[0m      [2mat [0m[0m[2m<anonymous>[0m[2m ([0m[0m[36m/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts[0m[2m:[0m[33m1143[0m[2m:[33m55[0m[2m)[0m
-[0m[31m✗[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m278.99ms[0m[2m][0m
-[0m[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44261 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
-[PIPELINE] DrawIO parser produced graph graph-3 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (5497 characters)
-[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
-[PIPELINE] DrawIO parser produced graph graph-5 with 94 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 94 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (5563 characters)
-[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m232.16ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23410 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-[PIPELINE] DrawIO parser produced graph graph-6 with 52 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 52 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (2914 characters)
-[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isDirectlyIncludedIn' (Jj78cHQdAaoJRiL902HJ-1) has no valid source.
-[PIPELINE] DrawIO parser produced graph graph-7 with 52 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 52 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (2914 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 52 vs 52
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[0m[1m1138 |[0m       actual_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1139 |[0m       baseline_filtered_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1140 |[0m       actual_filtered_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1141 |[0m     }[0m[2m;[0m
-[0m[1m1142 |[0m 
-[0m[1m1143 |[0m     expect(isomorphismResult.actual_filtered_triples)[0m[3m[1m.toBe[0m(
-                                                             [31m[1m^[0m
-[0m[31merror[0m[2m:[0m [1m[2mexpect([0m[31mreceived[0m[2m).[0mtoBe[2m([0m[32mexpected[0m[2m)[0m
-
-Expected: [32m51[0m
-Received: [31m50[0m
-[0m
-[0m      [2mat [0m[0m[2m<anonymous>[0m[2m ([0m[0m[36m/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts[0m[2m:[0m[33m1143[0m[2m:[33m55[0m[2m)[0m
-[0m[31m✗[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m88.31ms[0m[2m][0m
-[0m[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23546 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
-[PIPELINE] DrawIO parser produced graph graph-8 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (3738 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-9 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (3738 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
-[PIPELINE] DrawIO parser produced graph graph-10 with 51 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 51 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (3804 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m113.76ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39399 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
-[PIPELINE] DrawIO parser produced graph graph-11 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-12 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
-[PIPELINE] DrawIO parser produced graph graph-13 with 78 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 78 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (4656 characters)
-[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m164.85ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44795 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
-[PIPELINE] DrawIO parser produced graph graph-14 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-15 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (5458 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
-[PIPELINE] DrawIO parser produced graph graph-16 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (5524 characters)
-[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m175.55ms[0m[2m][0m
+[36m[1m=================================================== short test summary info ====================================================[0m
+[31mFAILED[0m legacy/tests/test_debug_cli_regression.py::[1mtest_debug_cli_matches_expected_triple_counts[fixture_path4][0m - AssertionError: Missing rdf:type 'picoL:j' for 'https://example.com'
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! KeyboardInterrupt !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+[1m[31m/root/.pyenv/versions/3.12.10/lib/python3.12/selectors.py[0m:415: KeyboardInterrupt
+[33m(to show a full traceback on KeyboardInterrupt use --full-trace)[0m
+[31m=============================== [31m[1m1 failed[0m, [32m23 passed[0m, [33m2 skipped[0m, [33m4 warnings[0m[31m in 219.36s (0:03:39)[0m[31m ================================[0m
+[0m[1mbun test [0m[2mv1.2.14 (6a363a38)[0m
+[PIPELINE] Initializing Pyodide runtime from /workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
+[PIPELINE] DrawIO parser produced graph graph-0 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-0 with 87 triples
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[0m[33m13004.24ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[7.23ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m360.43ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (39329 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
-[PIPELINE] DrawIO parser produced graph graph-17 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (5053 characters)
+[PIPELINE] DrawIO parser produced graph graph-1 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (5897 characters)
 [PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
 [PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-18 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5053 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
+[PIPELINE] DrawIO parser produced graph graph-2 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (5897 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 89 vs 89
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
@@ -2657,298 +333,75 @@ Received: [31m50[0m
 [PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
-[PIPELINE] DrawIO parser produced graph graph-19 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (5119 characters)
+[PIPELINE] DrawIO parser produced graph graph-3 with 90 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 90 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5963 characters)
 [PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m147.86ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (73837 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-[PIPELINE] DrawIO parser produced graph graph-20 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (9148 characters)
-[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rdfs:label' (mXWEuhzCrtuQsP6tQl7L-9) has no target.
-[PIPELINE] DrawIO parser produced graph graph-21 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (9148 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[0m[1m1146 |[0m     expect(isomorphismResult.actual_filtered_triples)[0m[3m[1m.toBeGreaterThan[0m([0m[33m0[0m)[0m[2m;[0m
-[0m[1m1147 |[0m     logInfo(
-[0m[1m1148 |[0m       LOG_PREFIX.TEST,
-[0m[1m1149 |[0m       [0m[32m`Number of filtered triples in Turtle vs baseline N-Triples: [0m${isomorphismResult.actual_filtered_triples}[0m[32m vs [0m${isomorphismResult.baseline_filtered_triples}[0m[32m`[0m,
-[0m[1m1150 |[0m     )[0m[2m;[0m
-[0m[1m1151 |[0m     expect(isomorphismResult.isomorphic)[0m[3m[1m.toBe[0m([0m[33mtrue[0m)[0m[2m;[0m
-                                                [31m[1m^[0m
-[0m[31merror[0m[2m:[0m [1m[2mexpect([0m[31mreceived[0m[2m).[0mtoBe[2m([0m[32mexpected[0m[2m)[0m
-
-Expected: [32mtrue[0m
-Received: [31mfalse[0m
-[0m
-[0m      [2mat [0m[0m[2m<anonymous>[0m[2m ([0m[0m[36m/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts[0m[2m:[0m[33m1151[0m[2m:[33m42[0m[2m)[0m
-[0m[31m✗[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m211.97ms[0m[2m][0m
-[0m[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m1466.60ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-4 with 141 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 141 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (7884 characters)
+[PIPELINE] DrawIO parser produced graph graph-5 with 141 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 141 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (7884 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 141 vs 141
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
+[PIPELINE] DrawIO parser produced graph graph-6 with 142 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 142 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (7950 characters)
+[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m1199.91ms[0m[2m][0m
 [0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] Generated DrawIO XML payload (30823 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (30823 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30823)
+[PIPELINE] DrawIO parser produced graph graph-7 with 79 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 79 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (5796 characters)
+[PIPELINE] Saving export payload to BA619 Walkerton Inquiry.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (30806 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30806)
+[PIPELINE] DrawIO parser produced graph graph-8 with 79 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 79 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (5796 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 79 vs 79
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 62 vs 62
+[PIPELINE] Generated DrawIO XML payload (30841 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (30841 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 30841)
+[PIPELINE] DrawIO parser produced graph graph-9 with 80 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 80 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (5862 characters)
+[PIPELINE] Saving RML export payload to BA619 Walkerton Inquiry.rml.ttl
+[PIPELINE] Export pipeline completed for BA619 Walkerton Inquiry.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m597.38ms[0m[2m][0m
 [0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (80881 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-26) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-30) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-46) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-54) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-58) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-62) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-66) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-76) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-88) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-94) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-107) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:occurredAtDate' (0Zy0miyS0KUs_HnzcUTQ-3) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:authorizedBy' (0Zy0miyS0KUs_HnzcUTQ-9) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:regulatesOrRegulated' (0Zy0miyS0KUs_HnzcUTQ-11) has no valid source.
-[PIPELINE] DrawIO parser produced graph graph-22 with 148 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 148 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (9681 characters)
-[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithEvent' (ccQ81NhYz9qmqgse-E7F-24) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isAssociatedWithPlace' (ccQ81NhYz9qmqgse-E7F-16) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasOrHadPlaceType' (ccQ81NhYz9qmqgse-E7F-20) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasBeginningDate' (ccQ81NhYz9qmqgse-E7F-28) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-30) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-36) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-38) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:isOrWasRegulatedBy' (ccQ81NhYz9qmqgse-E7F-42) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:occupiesOrOccupied' (ccQ81NhYz9qmqgse-E7F-64) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasEndDate' (ccQ81NhYz9qmqgse-E7F-70) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-76) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:normalizedDateValue' (ccQ81NhYz9qmqgse-E7F-78) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-13) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-16) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-26) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-30) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-46) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-54) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-58) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-62) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:includesOrIncluded' (HLbPBR5fNmHbn4HrSuu7-66) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-76) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-88) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-94) has no target.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:hasRecordSetType' (HLbPBR5fNmHbn4HrSuu7-107) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:occurredAtDate' (0Zy0miyS0KUs_HnzcUTQ-3) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:authorizedBy' (0Zy0miyS0KUs_HnzcUTQ-9) has no valid source.
-[PYODIDE] Warning: Skipping arrow due to error: Arrow 'rico:regulatesOrRegulated' (0Zy0miyS0KUs_HnzcUTQ-11) has no valid source.
-[PIPELINE] DrawIO parser produced graph graph-23 with 148 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 148 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (9681 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 148 vs 148
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[0m[1m1138 |[0m       actual_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1139 |[0m       baseline_filtered_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1140 |[0m       actual_filtered_triples: [0m[34mnumber[0m[0m[2m;[0m
-[0m[1m1141 |[0m     }[0m[2m;[0m
-[0m[1m1142 |[0m 
-[0m[1m1143 |[0m     expect(isomorphismResult.actual_filtered_triples)[0m[3m[1m.toBe[0m(
-                                                             [31m[1m^[0m
-[0m[31merror[0m[2m:[0m [1m[2mexpect([0m[31mreceived[0m[2m).[0mtoBe[2m([0m[32mexpected[0m[2m)[0m
-
-Expected: [32m170[0m
-Received: [31m146[0m
-[0m
-[0m      [2mat [0m[0m[2m<anonymous>[0m[2m ([0m[0m[36m/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts[0m[2m:[0m[33m1143[0m[2m:[33m55[0m[2m)[0m
-[0m[31m✗[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m225.56ms[0m[2m][0m
-[0m[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37618 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
-[PIPELINE] DrawIO parser produced graph graph-24 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (4345 characters)
-[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-25 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (4345 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
-[PIPELINE] DrawIO parser produced graph graph-26 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (4411 characters)
-[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m154.10ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (95213 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
-[PIPELINE] DrawIO parser produced graph graph-27 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (9826 characters)
-[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-28 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-28 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-28 (9826 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
-[PIPELINE] DrawIO parser produced graph graph-29 with 144 triples
-[BLACKBOX] Parsed DrawIO graph graph-29 with 144 triples
-[BLACKBOX] Returning Turtle payload for graph graph-29 (9892 characters)
-[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m311.28ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (54132 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
-[PIPELINE] DrawIO parser produced graph graph-30 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-30 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-30 (6195 characters)
-[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-31 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-31 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-31 (6195 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
-[PIPELINE] DrawIO parser produced graph graph-32 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-32 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-32 (6261 characters)
-[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m188.32ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (58348 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
-[PIPELINE] DrawIO parser produced graph graph-33 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-33 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-33 (9207 characters)
-[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-34 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (9207 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
-[PIPELINE] DrawIO parser produced graph graph-35 with 104 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 104 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (9273 characters)
-[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m196.35ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (34895 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
-[PIPELINE] DrawIO parser produced graph graph-36 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (5761 characters)
-[PIPELINE] Saving export payload to AA37 Department of Health.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-37 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-37 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-37 (5761 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
-[PIPELINE] DrawIO parser produced graph graph-38 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-38 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-38 (5827 characters)
-[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m133.99ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (49944 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (49944 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49944)
-[PIPELINE] DrawIO parser produced graph graph-39 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-39 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-39 (6443 characters)
+[PIPELINE] DrawIO parser produced graph graph-10 with 113 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 113 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (7287 characters)
 [PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-40 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-40 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-40 (6443 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
+[PIPELINE] DrawIO parser produced graph graph-11 with 113 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 113 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (7287 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 113 vs 113
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
@@ -2956,57 +409,28 @@ Received: [31m146[0m
 [PIPELINE] Generated DrawIO XML payload (49962 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (49962 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49962)
-[PIPELINE] DrawIO parser produced graph graph-41 with 99 triples
-[BLACKBOX] Parsed DrawIO graph graph-41 with 99 triples
-[BLACKBOX] Returning Turtle payload for graph graph-41 (6509 characters)
+[PIPELINE] DrawIO parser produced graph graph-12 with 114 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 114 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (7353 characters)
 [PIPELINE] Saving RML export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m196.71ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (32209 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (32209 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32209)
-[PIPELINE] DrawIO parser produced graph graph-42 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-42 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-42 (3931 characters)
-[PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-43 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-43 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-43 (3931 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (32227 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (32227 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 32227)
-[PIPELINE] DrawIO parser produced graph graph-44 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-44 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-44 (3997 characters)
-[PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
-[PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m121.93ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m985.44ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (40866 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (40866 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 40866)
-[PIPELINE] DrawIO parser produced graph graph-45 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-45 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-45 (5715 characters)
+[PIPELINE] DrawIO parser produced graph graph-13 with 101 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 101 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (6559 characters)
 [PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
 [PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
 [BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
-[PIPELINE] DrawIO parser produced graph graph-46 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-46 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-46 (5715 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
+[PIPELINE] DrawIO parser produced graph graph-14 with 101 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 101 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (6559 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 101 vs 101
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
@@ -3014,13 +438,386 @@ Received: [31m146[0m
 [PIPELINE] Generated DrawIO XML payload (40884 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (40884 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 40884)
-[PIPELINE] DrawIO parser produced graph graph-47 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-47 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-47 (5781 characters)
+[PIPELINE] DrawIO parser produced graph graph-15 with 102 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 102 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (6625 characters)
 [PIPELINE] Saving RML export payload to F 47-11-1-0-1 (VDB test).rml.ttl
 [PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m149.80ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m754.24ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-16 with 68 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 68 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (3846 characters)
+[PIPELINE] DrawIO parser produced graph graph-17 with 68 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 68 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (3846 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 68 vs 68
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
+[PIPELINE] DrawIO parser produced graph graph-18 with 69 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 69 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (3912 characters)
+[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m489.22ms[0m[2m][0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] DrawIO parser produced graph graph-19 with 65 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 65 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (4582 characters)
+[PIPELINE] DrawIO parser produced graph graph-20 with 65 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 65 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (4582 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 65 vs 65
+[PIPELINE] DrawIO parser produced graph graph-21 with 66 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 66 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (4648 characters)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m619.72ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (37299 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37299 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37299)
+[PIPELINE] DrawIO parser produced graph graph-22 with 90 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 90 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (5213 characters)
+[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-23 with 90 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 90 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (5213 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 90 vs 90
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (37317 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37317 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37317)
+[PIPELINE] DrawIO parser produced graph graph-24 with 91 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 91 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (5279 characters)
+[PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m722.16ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (58348 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
+[PIPELINE] DrawIO parser produced graph graph-25 with 118 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 118 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (10051 characters)
+[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
+[PIPELINE] DrawIO parser produced graph graph-26 with 118 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 118 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (10051 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 118 vs 118
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
+[PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
+[PIPELINE] DrawIO parser produced graph graph-27 with 119 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 119 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (10117 characters)
+[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m1837.51ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (44261 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
+[PIPELINE] DrawIO parser produced graph graph-28 with 108 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 108 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (6341 characters)
+[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
+[PIPELINE] DrawIO parser produced graph graph-29 with 108 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 108 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (6341 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 108 vs 108
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
+[PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
+[PIPELINE] DrawIO parser produced graph graph-30 with 109 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 109 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (6407 characters)
+[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m1782.47ms[0m[2m][0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[PIPELINE] DrawIO parser produced graph graph-31 with 112 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 112 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (7039 characters)
+[PIPELINE] DrawIO parser produced graph graph-32 with 112 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 112 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (7039 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 112 vs 112
+[PIPELINE] DrawIO parser produced graph graph-33 with 113 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 113 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (7105 characters)
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m975.27ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (48162 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (48162 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48162)
+[BLACKBOX] Returning Turtle payload for graph graph-34 (6565 characters)
+[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
+[PIPELINE] DrawIO parser produced graph graph-35 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (6565 characters)
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
+[PIPELINE] Generated DrawIO XML payload (48180 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (48180 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48180)
+[PIPELINE] DrawIO parser produced graph graph-36 with 104 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 104 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (6631 characters)
+[PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m813.55ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (95213 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
+[PIPELINE] DrawIO parser produced graph graph-37 with 147 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 147 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (10076 characters)
+[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-38 with 147 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 147 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (10076 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 147 vs 147
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
+[PIPELINE] DrawIO parser produced graph graph-39 with 148 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 148 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (10142 characters)
+[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m1471.97ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-40 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (4775 characters)
+[PIPELINE] DrawIO parser produced graph graph-41 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (4775 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 78 vs 78
+[PIPELINE] DrawIO parser produced graph graph-42 with 79 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 79 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (4841 characters)
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m623.25ms[0m[2m][0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (44795 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
+[PIPELINE] DrawIO parser produced graph graph-43 with 101 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 101 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (6302 characters)
+[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
+[PIPELINE] DrawIO parser produced graph graph-44 with 101 triples
+[BLACKBOX] Parsed DrawIO graph graph-44 with 101 triples
+[BLACKBOX] Returning Turtle payload for graph graph-44 (6302 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 101 vs 101
+[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
+[PIPELINE] DrawIO parser produced graph graph-45 with 102 triples
+[BLACKBOX] Parsed DrawIO graph graph-45 with 102 triples
+[BLACKBOX] Returning Turtle payload for graph graph-45 (6368 characters)
+[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m786.41ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (37618 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
+[PIPELINE] DrawIO parser produced graph graph-46 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-46 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-46 (5189 characters)
+[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-47 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-47 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-47 (5189 characters)
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
+[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
+[PIPELINE] DrawIO parser produced graph graph-48 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-48 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-48 (5255 characters)
+[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m649.98ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (80881 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
+[PIPELINE] DrawIO parser produced graph graph-49 with 187 triples
+[BLACKBOX] Parsed DrawIO graph graph-49 with 187 triples
+[BLACKBOX] Returning Turtle payload for graph graph-49 (12064 characters)
+[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
+[PIPELINE] DrawIO parser produced graph graph-50 with 187 triples
+[BLACKBOX] Parsed DrawIO graph graph-50 with 187 triples
+[BLACKBOX] Returning Turtle payload for graph graph-50 (12064 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 187 vs 187
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
+[PIPELINE] DrawIO parser produced graph graph-51 with 188 triples
+[BLACKBOX] Parsed DrawIO graph graph-51 with 188 triples
+[BLACKBOX] Returning Turtle payload for graph graph-51 (12130 characters)
+[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m1384.00ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] Generated DrawIO XML payload (34895 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
+[PIPELINE] DrawIO parser produced graph graph-52 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-52 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-52 (6605 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-53 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-53 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-53 (6605 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 87 vs 87
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
+[PIPELINE] DrawIO parser produced graph graph-54 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-54 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-54 (6671 characters)
+[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m608.88ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (39399 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
+[PIPELINE] DrawIO parser produced graph graph-55 with 92 triples
+[BLACKBOX] Parsed DrawIO graph graph-55 with 92 triples
+[BLACKBOX] Returning Turtle payload for graph graph-55 (5434 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-56 with 92 triples
+[BLACKBOX] Parsed DrawIO graph graph-56 with 92 triples
+[BLACKBOX] Returning Turtle payload for graph graph-56 (5434 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 92 vs 92
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
+[PIPELINE] DrawIO parser produced graph graph-57 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-57 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-57 (5500 characters)
+[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m646.82ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-58 with 90 triples
+[BLACKBOX] Parsed DrawIO graph graph-58 with 90 triples
+[BLACKBOX] Returning Turtle payload for graph graph-58 (7151 characters)
+[PIPELINE] DrawIO parser produced graph graph-59 with 90 triples
+[BLACKBOX] Parsed DrawIO graph graph-59 with 90 triples
+[BLACKBOX] Returning Turtle payload for graph graph-59 (7151 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 90 vs 90
+[PIPELINE] DrawIO parser produced graph graph-60 with 91 triples
+[BLACKBOX] Parsed DrawIO graph graph-60 with 91 triples
+[BLACKBOX] Returning Turtle payload for graph graph-60 (7217 characters)
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m680.87ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (73837 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
+[PIPELINE] DrawIO parser produced graph graph-61 with 147 triples
+[BLACKBOX] Parsed DrawIO graph graph-61 with 147 triples
+[BLACKBOX] Returning Turtle payload for graph graph-61 (9686 characters)
+[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-62 with 147 triples
+[BLACKBOX] Parsed DrawIO graph graph-62 with 147 triples
+[BLACKBOX] Returning Turtle payload for graph graph-62 (9686 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 147 vs 147
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (73855 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (73855 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73855)
+[PIPELINE] DrawIO parser produced graph graph-63 with 148 triples
+[BLACKBOX] Parsed DrawIO graph graph-63 with 148 triples
+[BLACKBOX] Returning Turtle payload for graph graph-63 (9752 characters)
+[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m1268.26ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-64 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-64 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-64 (6656 characters)
+[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m148.44ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-65 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-65 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-65 (6656 characters)
+[PIPELINE] DrawIO parser produced graph graph-66 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-66 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-66 (6988 characters)
+[0m[32m✓[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m300.00ms[0m[2m][0m
+[BLACKBOX] Received serialized payload (36445 characters)
+[PIPELINE] DrawIO parser produced graph graph-0 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-0 with 87 triples
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m137.88ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-67 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-67 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-67 (6688 characters)
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m137.61ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m53.80ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[0m[32m 29 pass[0m
+[0m[2m 0 fail[0m
+ 693 expect() calls
+Ran 37 tests across 1 files. [0m[2m[[1m34.83s[0m[2m][0m
+Script done on 2025-10-22 04:24:02+00:00 [COMMAND_EXIT_CODE="130"]
 [PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (48162 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (48162 characters)


### PR DESCRIPTION
## Summary
- allow the debug harness to reuse scenario parser options when invoking the legacy DrawIO parser so ontology and prefix IRIs match the modern pipeline outputs
- teach `_resolve_drawio_path` to locate fixtures by filename when absolute paths from another workstation are missing, updating the f-4711 artefacts and map entry accordingly
- prettify the impacted scenario YAML files and refresh the recorded test log after the full bun test run

## Testing
- ./.venv/bin/python -m pytest legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs -q
- ./.venv/bin/python -m pytest legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config -q
- ./.venv/bin/python -m pytest legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override -q
- ./.venv/bin/python -m pytest legacy/tests/test_patched_parser.py::test_parse_drawio_preserves_literal_targets -q
- ./.venv/bin/python -m pytest legacy/tests/test_patched_parser.py::test_serialise_to_graph_falls_back_for_relative_prefixes -q
- ./.venv/bin/python -m pytest legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] -q
- bun run test *(fails: known malformed type rejection checks and debug CLI coverage regression)*
- bun run check
- bun run test:log:linux *(fails like bun run test)*

------
https://chatgpt.com/codex/tasks/task_e_68f8447987f0832d8197b5d64eb61418