### PR TITLE
Restore literal detection for rounded text nodes

### DIFF
--- a/src/main/webapp/plugins/rdfexport/CHANGELOG.md
+++ b/src/main/webapp/plugins/rdfexport/CHANGELOG.md
@@ -27,6 +27,7 @@ This is reviewed by a human maintainer from time to time.
 
 ### Fixed
 
+- 2025-10-24 – Restored literal detection for DrawIO cells styled with `rounded=1` even when additional text styling is present, so override classification matches the legacy parser, and added pytest coverage for the regression. Report: `src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251024T210500Z.md`.
 - 2025-10-22 – Ensured the debug CLI exits with a non-zero status whenever scenario runs record errors in `map.json`, wiring the behaviour into `__main__` and adding pytest coverage for both the runner and entrypoint. Report: `src/main/webapp/plugins/rdfexport/docs/aicode/codex-report-20251022T223455Z.md`.
 - 2025-10-22 – Updated `debug/debug_cli_regression.py` to add `_scenario_slug_from_command` helper and enhance the manual follow-up test so it re-runs scenarios, reloads `debug/map.json`, and inspects errors, allowing only `py_legacy` issues. Report: `src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20250219T000000Z.md`.
 - 2025-10-22 – Restored DrawIO arrow classification parity with the legacy parser so override generation now recognises non-strict edges exactly as the original implementation, refreshed debug fixtures, and tightened pytest coverage for strict-mode failures.

--- a/src/main/webapp/plugins/rdfexport/debug/scenarios/class-diagram-tweaked.yml
+++ b/src/main/webapp/plugins/rdfexport/debug/scenarios/class-diagram-tweaked.yml
@@ -7,7 +7,7 @@ metadata:
     csvPath: /mock/path/to/file.csv
     baseUri: ontology://generated-from-draw-io/mock#
   preamble:
-  - prefix: mock1
-    iri: http://mock-uri.com
+    - prefix: mock1
+      iri: http://mock-uri.com
 parser_config:
   ontology_iri: mock://debug-ontology

--- a/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251024T210500Z.md
+++ b/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251024T210500Z.md
@@ -1,0 +1,34 @@
+# GPT-5-Codex Report — 2025-10-24T21:05:00Z
+
+## Summary
+- Restored literal detection for DrawIO cells whose style includes `rounded=1` by updating the `DrawIOCellClassifier` override to ignore such nodes when checking for decorations.
+- Added regression coverage ensuring the override honours the legacy parser's behaviour for `rounded=1` text nodes.
+- Regenerated the meta-builder artifact so the generated parser reflects the override update.
+
+## Technical Notes
+- Updated `legacy/overrides/cell_classifier.py` to parse style fragments through the new helper `_style_suggests_literal`, which short-circuits `_is_decoration` when `rounded=1` is present alongside other text styling flags.
+- Regenerated `legacy/draw_io_parser.py` with `python -m meta_builder -o legacy/draw_io_parser.py` to sync generated output with the override change.
+- Added `test_classifier_treats_text_rounded_nodes_as_literals` to `legacy/tests/test_cell_classifier.py` to lock in the regression.
+
+## Commands Run
+- `bun install`
+- `bun run setup:uv`
+- `bun run setup:pyodide`
+- `bun run test`
+- `bun run check`
+- `bun run fix`
+- `bun run test:log:linux`
+
+## Test Results
+- `bun run test` *(fails — existing issues with invalid prefix IRIs, HTML strip toggle expectations, and metadata patch script remain)*
+- `bun run check` *(passes)*
+- `bun run fix` *(no changes required)*
+- `bun run test:log:linux` *(fails for the same pre-existing Bun test assertion around literal HTML preservation)*
+
+## Logs
+- Updated Bun test log: `tests/demo_logs/test.log`
+- Latest `bun run test:log:linux` output stored in the same log.
+
+## Follow-up Suggestions
+- Investigate the `runDrawioPipeline preserves literal HTML when stripHtml disabled` regression surfaced by Bun tests.
+- Address failing pytest cases tied to invalid prefix IRIs and metadata fixture patching once upstream decisions are available.

--- a/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
@@ -718,15 +718,26 @@ class pipeline:
                             return False
                         return "text;" in style or "shape=text" in style
 
+                    @staticmethod
+                    def _style_suggests_literal(style: str) -> bool:
+                        if not style:
+                            return False
+                        for fragment in style.split(";"):
+                            key, _, value = fragment.partition("=")
+                            if key.strip() == "rounded" and value.strip() == "1":
+                                return True
+                        return False
+
                     def _is_decoration(self, cell: Element, raw_value: str) -> bool:
                         if not raw_value:
+                            return False
+                        style = cell.attrib.get("style", "")
+                        if self._style_suggests_literal(style):
                             return False
                         return (
                             not self._collect_child_tokens(cell)
                             and (not self._has_incident_edge(cell))
-                            and self._style_suggests_decoration(
-                                cell.attrib.get("style", "")
-                            )
+                            and self._style_suggests_decoration(style)
                         )
 
                 # END override cell_classifier.py.DrawIOCellClassifier

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/cell_classifier.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/cell_classifier.py
@@ -673,11 +673,24 @@ class DrawIOCellClassifier:
             return False
         return "text;" in style or "shape=text" in style
 
+    @staticmethod
+    def _style_suggests_literal(style: str) -> bool:
+        if not style:
+            return False
+        for fragment in style.split(";"):
+            key, _, value = fragment.partition("=")
+            if key.strip() == "rounded" and value.strip() == "1":
+                return True
+        return False
+
     def _is_decoration(self, cell: Element, raw_value: str) -> bool:
         if not raw_value:
+            return False
+        style = cell.attrib.get("style", "")
+        if self._style_suggests_literal(style):
             return False
         return (
             not self._collect_child_tokens(cell)
             and not self._has_incident_edge(cell)
-            and self._style_suggests_decoration(cell.attrib.get("style", ""))
+            and self._style_suggests_decoration(style)
         )

--- a/src/main/webapp/plugins/rdfexport/legacy/tests/test_cell_classifier.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/tests/test_cell_classifier.py
@@ -202,6 +202,21 @@ def test_absolute_uri_node_uses_default_type():
     assert (uri_value, DEFAULT_STANDALONE_TYPE) in observed
 
 
+def test_classifier_treats_text_rounded_nodes_as_literals():
+    xml = _drawio_xml(
+        _vertex_cell(
+            "literal",
+            "Literal Value",
+            style="text;html=1;rounded=1;whiteSpace=wrap;",
+        )
+    )
+
+    tree = draw_io_parser.DrawIOXMLTree(xml, draw_io_parser.get_prefixes())
+
+    literal_ids = {cell.attrib.get("id") for cell, _ in tree.literal_cells}
+    assert "literal" in literal_ids
+
+
 def test_decorations_serialise_to_skos_note(tmp_path: Path):
     xml = _drawio_xml(
         _vertex_cell("parent", "Subject"),

--- a/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
+++ b/src/main/webapp/plugins/rdfexport/tests/demo_logs/test.log
@@ -1,1811 +1,81 @@
-Script started on Thu Oct 23 03:10:14 2025
-Command: bun run test
+Script started on 2025-10-23 07:48:02+00:00 [COMMAND="bun run test" TERM="xterm" COLUMNS="128" LINES="-1"]
 [0m[2m[35m$[0m [2m[1mbash scripts/test_legacy.sh; bun --check test[0m
 [0m[2m[35m$[0m [2m[1mpython -m meta_builder -o legacy/draw_io_parser.py && bun run lint:fix:py && bun run format:py[0m
 [metabuilder] Wrote legacy/draw_io_parser.py ( overrides on; replacements=8 [NodeHTMLParser, _build_graph_from_raw_xml, _cell_is_literal, _ensure_known_curie, _extract_individual_and_arrow_and_literal_cells, _split_curie, individual_blocks, serialise_to_graph] additions=1 [DrawIOCellClassifier] )
-[metabuilder] Loaded override modules from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
+[metabuilder] Loaded override modules from /workspace/drawio/src/main/webapp/plugins/rdfexport/legacy/overrides: cell_classifier.py, curie_validator.py, rml_export.py, strip_html.py
 [0m[2m[35m$[0m [2m[1mruff check --fix .[0m
 Found 2 errors (2 fixed, 0 remaining).
 [0m[2m[35m$[0m [2m[1mruff format .[0m
 1 file reformatted, 24 files left unchanged
-Attempting to regenerate baselines from 1 commit(s)...
-Starting at: cf8f84bb84ff83843b6726ac96aff3a2055f4275
-
-✅ Baselines regenerated using commit cf8f84bb84ff83843b6726ac96aff3a2055f4275
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health.drawio -> webapp/plugins/rdfexport/tests/baselines/AA37 Department of Health.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/AA42 Ministry of Health.drawio -> webapp/plugins/rdfexport/tests/baselines/AA42 Ministry of Health.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/BA619 Walkerton Inquiry.drawio -> webapp/plugins/rdfexport/tests/baselines/BA619 Walkerton Inquiry.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/CA1853 Chest Disease Service.drawio -> webapp/plugins/rdfexport/tests/baselines/CA1853 Chest Disease Service.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/CA1934 Division of Tuberculosis Prevention.drawio -> webapp/plugins/rdfexport/tests/baselines/CA1934 Division of Tuberculosis Prevention.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47 Simcoe Family fonds.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47 Simcoe Family fonds.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11 Elizabeth Simcoe sketches.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11 Elizabeth Simcoe sketches.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-1 Elizabeth Simcoe loose sketches.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-1 Elizabeth Simcoe loose sketches.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1 (VDB test).drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-1-0-1 (VDB test).nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-1-0-1.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-1-0-1.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-2 Elizabeth Simcoe sketchbook.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-2 Elizabeth Simcoe sketchbook.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio -> webapp/plugins/rdfexport/tests/baselines/F 47-11-4 Notes on Elizabeth Simcoe sketches.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/F 4711 Orville Wood fonds.drawio -> webapp/plugins/rdfexport/tests/baselines/F 4711 Orville Wood fonds.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio -> webapp/plugins/rdfexport/tests/baselines/General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/General Authority to RiC-O Model_2025-06-25_PZ.drawio -> webapp/plugins/rdfexport/tests/baselines/General Authority to RiC-O Model_2025-06-25_PZ.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 10-142 Correspondence of the Chief of the Chest Disease Service.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 10-145 Mobile Tuberculosis Testing Clinic photographs.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio -> webapp/plugins/rdfexport/tests/baselines/RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.nt
-  overwrote: webapp/plugins/rdfexport/tests/fixtures/RG 18-210 Walkerton Inquiry in RiC-O (original).drawio -> webapp/plugins/rdfexport/tests/baselines/RG 18-210 Walkerton Inquiry in RiC-O (original).nt
-
-⚠️  Failed to generate baselines for 9 fixture(s):
-  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata-preserve-html.drawio
-     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
-  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata-rml.drawio
-     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
-  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37 Department of Health-with-metadata.drawio
-     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
-  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-even-more-severely-mocked.drawio
-     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
-  ❌ webapp/plugins/rdfexport/tests/fixtures/AA37-with-metadata-severely-mocked.drawio
-     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
-  ❌ webapp/plugins/rdfexport/tests/fixtures/Class_Diagram_tweaked.drawio
-     Expecting the mxGeometry element of the cell with the following id to have an mxPoint sub-element with 'as' attribute having value 'sourcePoint', but it does not: zkfFHV4jXpPFQw0GAbJ--0
-  ❌ webapp/plugins/rdfexport/tests/fixtures/General_Authority_bleep_mock.drawio
-     Could not parse XML tree: expecting an element with tag 'mxCell', but had tag 'UserObject'
-  ❌ webapp/plugins/rdfexport/tests/fixtures/knut_olborgs_forskningsnotater.drawio
-     An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
-  ❌ webapp/plugins/rdfexport/tests/fixtures/koronakommisjonen.drawio
-     An arrow has label 'rdfs:isDefinedBy', which is not a known object property or datatype property
-
-🧪 Running tests: webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py
-[1m====================================== test session starts ======================================[0m
-platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0 -- /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python
-cachedir: .pytest_cache
-rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
-configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 41 items                                                                              [0m
-
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_accepts_declared_prefix_curie [32mPASSED[0m[32m [  2%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_tracks_datatype_properties [32mPASSED[0m[32m [  4%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_preserves_literal_targets [31mFAILED[0m[31m [  7%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_serialise_to_graph_falls_back_for_relative_prefixes [31mFAILED[0m[31m [  9%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[unknown_prefix] [32mPASSED[0m[31m [ 12%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[dangling_curie] [31mFAILED[0m[31m [ 14%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[colon_only] [31mFAILED[0m[31m [ 17%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_malformed_type_variants[no_prefix] [31mFAILED[0m[31m [ 19%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_corrected_mock_types [31mFAILED[0m[31m [ 21%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path0] [32mPASSED[0m[31m [ 24%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path1] [32mPASSED[0m[31m [ 26%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path2] [32mPASSED[0m[31m [ 29%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path3] [32mPASSED[0m[31m [ 31%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path4] [32mPASSED[0m[31m [ 34%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path5] [32mPASSED[0m[31m [ 36%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path6] [32mPASSED[0m[31m [ 39%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path7] [32mPASSED[0m[31m [ 41%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path8] [32mPASSED[0m[31m [ 43%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path9] [32mPASSED[0m[31m [ 46%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path10] [32mPASSED[0m[31m [ 48%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path11] [32mPASSED[0m[31m [ 51%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path12] [32mPASSED[0m[31m [ 53%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path13] [32mPASSED[0m[31m [ 56%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path14] [32mPASSED[0m[31m [ 58%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path15] [32mPASSED[0m[31m [ 60%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path16] [32mPASSED[0m[31m [ 63%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path17] [32mPASSED[0m[31m [ 65%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path18] [32mPASSED[0m[31m [ 68%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path19] [32mPASSED[0m[31m [ 70%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_matches_baseline_graphs[baseline_path20] [32mPASSED[0m[31m [ 73%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[knut_olborgs_forskningsnotater.drawio] [32mPASSED[0m[31m [ 75%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_accepts_previous_unknown_properties[koronakommisjonen.drawio] [32mPASSED[0m[31m [ 78%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path [32mPASSED[0m[31m [ 80%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_with_rml_metadata_adds_triples_map [32mPASSED[0m[31m [ 82%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals [32mPASSED[0m[31m [ 85%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config [31mFAILED[0m[31m [ 87%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override [31mFAILED[0m[31m [ 90%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_without_metadata_sets_empty_metadata [32mPASSED[0m[31m [ 92%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_parse_drawio_rejects_unknown_literal_curie [32mPASSED[0m[31m [ 95%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_individual_blocks_rejects_unknown_prefix [32mPASSED[0m[31m [ 97%][0m
-webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip [31mFAILED[0m[31m [100%][0m
-
-=========================================== FAILURES ============================================
-[31m[1m__________________________ test_parse_drawio_preserves_literal_targets __________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_preserves_literal_targets[39;49;00m():[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(FIXTURES_DIR / [33m"[39;49;00m[33mAA37-with-metadata-even-more-severely-mocked.drawio[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:140: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('A%20Ontario%20Government%20...e'}}, ('AA37', 'AA37'): {'Types': {'rico:Identifier'}, 'rico:hasIdentifierType': {('Agent%20Identifier', False)}}, ...}
-object_properties = {'hellow:there', 'rdf:type', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', ...}
-datatype_properties = {'hellow:there', 'rdf:some-predicate', 'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-14', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m___________________ test_serialise_to_graph_falls_back_for_relative_prefixes ____________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_serialise_to_graph_falls_back_for_relative_prefixes[39;49;00m():[90m[39;49;00m
-        prefixes = draw_io_parser.get_prefixes().copy()[90m[39;49;00m
-        prefixes[[33m"[39;49;00m[33mbad[39;49;00m[33m"[39;49;00m] = [33m"[39;49;00m[33mrelative-prefix[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        items = [96miter[39;49;00m([90m[39;49;00m
-            [[90m[39;49;00m
-                draw_io_parser.Individual([33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mowl:NamedIndividual[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-                draw_io_parser.Arrow([90m[39;49;00m
-                    identifier=[33m"[39;49;00m[33mbad:prop[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    source=[33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    target=[33m"[39;49;00m[33mliteral value[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    is_datatype=[94mTrue[39;49;00m,[90m[39;49;00m
-                ),[90m[39;49;00m
-            ][90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        blocks, object_props, datatype_props = draw_io_parser.individual_blocks([90m[39;49;00m
-            items,[90m[39;49;00m
-            [],[90m[39;49;00m
-            [94mNone[39;49;00m,[90m[39;49;00m
-            draw_io_parser.DEFAULT_CAPITALISATION_SCHEME,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        config = draw_io_parser.SerialisationConfig([90m[39;49;00m
-            infer_type_of_literals=[94mTrue[39;49;00m,[90m[39;49;00m
-            include_preamble=[94mFalse[39;49;00m,[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33mhttp://example.com/ontology[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix=[33m"[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix_iri=[33m"[39;49;00m[33mhttp://example.com/[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            indentation=[94m2[39;49;00m,[90m[39;49;00m
-            include_label=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
->       graph = draw_io_parser.serialise_to_graph([90m[39;49;00m
-            blocks,[90m[39;49;00m
-            object_props,[90m[39;49;00m
-            datatype_props,[90m[39;49;00m
-            config,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:185: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('Source', 'Source'): {'Types': {'owl:NamedIndividual'}, 'bad:prop': {('literal value', True)}}}
-object_properties = set(), datatype_properties = {'bad:prop'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=False, ontology_iri='http://example.com/ontology', prefix='', prefix_iri='http://example.com/', indentation=2, include_label=False)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...gbad.ca/Schema/Authority/', 'bad': 'relative-prefix', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', ...}
-graph_cls = <class 'rdflib.graph.Graph'>, graph_kwargs = {}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'relative-prefix' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_______________ test_parse_drawio_rejects_malformed_type_variants[dangling_curie] _______________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-472/test_parse_drawio_rejects_malf1')
-case_key = 'dangling_curie'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-14', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_________________ test_parse_drawio_rejects_malformed_type_variants[colon_only] _________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-472/test_parse_drawio_rejects_malf2')
-case_key = 'colon_only'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-14', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_________________ test_parse_drawio_rejects_malformed_type_variants[no_prefix] __________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-472/test_parse_drawio_rejects_malf3')
-case_key = 'no_prefix'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-14', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m________________________ test_parse_drawio_accepts_corrected_mock_types _________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-472/test_parse_drawio_accepts_corr0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_accepts_corrected_mock_types[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, [94mNone[39;49;00m)[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:215: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-14', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_________________________ test_parse_drawio_respects_strip_html_config __________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_respects_strip_html_config[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            strip_html=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:361: AssertionError
-[31m[1m________________________ test_parse_drawio_metadata_strip_html_override _________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_metadata_strip_html_override[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:388: AssertionError
-[31m[1m__________________________ test_generated_metadata_fixtures_round_trip __________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-472/test_generated_metadata_fixtur0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_generated_metadata_fixtures_round_trip[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_paths = [96msorted[39;49;00m([90m[39;49;00m
-            path[90m[39;49;00m
-            [94mfor[39;49;00m path [95min[39;49;00m FIXTURES_DIR.glob([33m"[39;49;00m[33m*.drawio[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-            [94mif[39;49;00m [33m"[39;49;00m[33m-with-metadata[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m path.stem [95mand[39;49;00m [95mnot[39;49;00m _fixture_contains_metadata(path)[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m fixture_paths, [33m"[39;49;00m[33mExpected drawio fixtures to patch[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        [94mfor[39;49;00m index, fixture_path [95min[39;49;00m [96menumerate[39;49;00m(fixture_paths):[90m[39;49;00m
-            metadata_options = _build_metadata_options(index, fixture_path)[90m[39;49;00m
-            patched_path = tmp_path / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mfixture_path.stem[33m}[39;49;00m[33m-with-metadata.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
->           _run_drawio_metadata_patcher(fixture_path, patched_path, metadata_options)[90m[39;49;00m
-
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:504: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mwebapp/plugins/rdfexport/legacy/tests/test_patched_parser.py[0m:442: in _run_drawio_metadata_patcher
-    [0msubprocess.run([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-input = None, capture_output = False, timeout = None, check = True
-popenargs = (['bun', '--eval', "import { readFileSync, writeFileSync } from 'node:fs';\nimport { patchDrawioWithMetadata } from 'f...lass-diagram-tweaked/vocab#"}, {"rdfPrefix": "data5", "rdfIRI": "http://example.org/class-diagram-tweaked/data/"}]}'],)
-kwargs = {}
-process = <Popen: returncode: 1 args: ['bun', '--eval', "import { readFileSync, writeF...>
-stdout = None, stderr = None, retcode = 1
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mrun[39;49;00m(*popenargs,[90m[39;49;00m
-            [96minput[39;49;00m=[94mNone[39;49;00m, capture_output=[94mFalse[39;49;00m, timeout=[94mNone[39;49;00m, check=[94mFalse[39;49;00m, **kwargs):[90m[39;49;00m
-    [90m    [39;49;00m[33m"""Run command with arguments and return a CompletedProcess instance.[39;49;00m
-    [33m[39;49;00m
-    [33m    The returned instance will have attributes args, returncode, stdout and[39;49;00m
-    [33m    stderr. By default, stdout and stderr are not captured, and those attributes[39;49;00m
-    [33m    will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them,[39;49;00m
-    [33m    or pass capture_output=True to capture both.[39;49;00m
-    [33m[39;49;00m
-    [33m    If check is True and the exit code was non-zero, it raises a[39;49;00m
-    [33m    CalledProcessError. The CalledProcessError object will have the return code[39;49;00m
-    [33m    in the returncode attribute, and output & stderr attributes if those streams[39;49;00m
-    [33m    were captured.[39;49;00m
-    [33m[39;49;00m
-    [33m    If timeout (seconds) is given and the process takes too long,[39;49;00m
-    [33m     a TimeoutExpired exception will be raised.[39;49;00m
-    [33m[39;49;00m
-    [33m    There is an optional argument "input", allowing you to[39;49;00m
-    [33m    pass bytes or a string to the subprocess's stdin.  If you use this argument[39;49;00m
-    [33m    you may not also use the Popen constructor's "stdin" argument, as[39;49;00m
-    [33m    it will be used internally.[39;49;00m
-    [33m[39;49;00m
-    [33m    By default, all communication is in bytes, and therefore any "input" should[39;49;00m
-    [33m    be bytes, and the stdout and stderr will be bytes. If in text mode, any[39;49;00m
-    [33m    "input" should be a string, and stdout and stderr will be strings decoded[39;49;00m
-    [33m    according to locale encoding, or by "encoding" if set. Text mode is[39;49;00m
-    [33m    triggered by setting any of text, encoding, errors or universal_newlines.[39;49;00m
-    [33m[39;49;00m
-    [33m    The other arguments are the same as for the Popen constructor.[39;49;00m
-    [33m    """[39;49;00m[90m[39;49;00m
-        [94mif[39;49;00m [96minput[39;49;00m [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m kwargs.get([33m'[39;49;00m[33mstdin[39;49;00m[33m'[39;49;00m) [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m:[90m[39;49;00m
-                [94mraise[39;49;00m [96mValueError[39;49;00m([33m'[39;49;00m[33mstdin and input arguments may not both be used.[39;49;00m[33m'[39;49;00m)[90m[39;49;00m
-            kwargs[[33m'[39;49;00m[33mstdin[39;49;00m[33m'[39;49;00m] = PIPE[90m[39;49;00m
-    [90m[39;49;00m
-        [94mif[39;49;00m capture_output:[90m[39;49;00m
-            [94mif[39;49;00m kwargs.get([33m'[39;49;00m[33mstdout[39;49;00m[33m'[39;49;00m) [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m [95mor[39;49;00m kwargs.get([33m'[39;49;00m[33mstderr[39;49;00m[33m'[39;49;00m) [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m:[90m[39;49;00m
-                [94mraise[39;49;00m [96mValueError[39;49;00m([33m'[39;49;00m[33mstdout and stderr arguments may not be used [39;49;00m[33m'[39;49;00m[90m[39;49;00m
-                                 [33m'[39;49;00m[33mwith capture_output.[39;49;00m[33m'[39;49;00m)[90m[39;49;00m
-            kwargs[[33m'[39;49;00m[33mstdout[39;49;00m[33m'[39;49;00m] = PIPE[90m[39;49;00m
-            kwargs[[33m'[39;49;00m[33mstderr[39;49;00m[33m'[39;49;00m] = PIPE[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m Popen(*popenargs, **kwargs) [94mas[39;49;00m process:[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                stdout, stderr = process.communicate([96minput[39;49;00m, timeout=timeout)[90m[39;49;00m
-            [94mexcept[39;49;00m TimeoutExpired [94mas[39;49;00m exc:[90m[39;49;00m
-                process.kill()[90m[39;49;00m
-                [94mif[39;49;00m _mswindows:[90m[39;49;00m
-                    [90m# Windows accumulates the output in a single blocking[39;49;00m[90m[39;49;00m
-                    [90m# read() call run on child threads, with the timeout[39;49;00m[90m[39;49;00m
-                    [90m# being done in a join() on those threads.  communicate()[39;49;00m[90m[39;49;00m
-                    [90m# _after_ kill() is required to collect that and add it[39;49;00m[90m[39;49;00m
-                    [90m# to the exception.[39;49;00m[90m[39;49;00m
-                    exc.stdout, exc.stderr = process.communicate()[90m[39;49;00m
-                [94melse[39;49;00m:[90m[39;49;00m
-                    [90m# POSIX _communicate already populated the output so[39;49;00m[90m[39;49;00m
-                    [90m# far into the TimeoutExpired exception.[39;49;00m[90m[39;49;00m
-                    process.wait()[90m[39;49;00m
-                [94mraise[39;49;00m[90m[39;49;00m
-            [94mexcept[39;49;00m:  [90m# Including KeyboardInterrupt, communicate handled that.[39;49;00m[90m[39;49;00m
-                process.kill()[90m[39;49;00m
-                [90m# We don't call process.wait() as .__exit__ does that for us.[39;49;00m[90m[39;49;00m
-                [94mraise[39;49;00m[90m[39;49;00m
-            retcode = process.poll()[90m[39;49;00m
-            [94mif[39;49;00m check [95mand[39;49;00m retcode:[90m[39;49;00m
->               [94mraise[39;49;00m CalledProcessError(retcode, process.args,[90m[39;49;00m
-                                         output=stdout, stderr=stderr)[90m[39;49;00m
-[1m[31mE               subprocess.CalledProcessError: Command '['bun', '--eval', "import { readFileSync, writeFileSync } from 'node:fs';\nimport { patchDrawioWithMetadata } from 'file:///Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts';\n\nconst [, inputPath, outputPath, optionsJson] = process.argv;\nconst options = JSON.parse(optionsJson);\n\nconst patched = patchDrawioWithMetadata(readFileSync(inputPath, 'utf8'), options);\nwriteFileSync(outputPath, patched);", '/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/Class_Diagram_tweaked.drawio', '/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-472/test_generated_metadata_fixtur0/Class_Diagram_tweaked-with-metadata.drawio', '{"csvPath": "/tmp/class-diagram-tweaked.csv", "baseUri": "http://example.org/class-diagram-tweaked/", "label": "Class_Diagram_tweaked metadata", "preamble": [{"rdfPrefix": "fx5", "rdfIRI": "http://example.org/class-diagram-tweaked/vocab#"}, {"rdfPrefix": "data5", "rdfIRI": "http://example.org/class-diagram-tweaked/data/"}]}']' returned non-zero exit status 1.[0m
-
-[1m[31m/Users/anonymous/miniconda3/lib/python3.12/subprocess.py[0m:573: CalledProcessError
-------------------------------------- Captured stderr call --------------------------------------
-15 | function assertElement<T extends Element | null>(
-16 |   element: T,
-17 |   message: string,
-18 | ): asserts element is Exclude<T, null> {
-19 |   if (!element) {
-20 |     throw new Error(message);
-               ^
-error: Unable to locate root <mxCell id="0"> element to patch
-      at assertElement (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts:20:11)
-      at patchDrawioWithMetadata (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts:88:3)
-      at /Volumes/home/anonymous/drawio/src/main/[eval]:7:17
-      at loadAndEvaluateModule (2:1)
-
-Bun v1.2.21 (macOS arm64)
-[33m======================================= warnings summary ========================================[0m
-legacy/tests/test_patched_parser.py: 1227 warnings
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:617: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
-    target_cell
-
-legacy/tests/test_patched_parser.py: 38 warnings
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2563: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
-    parsed_root
-
-legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path
-legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals
-legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config
-legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2566: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
-    if parsed_root.find(".//UserObject[@id='0']")
-
--- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-[36m[1m==================================== short test summary info ====================================[0m
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_preserves_literal_targets[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_serialise_to_graph_falls_back_for_relative_prefixes[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI 'relative-prefix' looks invalid
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[dangling_curie][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[colon_only][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[no_prefix][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_accepts_corrected_mock_types[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_respects_strip_html_config[0m - assert []
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_metadata_strip_html_override[0m - assert []
-[31mFAILED[0m webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py::[1mtest_generated_metadata_fixtures_round_trip[0m - subprocess.CalledProcessError: Command '['bun', '--eval', "import { readFileSync, writeFileS...
-[31m========================== [31m[1m9 failed[0m, [32m32 passed[0m, [33m1274 warnings[0m[31m in 1.07s[0m[31m ==========================[0m
-Traceback (most recent call last):
-  File "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/tests/regenerate_baselines.py", line 294, in <module>
-    main()
-  File "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/tests/regenerate_baselines.py", line 290, in main
-    run_pytest([str(TEST_PATH.relative_to(REPO_ROOT)), "-v"])
-  File "/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/tests/regenerate_baselines.py", line 216, in run_pytest
-    subprocess.run(command, check=True, cwd=REPO_ROOT)
-  File "/Users/anonymous/miniconda3/lib/python3.12/subprocess.py", line 573, in run
-    raise CalledProcessError(retcode, process.args,
-subprocess.CalledProcessError: Command '['/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/.venv/bin/python', '-m', 'pytest', 'webapp/plugins/rdfexport/legacy/tests/test_patched_parser.py', '-v']' returned non-zero exit status 1.
-[1m====================================== test session starts ======================================[0m
-platform darwin -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0
-rootdir: /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport
-configfile: pyproject.toml
-[1mcollecting ... [0m[1mcollected 66 items                                                                              [0m
-
-legacy/tests/test_cell_classifier.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[33m                                         [ 18%][0m
-legacy/tests/test_curie_validator.py [32m.[0m[32m.[0m[32m.[0m[33m                                                  [ 22%][0m
-legacy/tests/test_patched_parser.py [32m.[0m[32m.[0m[31mF[0m[31mF[0m[32m.[0m[31mF[0m[31mF[0m[31mF[0m[31mF[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[31mF[0m[31mF[0m[32m.[0m[32m.[0m[32m.[0m[31mF[0m[31m             [ 84%][0m
-legacy/tests/test_pyodide_pipeline.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[31m                                                [ 90%][0m
-meta_builder/tests/test_drawio_meta_builder.py [32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[32m.[0m[31m                                     [100%][0m
-
-=========================================== FAILURES ============================================
-[31m[1m__________________________ test_parse_drawio_preserves_literal_targets __________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_preserves_literal_targets[39;49;00m():[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(FIXTURES_DIR / [33m"[39;49;00m[33mAA37-with-metadata-even-more-severely-mocked.drawio[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:140: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mlegacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('A%20Ontario%20Government%20...e'}}, ('AA37', 'AA37'): {'Types': {'rico:Identifier'}, 'rico:hasIdentifierType': {('Agent%20Identifier', False)}}, ...}
-object_properties = {'hellow:there', 'rdf:type', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', ...}
-datatype_properties = {'hellow:there', 'rdf:some-predicate', 'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-15', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m___________________ test_serialise_to_graph_falls_back_for_relative_prefixes ____________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_serialise_to_graph_falls_back_for_relative_prefixes[39;49;00m():[90m[39;49;00m
-        prefixes = draw_io_parser.get_prefixes().copy()[90m[39;49;00m
-        prefixes[[33m"[39;49;00m[33mbad[39;49;00m[33m"[39;49;00m] = [33m"[39;49;00m[33mrelative-prefix[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        items = [96miter[39;49;00m([90m[39;49;00m
-            [[90m[39;49;00m
-                draw_io_parser.Individual([33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mowl:NamedIndividual[39;49;00m[33m"[39;49;00m),[90m[39;49;00m
-                draw_io_parser.Arrow([90m[39;49;00m
-                    identifier=[33m"[39;49;00m[33mbad:prop[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    source=[33m"[39;49;00m[33mSource[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    target=[33m"[39;49;00m[33mliteral value[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-                    is_datatype=[94mTrue[39;49;00m,[90m[39;49;00m
-                ),[90m[39;49;00m
-            ][90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        blocks, object_props, datatype_props = draw_io_parser.individual_blocks([90m[39;49;00m
-            items,[90m[39;49;00m
-            [],[90m[39;49;00m
-            [94mNone[39;49;00m,[90m[39;49;00m
-            draw_io_parser.DEFAULT_CAPITALISATION_SCHEME,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        config = draw_io_parser.SerialisationConfig([90m[39;49;00m
-            infer_type_of_literals=[94mTrue[39;49;00m,[90m[39;49;00m
-            include_preamble=[94mFalse[39;49;00m,[90m[39;49;00m
-            ontology_iri=[33m"[39;49;00m[33mhttp://example.com/ontology[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix=[33m"[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            prefix_iri=[33m"[39;49;00m[33mhttp://example.com/[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-            indentation=[94m2[39;49;00m,[90m[39;49;00m
-            include_label=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
->       graph = draw_io_parser.serialise_to_graph([90m[39;49;00m
-            blocks,[90m[39;49;00m
-            object_props,[90m[39;49;00m
-            datatype_props,[90m[39;49;00m
-            config,[90m[39;49;00m
-            prefixes,[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:185: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('Source', 'Source'): {'Types': {'owl:NamedIndividual'}, 'bad:prop': {('literal value', True)}}}
-object_properties = set(), datatype_properties = {'bad:prop'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=False, ontology_iri='http://example.com/ontology', prefix='', prefix_iri='http://example.com/', indentation=2, include_label=False)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...gbad.ca/Schema/Authority/', 'bad': 'relative-prefix', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', ...}
-graph_cls = <class 'rdflib.graph.Graph'>, graph_kwargs = {}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI 'relative-prefix' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_______________ test_parse_drawio_rejects_malformed_type_variants[dangling_curie] _______________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-473/test_parse_drawio_rejects_malf1')
-case_key = 'dangling_curie'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mlegacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-15', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_________________ test_parse_drawio_rejects_malformed_type_variants[colon_only] _________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-473/test_parse_drawio_rejects_malf2')
-case_key = 'colon_only'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mlegacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-15', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_________________ test_parse_drawio_rejects_malformed_type_variants[no_prefix] __________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-473/test_parse_drawio_rejects_malf3')
-case_key = 'no_prefix'
-
-    [0m[37m@pytest[39;49;00m.mark.parametrize([90m[39;49;00m
-        [33m"[39;49;00m[33mcase_key[39;49;00m[33m"[39;49;00m,[90m[39;49;00m
-        [[33m"[39;49;00m[33munknown_prefix[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mdangling_curie[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mcolon_only[39;49;00m[33m"[39;49;00m, [33m"[39;49;00m[33mno_prefix[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-    )[90m[39;49;00m
-    [94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_rejects_malformed_type_variants[39;49;00m(tmp_path: Path, case_key: [96mstr[39;49;00m):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, case_key)[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m pytest.raises(draw_io_parser.NotInKnownException):[90m[39;49;00m
->           draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-                [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-                metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:207: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mlegacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-16', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m________________________ test_parse_drawio_accepts_corrected_mock_types _________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-473/test_parse_drawio_accepts_corr0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_accepts_corrected_mock_types[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_path = _mutate_fixture_for_case(tmp_path, [94mNone[39;49;00m)[90m[39;49;00m
->       graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33mremove[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:215: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mlegacy/draw_io_parser.py[0m:2855: in parse_drawio_to_graph
-    [0m[94mreturn[39;49;00m _build_graph_from_raw_xml(raw_xml, config_args)[90m[39;49;00m
-           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[90m[39;49;00m
-[1m[31mlegacy/draw_io_parser.py[0m:2551: in _build_graph_from_raw_xml
-    [0mgraph = serialise_to_graph([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-blocks = {('1924', '1924'): {'Types': {'rico:Date'}}, ('1972', '1972'): {'Types': {'rico:Date'}}, ('AA37', 'AA37'): {'Types': {...tifier', False)}}, ('AOntarioGovernmentName', 'A Ontario Government Name'): {'Types': {'rico:CorporateBodyType'}}, ...}
-object_properties = {'hellow:there', 'rico:authorizedBy', 'rico:hasBeginningDate', 'rico:hasEndDate', 'rico:hasIdentifierType', 'rico:hasOrHadAgentName', ...}
-datatype_properties = {'rico:generalDescription', 'rico:history', 'rico:lastModificationDate', 'rico:normalizedValue'}
-serialisation_config = internal_metadata_pre.SerialisationConfig(infer_type_of_literals=True, include_preamble=True, ontology_iri='ontology:/...-draw-io/2025-10-23T03-10-16', prefix=None, prefix_iri='http://mock23-base-uri.com', indentation=2, include_label=True)
-prefixes = {'add': 'https://data.archives.gov.on.test.gbad.ca/Schema/Description-Listings/', 'auth': 'https://data.archives.gov.o...ca/Schema/Authority/', 'gbad': 'https://data.archives.gov.on.test.gbad.ca/Schema/', 'hellow': 'some://helloworld', ...}
-graph_cls = <class 'draw_io_parser.rdf_control_core.DrawIOParserGraph'>
-graph_kwargs = {'csv_path': '/mock22/path/to/file.csv'}
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mserialise_to_graph[39;49;00m([90m[39;49;00m
-        blocks: Blocks,[90m[39;49;00m
-        object_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        datatype_properties: [96mset[39;49;00m[[96mstr[39;49;00m],[90m[39;49;00m
-        serialisation_config: SerialisationConfig,[90m[39;49;00m
-        prefixes: [96mdict[39;49;00m,[90m[39;49;00m
-        graph_cls: [96mtype[39;49;00m[Graph] = Graph,[90m[39;49;00m
-        graph_kwargs: [96mdict[39;49;00m[[96mstr[39;49;00m, Any] | [94mNone[39;49;00m = [94mNone[39;49;00m,[90m[39;49;00m
-    ) -> Graph:[90m[39;49;00m
-        graph_kwargs = graph_kwargs [95mor[39;49;00m {}[90m[39;49;00m
-        graph = graph_cls(**graph_kwargs)[90m[39;49;00m
-        prefix = serialisation_config.prefix[90m[39;49;00m
-        prefix_iri = serialisation_config.prefix_iri [95mor[39;49;00m get_prefix_iri([90m[39;49;00m
-            serialisation_config.ontology_iri[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94mdef[39;49;00m[90m [39;49;00m[92m_is_absolute_iri[39;49;00m(candidate: [96mstr[39;49;00m) -> [96mbool[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m [95mnot[39;49;00m candidate:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                parsed = urllib.parse.urlparse(candidate)[90m[39;49;00m
-            [94mexcept[39;49;00m [96mException[39;49;00m:[90m[39;49;00m
-                [94mreturn[39;49;00m [94mFalse[39;49;00m[90m[39;49;00m
-            [94mreturn[39;49;00m [96mbool[39;49;00m(parsed.scheme [95mand[39;49;00m (parsed.netloc [95mor[39;49;00m parsed.path))[90m[39;49;00m
-    [90m[39;49;00m
-        namespace_map: [96mdict[39;49;00m[[96mstr[39;49;00m, Namespace] = {}[90m[39;49;00m
-        [94mfor[39;49;00m prefix_key, uri [95min[39;49;00m prefixes.items():[90m[39;49;00m
-            [94mif[39;49;00m _is_absolute_iri(uri):[90m[39;49;00m
-                namespace = Namespace(uri)[90m[39;49;00m
-                graph.bind(prefix_key, namespace, replace=[94mTrue[39;49;00m)[90m[39;49;00m
-            [94melse[39;49;00m:[90m[39;49;00m
->               [94mraise[39;49;00m ParseException([33mf[39;49;00m[33m"[39;49;00m[33mPrefix IRI [39;49;00m[33m'[39;49;00m[33m{[39;49;00muri[33m}[39;49;00m[33m'[39;49;00m[33m looks invalid[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-[1m[31mE               draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid[0m
-
-[1m[31mlegacy/draw_io_parser.py[0m:2674: ParseException
-[31m[1m_________________________ test_parse_drawio_respects_strip_html_config __________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_respects_strip_html_config[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-            strip_html=[94mFalse[39;49;00m,[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:361: AssertionError
-[31m[1m________________________ test_parse_drawio_metadata_strip_html_override _________________________[0m
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_parse_drawio_metadata_strip_html_override[39;49;00m():[90m[39;49;00m
-        fixture_path = ([90m[39;49;00m
-            FIXTURES_DIR / [33m"[39;49;00m[33mAA37 Department of Health-with-metadata-preserve-html.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-        )[90m[39;49;00m
-        graph = draw_io_parser.parse_drawio_to_graph([90m[39;49;00m
-            [96mstr[39;49;00m(fixture_path),[90m[39;49;00m
-            metacharacter_substitute=[[33m"[39;49;00m[33murl[39;49;00m[33m"[39;49;00m],[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m [96misinstance[39;49;00m(graph, draw_io_parser.DrawIOParserGraph)[90m[39;49;00m
-    [90m[39;49;00m
-        literal_values = [[96mstr[39;49;00m(obj) [94mfor[39;49;00m obj [95min[39;49;00m graph.objects() [94mif[39;49;00m [96misinstance[39;49;00m(obj, Literal)][90m[39;49;00m
-    [90m[39;49;00m
-        html_literals = [value [94mfor[39;49;00m value [95min[39;49;00m literal_values [94mif[39;49;00m [33m"[39;49;00m[33m<blockquote[39;49;00m[33m"[39;49;00m [95min[39;49;00m value][90m[39;49;00m
-    [90m[39;49;00m
->       [94massert[39;49;00m html_literals[90m[39;49;00m
-[1m[31mE       assert [][0m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:388: AssertionError
-[31m[1m__________________________ test_generated_metadata_fixtures_round_trip __________________________[0m
-
-tmp_path = PosixPath('/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-473/test_generated_metadata_fixtur0')
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mtest_generated_metadata_fixtures_round_trip[39;49;00m(tmp_path: Path):[90m[39;49;00m
-        fixture_paths = [96msorted[39;49;00m([90m[39;49;00m
-            path[90m[39;49;00m
-            [94mfor[39;49;00m path [95min[39;49;00m FIXTURES_DIR.glob([33m"[39;49;00m[33m*.drawio[39;49;00m[33m"[39;49;00m)[90m[39;49;00m
-            [94mif[39;49;00m [33m"[39;49;00m[33m-with-metadata[39;49;00m[33m"[39;49;00m [95mnot[39;49;00m [95min[39;49;00m path.stem [95mand[39;49;00m [95mnot[39;49;00m _fixture_contains_metadata(path)[90m[39;49;00m
-        )[90m[39;49;00m
-    [90m[39;49;00m
-        [94massert[39;49;00m fixture_paths, [33m"[39;49;00m[33mExpected drawio fixtures to patch[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
-        [94mfor[39;49;00m index, fixture_path [95min[39;49;00m [96menumerate[39;49;00m(fixture_paths):[90m[39;49;00m
-            metadata_options = _build_metadata_options(index, fixture_path)[90m[39;49;00m
-            patched_path = tmp_path / [33mf[39;49;00m[33m"[39;49;00m[33m{[39;49;00mfixture_path.stem[33m}[39;49;00m[33m-with-metadata.drawio[39;49;00m[33m"[39;49;00m[90m[39;49;00m
-    [90m[39;49;00m
->           _run_drawio_metadata_patcher(fixture_path, patched_path, metadata_options)[90m[39;49;00m
-
-[1m[31mlegacy/tests/test_patched_parser.py[0m:504: 
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-[1m[31mlegacy/tests/test_patched_parser.py[0m:442: in _run_drawio_metadata_patcher
-    [0msubprocess.run([90m[39;49;00m
-_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
-
-input = None, capture_output = False, timeout = None, check = True
-popenargs = (['bun', '--eval', "import { readFileSync, writeFileSync } from 'node:fs';\nimport { patchDrawioWithMetadata } from 'f...lass-diagram-tweaked/vocab#"}, {"rdfPrefix": "data5", "rdfIRI": "http://example.org/class-diagram-tweaked/data/"}]}'],)
-kwargs = {}
-process = <Popen: returncode: 1 args: ['bun', '--eval', "import { readFileSync, writeF...>
-stdout = None, stderr = None, retcode = 1
-
-    [0m[94mdef[39;49;00m[90m [39;49;00m[92mrun[39;49;00m(*popenargs,[90m[39;49;00m
-            [96minput[39;49;00m=[94mNone[39;49;00m, capture_output=[94mFalse[39;49;00m, timeout=[94mNone[39;49;00m, check=[94mFalse[39;49;00m, **kwargs):[90m[39;49;00m
-    [90m    [39;49;00m[33m"""Run command with arguments and return a CompletedProcess instance.[39;49;00m
-    [33m[39;49;00m
-    [33m    The returned instance will have attributes args, returncode, stdout and[39;49;00m
-    [33m    stderr. By default, stdout and stderr are not captured, and those attributes[39;49;00m
-    [33m    will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them,[39;49;00m
-    [33m    or pass capture_output=True to capture both.[39;49;00m
-    [33m[39;49;00m
-    [33m    If check is True and the exit code was non-zero, it raises a[39;49;00m
-    [33m    CalledProcessError. The CalledProcessError object will have the return code[39;49;00m
-    [33m    in the returncode attribute, and output & stderr attributes if those streams[39;49;00m
-    [33m    were captured.[39;49;00m
-    [33m[39;49;00m
-    [33m    If timeout (seconds) is given and the process takes too long,[39;49;00m
-    [33m     a TimeoutExpired exception will be raised.[39;49;00m
-    [33m[39;49;00m
-    [33m    There is an optional argument "input", allowing you to[39;49;00m
-    [33m    pass bytes or a string to the subprocess's stdin.  If you use this argument[39;49;00m
-    [33m    you may not also use the Popen constructor's "stdin" argument, as[39;49;00m
-    [33m    it will be used internally.[39;49;00m
-    [33m[39;49;00m
-    [33m    By default, all communication is in bytes, and therefore any "input" should[39;49;00m
-    [33m    be bytes, and the stdout and stderr will be bytes. If in text mode, any[39;49;00m
-    [33m    "input" should be a string, and stdout and stderr will be strings decoded[39;49;00m
-    [33m    according to locale encoding, or by "encoding" if set. Text mode is[39;49;00m
-    [33m    triggered by setting any of text, encoding, errors or universal_newlines.[39;49;00m
-    [33m[39;49;00m
-    [33m    The other arguments are the same as for the Popen constructor.[39;49;00m
-    [33m    """[39;49;00m[90m[39;49;00m
-        [94mif[39;49;00m [96minput[39;49;00m [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m:[90m[39;49;00m
-            [94mif[39;49;00m kwargs.get([33m'[39;49;00m[33mstdin[39;49;00m[33m'[39;49;00m) [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m:[90m[39;49;00m
-                [94mraise[39;49;00m [96mValueError[39;49;00m([33m'[39;49;00m[33mstdin and input arguments may not both be used.[39;49;00m[33m'[39;49;00m)[90m[39;49;00m
-            kwargs[[33m'[39;49;00m[33mstdin[39;49;00m[33m'[39;49;00m] = PIPE[90m[39;49;00m
-    [90m[39;49;00m
-        [94mif[39;49;00m capture_output:[90m[39;49;00m
-            [94mif[39;49;00m kwargs.get([33m'[39;49;00m[33mstdout[39;49;00m[33m'[39;49;00m) [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m [95mor[39;49;00m kwargs.get([33m'[39;49;00m[33mstderr[39;49;00m[33m'[39;49;00m) [95mis[39;49;00m [95mnot[39;49;00m [94mNone[39;49;00m:[90m[39;49;00m
-                [94mraise[39;49;00m [96mValueError[39;49;00m([33m'[39;49;00m[33mstdout and stderr arguments may not be used [39;49;00m[33m'[39;49;00m[90m[39;49;00m
-                                 [33m'[39;49;00m[33mwith capture_output.[39;49;00m[33m'[39;49;00m)[90m[39;49;00m
-            kwargs[[33m'[39;49;00m[33mstdout[39;49;00m[33m'[39;49;00m] = PIPE[90m[39;49;00m
-            kwargs[[33m'[39;49;00m[33mstderr[39;49;00m[33m'[39;49;00m] = PIPE[90m[39;49;00m
-    [90m[39;49;00m
-        [94mwith[39;49;00m Popen(*popenargs, **kwargs) [94mas[39;49;00m process:[90m[39;49;00m
-            [94mtry[39;49;00m:[90m[39;49;00m
-                stdout, stderr = process.communicate([96minput[39;49;00m, timeout=timeout)[90m[39;49;00m
-            [94mexcept[39;49;00m TimeoutExpired [94mas[39;49;00m exc:[90m[39;49;00m
-                process.kill()[90m[39;49;00m
-                [94mif[39;49;00m _mswindows:[90m[39;49;00m
-                    [90m# Windows accumulates the output in a single blocking[39;49;00m[90m[39;49;00m
-                    [90m# read() call run on child threads, with the timeout[39;49;00m[90m[39;49;00m
-                    [90m# being done in a join() on those threads.  communicate()[39;49;00m[90m[39;49;00m
-                    [90m# _after_ kill() is required to collect that and add it[39;49;00m[90m[39;49;00m
-                    [90m# to the exception.[39;49;00m[90m[39;49;00m
-                    exc.stdout, exc.stderr = process.communicate()[90m[39;49;00m
-                [94melse[39;49;00m:[90m[39;49;00m
-                    [90m# POSIX _communicate already populated the output so[39;49;00m[90m[39;49;00m
-                    [90m# far into the TimeoutExpired exception.[39;49;00m[90m[39;49;00m
-                    process.wait()[90m[39;49;00m
-                [94mraise[39;49;00m[90m[39;49;00m
-            [94mexcept[39;49;00m:  [90m# Including KeyboardInterrupt, communicate handled that.[39;49;00m[90m[39;49;00m
-                process.kill()[90m[39;49;00m
-                [90m# We don't call process.wait() as .__exit__ does that for us.[39;49;00m[90m[39;49;00m
-                [94mraise[39;49;00m[90m[39;49;00m
-            retcode = process.poll()[90m[39;49;00m
-            [94mif[39;49;00m check [95mand[39;49;00m retcode:[90m[39;49;00m
->               [94mraise[39;49;00m CalledProcessError(retcode, process.args,[90m[39;49;00m
-                                         output=stdout, stderr=stderr)[90m[39;49;00m
-[1m[31mE               subprocess.CalledProcessError: Command '['bun', '--eval', "import { readFileSync, writeFileSync } from 'node:fs';\nimport { patchDrawioWithMetadata } from 'file:///Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts';\n\nconst [, inputPath, outputPath, optionsJson] = process.argv;\nconst options = JSON.parse(optionsJson);\n\nconst patched = patchDrawioWithMetadata(readFileSync(inputPath, 'utf8'), options);\nwriteFileSync(outputPath, patched);", '/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/fixtures/Class_Diagram_tweaked.drawio', '/private/var/folders/dr/h5f6hp6j20s6x8737ypcwxj40000gn/T/pytest-of-anonymous/pytest-473/test_generated_metadata_fixtur0/Class_Diagram_tweaked-with-metadata.drawio', '{"csvPath": "/tmp/class-diagram-tweaked.csv", "baseUri": "http://example.org/class-diagram-tweaked/", "label": "Class_Diagram_tweaked metadata", "preamble": [{"rdfPrefix": "fx5", "rdfIRI": "http://example.org/class-diagram-tweaked/vocab#"}, {"rdfPrefix": "data5", "rdfIRI": "http://example.org/class-diagram-tweaked/data/"}]}']' returned non-zero exit status 1.[0m
-
-[1m[31m/Users/anonymous/miniconda3/lib/python3.12/subprocess.py[0m:573: CalledProcessError
-------------------------------------- Captured stderr call --------------------------------------
-15 | function assertElement<T extends Element | null>(
-16 |   element: T,
-17 |   message: string,
-18 | ): asserts element is Exclude<T, null> {
-19 |   if (!element) {
-20 |     throw new Error(message);
-               ^
-error: Unable to locate root <mxCell id="0"> element to patch
-      at assertElement (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts:20:11)
-      at patchDrawioWithMetadata (/Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts:88:3)
-      at /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/[eval]:7:17
-      at loadAndEvaluateModule (2:1)
-
-Bun v1.2.21 (macOS arm64)
-[33m======================================= warnings summary ========================================[0m
-legacy/tests/test_cell_classifier.py: 4 warnings
-legacy/tests/test_patched_parser.py: 38 warnings
-legacy/tests/test_pyodide_pipeline.py: 5 warnings
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2563: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
-    parsed_root
-
-legacy/tests/test_cell_classifier.py: 101 warnings
-legacy/tests/test_patched_parser.py: 1227 warnings
-legacy/tests/test_pyodide_pipeline.py: 105 warnings
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:617: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
-    target_cell
-
-legacy/tests/test_patched_parser.py::test_parse_drawio_with_metadata_exposes_namespace_and_csv_path
-legacy/tests/test_patched_parser.py::test_parse_drawio_default_strips_html_literals
-legacy/tests/test_patched_parser.py::test_parse_drawio_respects_strip_html_config
-legacy/tests/test_patched_parser.py::test_parse_drawio_metadata_strip_html_override
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip
-  /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py:2566: DeprecationWarning: Testing an element's truth value will always return True in future versions.  Use specific 'len(elem)' or 'elem is not None' test instead.
-    if parsed_root.find(".//UserObject[@id='0']")
-
--- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-[36m[1m==================================== short test summary info ====================================[0m
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_preserves_literal_targets[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI 'sdfsdf' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_serialise_to_graph_falls_back_for_relative_prefixes[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI 'relative-prefix' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[dangling_curie][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[colon_only][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_rejects_malformed_type_variants[no_prefix][0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_accepts_corrected_mock_types[0m - draw_io_parser.xml_data_core.ParseException: Prefix IRI '://hello' looks invalid
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_respects_strip_html_config[0m - assert []
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_parse_drawio_metadata_strip_html_override[0m - assert []
-[31mFAILED[0m legacy/tests/test_patched_parser.py::[1mtest_generated_metadata_fixtures_round_trip[0m - subprocess.CalledProcessError: Command '['bun', '--eval', "import { readFileSync, writeFileS...
-[31m========================== [31m[1m9 failed[0m, [32m57 passed[0m, [33m1489 warnings[0m[31m in 1.58s[0m[31m ==========================[0m
-[0m[1mbun test [0m[2mv1.2.21 (7c45ed97)[0m
-[0m
-tests/rdfexport.test.ts:
-[BLACKBOX] Received serialized payload (36445 characters)
-[PIPELINE] Initializing Pyodide runtime from /Volumes/home/anonymous/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
-[PIPELINE] Pyodide runtime ready
-[PIPELINE] Preparing Pyodide Python environment
-[PIPELINE] Syncing Python module to virtual FS: /app/legacy/draw_io_parser.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/__init__.py
-[PIPELINE] Syncing Python module to virtual FS: /app/pyodide_pipeline/drawio_pipeline.py
-[PIPELINE] Syncing Python wheel to virtual FS: /app/wheels/rdflib-7.2.1-py3-none-any.whl
-[PIPELINE] Pyodide Python environment ready
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 36445)
-[PIPELINE] DrawIO parser produced graph graph-0 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-0 with 72 triples
-[BLACKBOX] Black box processing completed
-[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m1369.51ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[0.62ms[0m[2m][0m
-[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m19.89ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
-[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (61829 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
-[PIPELINE] DrawIO parser produced graph graph-1 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-1 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-1 (7040 characters)
-[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
-[PIPELINE] DrawIO parser produced graph graph-2 with 126 triples
-[BLACKBOX] Parsed DrawIO graph graph-2 with 126 triples
-[BLACKBOX] Returning Turtle payload for graph graph-2 (7040 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
-[PIPELINE] DrawIO parser produced graph graph-3 with 127 triples
-[BLACKBOX] Parsed DrawIO graph graph-3 with 127 triples
-[BLACKBOX] Returning Turtle payload for graph graph-3 (7106 characters)
-[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m235.04ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44261 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
-[PIPELINE] DrawIO parser produced graph graph-4 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-4 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-4 (5497 characters)
-[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
-[PIPELINE] DrawIO parser produced graph graph-5 with 93 triples
-[BLACKBOX] Parsed DrawIO graph graph-5 with 93 triples
-[BLACKBOX] Returning Turtle payload for graph graph-5 (5497 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
-[PIPELINE] DrawIO parser produced graph graph-6 with 94 triples
-[BLACKBOX] Parsed DrawIO graph graph-6 with 94 triples
-[BLACKBOX] Returning Turtle payload for graph graph-6 (5563 characters)
-[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m133.10ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23410 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
-[PIPELINE] DrawIO parser produced graph graph-7 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-7 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-7 (3002 characters)
-[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
-[PIPELINE] DrawIO parser produced graph graph-8 with 53 triples
-[BLACKBOX] Parsed DrawIO graph graph-8 with 53 triples
-[BLACKBOX] Returning Turtle payload for graph graph-8 (3002 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
-[PIPELINE] DrawIO parser produced graph graph-9 with 54 triples
-[BLACKBOX] Parsed DrawIO graph graph-9 with 54 triples
-[BLACKBOX] Returning Turtle payload for graph graph-9 (3068 characters)
-[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
-[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m78.50ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (23546 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
-[PIPELINE] DrawIO parser produced graph graph-10 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-10 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-10 (3738 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
-[PIPELINE] DrawIO parser produced graph graph-11 with 50 triples
-[BLACKBOX] Parsed DrawIO graph graph-11 with 50 triples
-[BLACKBOX] Returning Turtle payload for graph graph-11 (3738 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
-[PIPELINE] DrawIO parser produced graph graph-12 with 51 triples
-[BLACKBOX] Parsed DrawIO graph graph-12 with 51 triples
-[BLACKBOX] Returning Turtle payload for graph graph-12 (3804 characters)
-[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m74.52ms[0m[2m][0m
-[0m[33m»[2m[0m[2m knut_olborgs_forskningsnotater.drawio: skipped (no matching baseline knut_olborgs_forskningsnotater.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39399 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
-[PIPELINE] DrawIO parser produced graph graph-13 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-13 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-13 (4590 characters)
-[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
-[PIPELINE] DrawIO parser produced graph graph-14 with 77 triples
-[BLACKBOX] Parsed DrawIO graph graph-14 with 77 triples
-[BLACKBOX] Returning Turtle payload for graph graph-14 (4590 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
-[PIPELINE] DrawIO parser produced graph graph-15 with 78 triples
-[BLACKBOX] Parsed DrawIO graph graph-15 with 78 triples
-[BLACKBOX] Returning Turtle payload for graph graph-15 (4656 characters)
-[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m111.89ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (44795 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
-[PIPELINE] DrawIO parser produced graph graph-16 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-16 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-16 (5458 characters)
-[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
-[PIPELINE] DrawIO parser produced graph graph-17 with 86 triples
-[BLACKBOX] Parsed DrawIO graph graph-17 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-17 (5458 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
-[PIPELINE] DrawIO parser produced graph graph-18 with 87 triples
-[BLACKBOX] Parsed DrawIO graph graph-18 with 87 triples
-[BLACKBOX] Returning Turtle payload for graph graph-18 (5524 characters)
-[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m127.42ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (39329 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (39329 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39329)
-[PIPELINE] DrawIO parser produced graph graph-19 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-19 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-19 (5053 characters)
-[PIPELINE] Saving export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (39312 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39312)
-[PIPELINE] DrawIO parser produced graph graph-20 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-20 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-20 (5053 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 74 vs 74
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 72 vs 72
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (39347 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (39347 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39347)
-[PIPELINE] DrawIO parser produced graph graph-21 with 75 triples
-[BLACKBOX] Parsed DrawIO graph graph-21 with 75 triples
-[BLACKBOX] Returning Turtle payload for graph graph-21 (5119 characters)
-[PIPELINE] Saving RML export payload to F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m122.44ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (73837 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
-[PIPELINE] DrawIO parser produced graph graph-22 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-22 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-22 (9086 characters)
-[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
-[PIPELINE] DrawIO parser produced graph graph-23 with 136 triples
-[BLACKBOX] Parsed DrawIO graph graph-23 with 136 triples
-[BLACKBOX] Returning Turtle payload for graph graph-23 (9086 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (73855 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (73855 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73855)
-[PIPELINE] DrawIO parser produced graph graph-24 with 137 triples
-[BLACKBOX] Parsed DrawIO graph graph-24 with 137 triples
-[BLACKBOX] Returning Turtle payload for graph graph-24 (9152 characters)
-[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m199.55ms[0m[2m][0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
-[0m[33m»[2m[0m[2m Class_Diagram_tweaked.drawio: skipped (no matching baseline Class_Diagram_tweaked.nt)[0m
-[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
-[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
+bash: src/main/webapp/plugins/rdfexport/legacy/scripts/run_regeneration.sh: No such file or directory
+scripts/test_legacy.sh: line 23: cd: src/main/webapp/plugins/rdfexport: No such file or directory
+[0m[1mbun test [0m[2mv1.2.14 (6a363a38)[0m
+[PIPELINE] Initializing Pyodide runtime from /workspace/drawio/src/main/webapp/plugins/rdfexport/node_modules/pyodide/
+[0m[32m✓[0m[0m[1m runMockBlackBox returns DrawIO parser summary[0m [0m[2m[[1m5985.40ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m debugPyodide evaluates Python expressions[0m [0m[2m[2.34ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m compiled rdfexport plugin bundle includes CSV property hook[0m [0m[2m[[1m164.17ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (48162 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (48162 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48162)
+[PIPELINE] DrawIO parser produced graph graph-1 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-1 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-1 (5721 characters)
+[PIPELINE] Saving export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (48145 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48145)
+[PIPELINE] DrawIO parser produced graph graph-2 with 88 triples
+[BLACKBOX] Parsed DrawIO graph graph-2 with 88 triples
+[BLACKBOX] Returning Turtle payload for graph graph-2 (5721 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 88 vs 88
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 86 vs 86
+[PIPELINE] Generated DrawIO XML payload (48180 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (48180 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 48180)
+[PIPELINE] DrawIO parser produced graph graph-3 with 89 triples
+[BLACKBOX] Parsed DrawIO graph graph-3 with 89 triples
+[BLACKBOX] Returning Turtle payload for graph graph-3 (5787 characters)
+[PIPELINE] Saving RML export payload to RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for RG 10-142 Correspondence of the Chief of the Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 10-142 Correspondence of the Chief of the Chest Disease Service.drawio: no regression[0m [0m[2m[[1m742.29ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (42022 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (42022 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42022)
+[PIPELINE] DrawIO parser produced graph graph-4 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-4 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-4 (6307 characters)
+[PIPELINE] Saving export payload to F 47-11-1 Elizabeth Simcoe loose sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (42005 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42005)
+[PIPELINE] DrawIO parser produced graph graph-5 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-5 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-5 (6307 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[PIPELINE] Generated DrawIO XML payload (42040 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (42040 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 42040)
+[PIPELINE] DrawIO parser produced graph graph-6 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-6 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-6 (6373 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1 Elizabeth Simcoe loose sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1 Elizabeth Simcoe loose sketches.drawio: no regression[0m [0m[2m[[1m387.40ms[0m[2m][0m
 [0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (80881 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
-[PIPELINE] DrawIO parser produced graph graph-25 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-25 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-25 (11220 characters)
-[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
-[PIPELINE] DrawIO parser produced graph graph-26 with 172 triples
-[BLACKBOX] Parsed DrawIO graph graph-26 with 172 triples
-[BLACKBOX] Returning Turtle payload for graph graph-26 (11220 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
-[PIPELINE] DrawIO parser produced graph graph-27 with 173 triples
-[BLACKBOX] Parsed DrawIO graph graph-27 with 173 triples
-[BLACKBOX] Returning Turtle payload for graph graph-27 (11286 characters)
-[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
-[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m248.49ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (37618 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
-[PIPELINE] DrawIO parser produced graph graph-28 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-28 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-28 (4345 characters)
-[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
-[PIPELINE] DrawIO parser produced graph graph-29 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-29 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-29 (4345 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
-[PIPELINE] DrawIO parser produced graph graph-30 with 74 triples
-[BLACKBOX] Parsed DrawIO graph graph-30 with 74 triples
-[BLACKBOX] Returning Turtle payload for graph graph-30 (4411 characters)
-[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
-[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m107.76ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (95213 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
-[PIPELINE] DrawIO parser produced graph graph-31 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-31 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-31 (9826 characters)
-[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
-[PIPELINE] DrawIO parser produced graph graph-32 with 143 triples
-[BLACKBOX] Parsed DrawIO graph graph-32 with 143 triples
-[BLACKBOX] Returning Turtle payload for graph graph-32 (9826 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
-[PIPELINE] DrawIO parser produced graph graph-33 with 144 triples
-[BLACKBOX] Parsed DrawIO graph graph-33 with 144 triples
-[BLACKBOX] Returning Turtle payload for graph graph-33 (9892 characters)
-[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
-[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m237.37ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (54132 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
-[PIPELINE] DrawIO parser produced graph graph-34 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-34 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-34 (6195 characters)
-[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
-[PIPELINE] DrawIO parser produced graph graph-35 with 97 triples
-[BLACKBOX] Parsed DrawIO graph graph-35 with 97 triples
-[BLACKBOX] Returning Turtle payload for graph graph-35 (6195 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
-[PIPELINE] DrawIO parser produced graph graph-36 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-36 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-36 (6261 characters)
-[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
-[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m141.74ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (58348 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (58348 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58348)
-[PIPELINE] DrawIO parser produced graph graph-37 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-37 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-37 (9207 characters)
-[PIPELINE] Saving export payload to F 47 Simcoe Family fonds.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (58331 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58331)
-[PIPELINE] DrawIO parser produced graph graph-38 with 103 triples
-[BLACKBOX] Parsed DrawIO graph graph-38 with 103 triples
-[BLACKBOX] Returning Turtle payload for graph graph-38 (9207 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 103 vs 103
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 101 vs 101
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (58366 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (58366 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 58366)
-[PIPELINE] DrawIO parser produced graph graph-39 with 104 triples
-[BLACKBOX] Parsed DrawIO graph graph-39 with 104 triples
-[BLACKBOX] Returning Turtle payload for graph graph-39 (9273 characters)
-[PIPELINE] Saving RML export payload to F 47 Simcoe Family fonds.rml.ttl
-[PIPELINE] Export pipeline completed for F 47 Simcoe Family fonds.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m193.66ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (34895 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
-[PIPELINE] DrawIO parser produced graph graph-40 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-40 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-40 (5761 characters)
-[PIPELINE] Saving export payload to AA37 Department of Health.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
-[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
-[PIPELINE] DrawIO parser produced graph graph-41 with 72 triples
-[BLACKBOX] Parsed DrawIO graph graph-41 with 72 triples
-[BLACKBOX] Returning Turtle payload for graph graph-41 (5761 characters)
-[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
-[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
-[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
-[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
-[PIPELINE] DrawIO parser produced graph graph-42 with 73 triples
-[BLACKBOX] Parsed DrawIO graph graph-42 with 73 triples
-[BLACKBOX] Returning Turtle payload for graph graph-42 (5827 characters)
-[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
-[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m98.21ms[0m[2m][0m
-[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
-[PIPELINE] exportRdfXml action invoked
 [PIPELINE] Generated DrawIO XML payload (49944 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (49944 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49944)
-[PIPELINE] DrawIO parser produced graph graph-43 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-43 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-43 (6443 characters)
+[PIPELINE] DrawIO parser produced graph graph-7 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-7 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-7 (6443 characters)
 [PIPELINE] Saving export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (49927 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49927)
-[PIPELINE] DrawIO parser produced graph graph-44 with 98 triples
-[BLACKBOX] Parsed DrawIO graph graph-44 with 98 triples
-[BLACKBOX] Returning Turtle payload for graph graph-44 (6443 characters)
+[PIPELINE] DrawIO parser produced graph graph-8 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-8 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-8 (6443 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 98 vs 98
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 96 vs 96
@@ -1814,59 +84,441 @@ tests/rdfexport.test.ts:
 [PIPELINE] Generated DrawIO XML payload (49962 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (49962 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 49962)
-[PIPELINE] DrawIO parser produced graph graph-45 with 99 triples
-[BLACKBOX] Parsed DrawIO graph graph-45 with 99 triples
-[BLACKBOX] Returning Turtle payload for graph graph-45 (6509 characters)
+[PIPELINE] DrawIO parser produced graph graph-9 with 99 triples
+[BLACKBOX] Parsed DrawIO graph graph-9 with 99 triples
+[BLACKBOX] Returning Turtle payload for graph graph-9 (6509 characters)
 [PIPELINE] Saving RML export payload to RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl
 [PIPELINE] Export pipeline completed for RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m136.85ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 18-210 Records of the Walkerton Inquiry - revised to ADD mapping.drawio: no regression[0m [0m[2m[[1m448.90ms[0m[2m][0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[0m[33m»[2m[0m[2m General_Authority_bleep_mock.drawio: skipped (no matching baseline General_Authority_bleep_mock.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
+[PIPELINE] DrawIO parser produced graph graph-10 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-10 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-10 (5053 characters)
+[PIPELINE] DrawIO parser produced graph graph-11 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-11 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-11 (5053 characters)
+[PIPELINE] DrawIO parser produced graph graph-12 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-12 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-12 (5119 characters)
+[0m[32m✓[0m[0m[1m F 47-11-3 Elizabeth Simcoe miscellaneous sketches and fragments.drawio: no regression[0m [0m[2m[[1m294.37ms[0m[2m][0m
 [PIPELINE] Generated DrawIO XML payload (32209 characters)
 [BLACKBOX] Generating Turtle payload for serialized input (32209 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 32209)
-[PIPELINE] DrawIO parser produced graph graph-46 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-46 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-46 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-13 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-13 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-13 (3931 characters)
 [PIPELINE] Saving export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
 [PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.ttl
 [BLACKBOX] Generating Turtle payload for serialized input (32192 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 32192)
-[PIPELINE] DrawIO parser produced graph graph-47 with 63 triples
-[BLACKBOX] Parsed DrawIO graph graph-47 with 63 triples
-[BLACKBOX] Returning Turtle payload for graph graph-47 (3931 characters)
+[PIPELINE] DrawIO parser produced graph graph-14 with 63 triples
+[BLACKBOX] Parsed DrawIO graph graph-14 with 63 triples
+[BLACKBOX] Returning Turtle payload for graph graph-14 (3931 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 63 vs 63
-[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 61 vs 61
-[TEST] Also, Turtle is isomorphic to baseline N-Triples
-[PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (32227 characters) for RML export
 [BLACKBOX] Generating Turtle payload for serialized input (32227 characters)
 [PIPELINE] Invoking DrawIO parser via Pyodide (input length 32227)
-[PIPELINE] DrawIO parser produced graph graph-48 with 64 triples
-[BLACKBOX] Parsed DrawIO graph graph-48 with 64 triples
-[BLACKBOX] Returning Turtle payload for graph graph-48 (3997 characters)
+[PIPELINE] DrawIO parser produced graph graph-15 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-15 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-15 (3997 characters)
 [PIPELINE] Saving RML export payload to RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl
 [PIPELINE] Export pipeline completed for RG 10-145 Mobile Tuberculosis Testing Clinic photographs.rml.ttl (RML mode)
-[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m90.35ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m RG 10-145 Mobile Tuberculosis Testing Clinic photographs.drawio: no regression[0m [0m[2m[[1m262.53ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (23410 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23410 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23410)
+[PIPELINE] DrawIO parser produced graph graph-16 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-16 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-16 (3002 characters)
+[PIPELINE] Saving export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23393 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23393)
+[PIPELINE] DrawIO parser produced graph graph-17 with 53 triples
+[BLACKBOX] Parsed DrawIO graph graph-17 with 53 triples
+[BLACKBOX] Returning Turtle payload for graph graph-17 (3002 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 53 vs 53
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 51 vs 51
+[PIPELINE] Generated DrawIO XML payload (23428 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23428 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23428)
+[PIPELINE] DrawIO parser produced graph graph-18 with 54 triples
+[BLACKBOX] Parsed DrawIO graph graph-18 with 54 triples
+[BLACKBOX] Returning Turtle payload for graph graph-18 (3068 characters)
+[PIPELINE] Saving RML export payload to RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl
+[PIPELINE] Export pipeline completed for RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 1-659 - Northern pike lamprey mark, Rondeau Park, April 20, 1955.drawio: no regression[0m [0m[2m[[1m207.88ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (54132 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (54132 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54132)
+[PIPELINE] DrawIO parser produced graph graph-19 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-19 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-19 (6195 characters)
+[PIPELINE] Saving export payload to CA1934 Division of Tuberculosis Prevention.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (54115 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54115)
+[PIPELINE] DrawIO parser produced graph graph-20 with 97 triples
+[BLACKBOX] Parsed DrawIO graph graph-20 with 97 triples
+[BLACKBOX] Returning Turtle payload for graph graph-20 (6195 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 97 vs 97
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 95 vs 95
+[PIPELINE] Generated DrawIO XML payload (54150 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (54150 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 54150)
+[PIPELINE] DrawIO parser produced graph graph-21 with 98 triples
+[BLACKBOX] Parsed DrawIO graph graph-21 with 98 triples
+[BLACKBOX] Returning Turtle payload for graph graph-21 (6261 characters)
+[PIPELINE] Saving RML export payload to CA1934 Division of Tuberculosis Prevention.rml.ttl
+[PIPELINE] Export pipeline completed for CA1934 Division of Tuberculosis Prevention.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1934 Division of Tuberculosis Prevention.drawio: no regression[0m [0m[2m[[1m437.12ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (37299 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37299 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37299)
+[PIPELINE] DrawIO parser produced graph graph-22 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-22 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-22 (4369 characters)
+[PIPELINE] Saving export payload to CA1853 Chest Disease Service.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37282 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37282)
+[PIPELINE] DrawIO parser produced graph graph-23 with 75 triples
+[BLACKBOX] Parsed DrawIO graph graph-23 with 75 triples
+[BLACKBOX] Returning Turtle payload for graph graph-23 (4369 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 75 vs 75
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 73 vs 73
+[PIPELINE] Generated DrawIO XML payload (37317 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37317 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37317)
+[PIPELINE] DrawIO parser produced graph graph-24 with 76 triples
+[BLACKBOX] Parsed DrawIO graph graph-24 with 76 triples
+[BLACKBOX] Returning Turtle payload for graph graph-24 (4435 characters)
+[PIPELINE] Saving RML export payload to CA1853 Chest Disease Service.rml.ttl
+[PIPELINE] Export pipeline completed for CA1853 Chest Disease Service.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m CA1853 Chest Disease Service.drawio: no regression[0m [0m[2m[[1m305.92ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (34895 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (34895 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34895)
+[PIPELINE] DrawIO parser produced graph graph-25 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-25 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-25 (5761 characters)
+[PIPELINE] Saving export payload to AA37 Department of Health.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (34878 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34878)
+[PIPELINE] DrawIO parser produced graph graph-26 with 72 triples
+[BLACKBOX] Parsed DrawIO graph graph-26 with 72 triples
+[BLACKBOX] Returning Turtle payload for graph graph-26 (5761 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 72 vs 72
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 70 vs 70
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (34913 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (34913 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 34913)
+[PIPELINE] DrawIO parser produced graph graph-27 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-27 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-27 (5827 characters)
+[PIPELINE] Saving RML export payload to AA37 Department of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA37 Department of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA37 Department of Health.drawio: no regression[0m [0m[2m[[1m262.93ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-severely-mocked.nt)[0m
 [TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
 [PIPELINE] exportRdfXml action invoked
-[PIPELINE] Generated DrawIO XML payload (40866 characters)
-[BLACKBOX] Generating Turtle payload for serialized input (40866 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40866)
+[PIPELINE] Generated DrawIO XML payload (23546 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (23546 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23546)
+[PIPELINE] DrawIO parser produced graph graph-28 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-28 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-28 (3738 characters)
+[PIPELINE] Saving export payload to F 47-11-1-0-1.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (23529 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23529)
+[PIPELINE] DrawIO parser produced graph graph-29 with 50 triples
+[BLACKBOX] Parsed DrawIO graph graph-29 with 50 triples
+[BLACKBOX] Returning Turtle payload for graph graph-29 (3738 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 50 vs 50
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 48 vs 48
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (23564 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (23564 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 23564)
+[PIPELINE] DrawIO parser produced graph graph-30 with 51 triples
+[BLACKBOX] Parsed DrawIO graph graph-30 with 51 triples
+[BLACKBOX] Returning Turtle payload for graph graph-30 (3804 characters)
+[PIPELINE] Saving RML export payload to F 47-11-1-0-1.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-1-0-1.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1.drawio: no regression[0m [0m[2m[[1m196.30ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (80881 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (80881 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80881)
+[PIPELINE] DrawIO parser produced graph graph-31 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-31 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-31 (11220 characters)
+[PIPELINE] Saving export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).ttl
+[BLACKBOX] Generating Turtle payload for serialized input (80864 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80864)
+[PIPELINE] DrawIO parser produced graph graph-32 with 172 triples
+[BLACKBOX] Parsed DrawIO graph graph-32 with 172 triples
+[BLACKBOX] Returning Turtle payload for graph graph-32 (11220 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 172 vs 172
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 170 vs 170
+[PIPELINE] Generated DrawIO XML payload (80899 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (80899 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 80899)
+[PIPELINE] DrawIO parser produced graph graph-33 with 173 triples
+[BLACKBOX] Parsed DrawIO graph graph-33 with 173 triples
+[BLACKBOX] Returning Turtle payload for graph graph-33 (11286 characters)
+[PIPELINE] Saving RML export payload to RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl
+[PIPELINE] Export pipeline completed for RG 18-210 Walkerton Inquiry in RiC-O (original).rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m RG 18-210 Walkerton Inquiry in RiC-O (original).drawio: no regression[0m [0m[2m[[1m663.93ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-34 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-34 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-34 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-35 with 103 triples
+[BLACKBOX] Parsed DrawIO graph graph-35 with 103 triples
+[BLACKBOX] Returning Turtle payload for graph graph-35 (9207 characters)
+[PIPELINE] DrawIO parser produced graph graph-36 with 104 triples
+[BLACKBOX] Parsed DrawIO graph graph-36 with 104 triples
+[BLACKBOX] Returning Turtle payload for graph graph-36 (9273 characters)
+[0m[32m✓[0m[0m[1m F 47 Simcoe Family fonds.drawio: no regression[0m [0m[2m[[1m417.28ms[0m[2m][0m
+[0m[33m»[2m[0m[2m Class_Diagram_tweaked.drawio: skipped (no matching baseline Class_Diagram_tweaked.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (73837 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (73837 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73837)
+[PIPELINE] DrawIO parser produced graph graph-37 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-37 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-37 (9086 characters)
+[PIPELINE] Saving export payload to General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (73820 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73820)
+[PIPELINE] DrawIO parser produced graph graph-38 with 136 triples
+[BLACKBOX] Parsed DrawIO graph graph-38 with 136 triples
+[BLACKBOX] Returning Turtle payload for graph graph-38 (9086 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 136 vs 136
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[PIPELINE] Generated DrawIO XML payload (73855 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (73855 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 73855)
+[PIPELINE] DrawIO parser produced graph graph-39 with 137 triples
+[BLACKBOX] Parsed DrawIO graph graph-39 with 137 triples
+[BLACKBOX] Returning Turtle payload for graph graph-39 (9152 characters)
+[PIPELINE] Saving RML export payload to General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General Authority to RiC-O Model_2025-06-25_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General Authority to RiC-O Model_2025-06-25_PZ.drawio: no regression[0m [0m[2m[[1m528.59ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (95213 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (95213 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95213)
+[PIPELINE] DrawIO parser produced graph graph-40 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-40 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-40 (9826 characters)
+[PIPELINE] Saving export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (95196 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95196)
+[PIPELINE] DrawIO parser produced graph graph-41 with 143 triples
+[BLACKBOX] Parsed DrawIO graph graph-41 with 143 triples
+[BLACKBOX] Returning Turtle payload for graph graph-41 (9826 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 143 vs 143
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 130 vs 130
+[PIPELINE] Generated DrawIO XML payload (95231 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (95231 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 95231)
+[PIPELINE] DrawIO parser produced graph graph-42 with 144 triples
+[BLACKBOX] Parsed DrawIO graph graph-42 with 144 triples
+[BLACKBOX] Returning Turtle payload for graph graph-42 (9892 characters)
+[PIPELINE] Saving RML export payload to General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl
+[PIPELINE] Export pipeline completed for General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m General ADD (Descriptions and Listings) to RiC-O Model_2025-06-20_PZ.drawio: no regression[0m [0m[2m[[1m716.15ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-43 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-43 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-43 (5715 characters)
+[PIPELINE] DrawIO parser produced graph graph-44 with 86 triples
+[BLACKBOX] Parsed DrawIO graph graph-44 with 86 triples
+[BLACKBOX] Returning Turtle payload for graph graph-44 (5715 characters)
+[PIPELINE] DrawIO parser produced graph graph-45 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-45 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-45 (5781 characters)
+[0m[32m✓[0m[0m[1m F 47-11-1-0-1 (VDB test).drawio: no regression[0m [0m[2m[[1m313.81ms[0m[2m][0m
+[PIPELINE] Generated DrawIO XML payload (61829 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (61829 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61829)
+[PIPELINE] DrawIO parser produced graph graph-46 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-46 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-46 (7040 characters)
+[PIPELINE] Saving export payload to F 4711 Orville Wood fonds.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (61812 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61812)
+[PIPELINE] DrawIO parser produced graph graph-47 with 126 triples
+[BLACKBOX] Parsed DrawIO graph graph-47 with 126 triples
+[BLACKBOX] Returning Turtle payload for graph graph-47 (7040 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 126 vs 126
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 124 vs 124
+[PIPELINE] Generated DrawIO XML payload (61847 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (61847 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 61847)
+[PIPELINE] DrawIO parser produced graph graph-48 with 127 triples
+[BLACKBOX] Parsed DrawIO graph graph-48 with 127 triples
+[BLACKBOX] Returning Turtle payload for graph graph-48 (7106 characters)
+[PIPELINE] Saving RML export payload to F 4711 Orville Wood fonds.rml.ttl
+[PIPELINE] Export pipeline completed for F 4711 Orville Wood fonds.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 4711 Orville Wood fonds.drawio: no regression[0m [0m[2m[[1m475.34ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (44795 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44795 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44795)
 [PIPELINE] DrawIO parser produced graph graph-49 with 86 triples
 [BLACKBOX] Parsed DrawIO graph graph-49 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-49 (5715 characters)
-[PIPELINE] Saving export payload to F 47-11-1-0-1 (VDB test).ttl
-[PIPELINE] Export pipeline completed for F 47-11-1-0-1 (VDB test).ttl
-[BLACKBOX] Generating Turtle payload for serialized input (40849 characters)
-[PIPELINE] Invoking DrawIO parser via Pyodide (input length 40849)
+[BLACKBOX] Returning Turtle payload for graph graph-49 (5458 characters)
+[PIPELINE] Saving export payload to F 47-11 Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44778 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44778)
 [PIPELINE] DrawIO parser produced graph graph-50 with 86 triples
 [BLACKBOX] Parsed DrawIO graph graph-50 with 86 triples
-[BLACKBOX] Returning Turtle payload for graph graph-50 (5715 characters)
+[BLACKBOX] Returning Turtle payload for graph graph-50 (5458 characters)
 [TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 86 vs 86
 [TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
 [TEST] Number of filtered triples in Turtle vs baseline N-Triples: 84 vs 84
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (44813 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44813 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44813)
+[PIPELINE] DrawIO parser produced graph graph-51 with 87 triples
+[BLACKBOX] Parsed DrawIO graph graph-51 with 87 triples
+[BLACKBOX] Returning Turtle payload for graph graph-51 (5524 characters)
+[PIPELINE] Saving RML export payload to F 47-11 Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11 Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11 Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m339.79ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (39399 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (39399 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39399)
+[PIPELINE] DrawIO parser produced graph graph-52 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-52 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-52 (4590 characters)
+[PIPELINE] Saving export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (39382 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39382)
+[PIPELINE] DrawIO parser produced graph graph-53 with 77 triples
+[BLACKBOX] Parsed DrawIO graph graph-53 with 77 triples
+[BLACKBOX] Returning Turtle payload for graph graph-53 (4590 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 77 vs 77
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 75 vs 75
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (39417 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (39417 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 39417)
+[PIPELINE] DrawIO parser produced graph graph-54 with 78 triples
+[BLACKBOX] Parsed DrawIO graph graph-54 with 78 triples
+[BLACKBOX] Returning Turtle payload for graph graph-54 (4656 characters)
+[PIPELINE] Saving RML export payload to F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-4 Notes on Elizabeth Simcoe sketches.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-4 Notes on Elizabeth Simcoe sketches.drawio: no regression[0m [0m[2m[[1m286.62ms[0m[2m][0m
+[TEST] Patched ontology IRI in fixture, set to: ontology://generated-from-draw-io/mock#
+[PIPELINE] exportRdfXml action invoked
+[PIPELINE] Generated DrawIO XML payload (44261 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (44261 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44261)
+[PIPELINE] DrawIO parser produced graph graph-55 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-55 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-55 (5497 characters)
+[PIPELINE] Saving export payload to AA42 Ministry of Health.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (44244 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44244)
+[PIPELINE] DrawIO parser produced graph graph-56 with 93 triples
+[BLACKBOX] Parsed DrawIO graph graph-56 with 93 triples
+[BLACKBOX] Returning Turtle payload for graph graph-56 (5497 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 93 vs 93
+[TEST] Also, Actual Turtle (plugin) is isomorphic to expected Turtle (pipeline): true
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 91 vs 91
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (44279 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (44279 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 44279)
+[PIPELINE] DrawIO parser produced graph graph-57 with 94 triples
+[BLACKBOX] Parsed DrawIO graph graph-57 with 94 triples
+[BLACKBOX] Returning Turtle payload for graph graph-57 (5563 characters)
+[PIPELINE] Saving RML export payload to AA42 Ministry of Health.rml.ttl
+[PIPELINE] Export pipeline completed for AA42 Ministry of Health.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m AA42 Ministry of Health.drawio: no regression[0m [0m[2m[[1m340.37ms[0m[2m][0m
+[PIPELINE] DrawIO parser produced graph graph-58 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-58 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-58 (4952 characters)
+[PIPELINE] DrawIO parser produced graph graph-59 with 64 triples
+[BLACKBOX] Parsed DrawIO graph graph-59 with 64 triples
+[BLACKBOX] Returning Turtle payload for graph graph-59 (4952 characters)
+[PIPELINE] DrawIO parser produced graph graph-60 with 65 triples
+[BLACKBOX] Parsed DrawIO graph graph-60 with 65 triples
+[BLACKBOX] Returning Turtle payload for graph graph-60 (5018 characters)
+[0m[32m✓[0m[0m[1m BA619 Walkerton Inquiry.drawio: no regression[0m [0m[2m[[1m313.07ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[PIPELINE] Generated DrawIO XML payload (37618 characters)
+[BLACKBOX] Generating Turtle payload for serialized input (37618 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37618)
+[PIPELINE] DrawIO parser produced graph graph-61 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-61 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-61 (4345 characters)
+[PIPELINE] Saving export payload to F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.ttl
+[BLACKBOX] Generating Turtle payload for serialized input (37601 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37601)
+[PIPELINE] DrawIO parser produced graph graph-62 with 73 triples
+[BLACKBOX] Parsed DrawIO graph graph-62 with 73 triples
+[BLACKBOX] Returning Turtle payload for graph graph-62 (4345 characters)
+[TEST] Number of triples in actual Turtle (plugin) vs expected Turtle (pipeline): 73 vs 73
+[TEST] Number of filtered triples in Turtle vs baseline N-Triples: 71 vs 71
+[TEST] Also, Turtle is isomorphic to baseline N-Triples
+[PIPELINE] exportRml action invoked
+[PIPELINE] Generated DrawIO XML payload (37636 characters) for RML export
+[BLACKBOX] Generating Turtle payload for serialized input (37636 characters)
+[PIPELINE] Invoking DrawIO parser via Pyodide (input length 37636)
+[PIPELINE] DrawIO parser produced graph graph-63 with 74 triples
+[BLACKBOX] Parsed DrawIO graph graph-63 with 74 triples
+[BLACKBOX] Returning Turtle payload for graph graph-63 (4411 characters)
+[PIPELINE] Saving RML export payload to F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl
+[PIPELINE] Export pipeline completed for F 47-11-2 Elizabeth Simcoe sketchbook.rml.ttl (RML mode)
+[0m[32m✓[0m[0m[1m F 47-11-2 Elizabeth Simcoe sketchbook.drawio: no regression[0m [0m[2m[[1m268.84ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline emits rr:TriplesMap triple when RML metadata enabled[0m [0m[2m[[1m66.87ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m runDrawioPipeline strips literal HTML when stripHtml enabled[0m [0m[2m[[1m57.95ms[0m[2m][0m
+[0m      [2mat [0m[0m[2m<anonymous>[0m[2m ([0m[0m[36m/workspace/drawio/src/main/webapp/plugins/rdfexport/tests/rdfexport.test.ts[0m[2m:[0m[33m1378[0m[2m:[33m39[0m[2m)[0m
+[0m[31m✗[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m77.85ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m rdfexport plugin exposes preamble controls and diagram properties[0m [0m[2m[[1m67.49ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m parser settings dialog updates stored configuration and pipeline[0m [0m[2m[[1m63.90ms[0m[2m][0m
+[0m[32m✓[0m[0m[1m patchDrawioWithMetadata reproduces AA37 metadata artifact[0m [0m[2m[[1m14.86ms[0m[2m][0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-rml.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-rml.nt)[0m
+[0m[33m»[2m[0m[2m koronakommisjonen.drawio: skipped (no matching baseline koronakommisjonen.nt)[0m
+[0m[33m»[2m[0m[2m AA37-with-metadata-even-more-severely-mocked.drawio: skipped (no matching baseline AA37-with-metadata-even-more-severely-mocked.nt)[0m
+[0m[33m»[2m[0m[2m Class_Diagram_tweaked.drawio: skipped (no matching baseline Class_Diagram_tweaked.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata.nt)[0m
+[0m[33m»[2m[0m[2m AA37 Department of Health-with-metadata-preserve-html.drawio: skipped (no matching baseline AA37 Department of Health-with-metadata-preserve-html.nt)[0m
+[0m[31m✗[0m[0m[1m runDrawioPipeline preserves literal HTML when stripHtml disabled[0m [0m[2m[[1m77.85ms[0m[2m][0m
+ 693 expect() calls
+Ran 39 tests across 1 files. [0m[2m[[1m14.87s[0m[2m][0m
+Script done on 2025-10-23 07:48:18+00:00 [COMMAND_EXIT_CODE="1"]
 [TEST] Also, Turtle is isomorphic to baseline N-Triples
 [PIPELINE] exportRml action invoked
 [PIPELINE] Generated DrawIO XML payload (40884 characters) for RML export


### PR DESCRIPTION
## Summary
- restore literal detection for `rounded=1` text nodes in the cell classifier override so they are treated as literals instead of decorations
- add pytest coverage that exercises the regression and regenerate the generated parser plus supporting artifacts
- record the work in the changelog, add the required report file, refresh the Bun test log, and keep debug scenario formatting in sync

## Testing
- bun install
- bun run setup:uv
- bun run setup:pyodide
- bun run test *(fails: existing issues with invalid prefix IRIs, HTML strip toggle expectations, and metadata patch script)*
- uv run pytest legacy/tests/test_cell_classifier.py -k rounded -vv
- bun run check
- bun run fix
- bun run test:log:linux *(fails: existing issue with `runDrawioPipeline preserves literal HTML when stripHtml disabled`)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d94c9ef4832d997c045b0dff0fcc