### PR TITLE
Fix literal detection for rounded draw.io cells

### DIFF
--- a/src/main/webapp/plugins/rdfexport/CHANGELOG.md
+++ b/src/main/webapp/plugins/rdfexport/CHANGELOG.md
@@ -27,6 +27,7 @@ This is reviewed by a human maintainer from time to time.
 
 ### Fixed
 
+- 2025-10-23 – Restored literal detection for DrawIO cells styled with `rounded=1` so absolute URIs stay datatype targets, updating the classifier override and pytest coverage. Report: `src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251023T074007Z.md`.
 - 2025-10-22 – Ensured the debug CLI exits with a non-zero status whenever scenario runs record errors in `map.json`, wiring the behaviour into `__main__` and adding pytest coverage for both the runner and entrypoint. Report: `src/main/webapp/plugins/rdfexport/docs/aicode/codex-report-20251022T223455Z.md`.
 - 2025-10-22 – Updated `debug/debug_cli_regression.py` to add `_scenario_slug_from_command` helper and enhance the manual follow-up test so it re-runs scenarios, reloads `debug/map.json`, and inspects errors, allowing only `py_legacy` issues. Report: `src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20250219T000000Z.md`.
 - 2025-10-22 – Restored DrawIO arrow classification parity with the legacy parser so override generation now recognises non-strict edges exactly as the original implementation, refreshed debug fixtures, and tightened pytest coverage for strict-mode failures.

--- a/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251023T074007Z.md
+++ b/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20251023T074007Z.md
@@ -1,0 +1,11 @@
+# Task Report – Restore rounded literal detection
+
+## Summary
+- Reintroduced DrawIO literal detection for `rounded=1` cells by adding a style-aware check to the override classifier and ensuring the override is used during extraction.
+- Added a regression test covering rounded literal behaviour with absolute URI values and wired the legacy override loader to prefer the local classifier implementation.
+- Documented the change in the changelog and captured execution logs as required.
+
+## Testing
+- `pytest legacy/tests/test_cell_classifier.py::test_rounded_style_literals_remain_literals`
+- `bun run check`
+- `bun run test` *(fails: baseline regeneration rejects invalid prefix IRIs and existing HTML-preservation expectations; see console log)*

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/cell_classifier.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/cell_classifier.py
@@ -5,6 +5,11 @@ import typing
 from typing import Iterable
 
 from legacy.draw_io_parser import *  # type: ignore=imported-unused
+from legacy.draw_io_parser import (  # type: ignore=attr-defined
+    _NoCellCloseEnoughException,
+    _NoValueException,
+    _verify_is_ric_class,
+)
 from meta_builder.drawio_meta_builder import override
 
 # ruff: noqa: F403, F405
@@ -219,6 +224,9 @@ class DrawIOCellClassifier:
             return CellClassification(kind.ARROW_LABEL, raw_value, cell)
 
         if not raw_value:
+            return CellClassification(kind.LITERAL, raw_value, cell)
+
+        if self._style_suggests_literal(cell, raw_value, style):
             return CellClassification(kind.LITERAL, raw_value, cell)
 
         parent_cell, parent_identifier = self._resolve_parent(cell)
@@ -672,6 +680,16 @@ class DrawIOCellClassifier:
         if not style:
             return False
         return "text;" in style or "shape=text" in style
+
+    def _style_suggests_literal(
+        self, cell: Element, raw_value: str, style: str
+    ) -> bool:
+        if not style or "rounded=1" not in style:
+            return False
+        if cell.attrib.get("parent") != "1":
+            return False
+        prefix_candidate = raw_value.split(":", 1)[0]
+        return prefix_candidate not in self._prefixes
 
     def _is_decoration(self, cell: Element, raw_value: str) -> bool:
         if not raw_value:

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/curie_validator.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/curie_validator.py
@@ -57,7 +57,14 @@ def _ensure_known_curie(
 
 @override(phase="core", type="xml", role="data")
 def _extract_individual_and_arrow_and_literal_cells(self, prefixes) -> None:
-    classifier_cls = pipeline.core.xml.data.DrawIOCellClassifier
+    try:
+        from legacy.overrides.cell_classifier import (
+            DrawIOCellClassifier as OverrideClassifier,
+        )
+
+        classifier_cls = OverrideClassifier
+    except Exception:
+        classifier_cls = pipeline.core.xml.data.DrawIOCellClassifier
     decorations_attr = getattr(
         classifier_cls,
         "DECORATION_REGISTRY_ATTR",

--- a/src/main/webapp/plugins/rdfexport/legacy/tests/test_cell_classifier.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/tests/test_cell_classifier.py
@@ -138,6 +138,18 @@ def _apply_drawio_overrides(monkeypatch):
         raising=False,
     )
 
+    from legacy.overrides.cell_classifier import (
+        DrawIOCellClassifier as OverrideClassifier,
+    )
+
+    monkeypatch.setattr(
+        draw_io_parser.pipeline.core.xml.data,
+        "DrawIOCellClassifier",
+        OverrideClassifier,
+        raising=False,
+    )
+    globals()["DrawIOCellClassifier"] = OverrideClassifier
+
 
 def test_classifier_detects_typed_individuals_and_literals():
     xml = _drawio_xml(
@@ -200,6 +212,23 @@ def test_absolute_uri_node_uses_default_type():
         for _, individual, _ in tree.individual_cells
     }
     assert (uri_value, DEFAULT_STANDALONE_TYPE) in observed
+
+
+def test_rounded_style_literals_remain_literals():
+    uri_value = "http://example.com/literal"
+    xml = _drawio_xml(
+        _vertex_cell("source", "Source"),
+        _vertex_cell("source_type", "rico:Record", parent="source"),
+        _vertex_cell("literal", uri_value, style="html=1;rounded=1;"),
+    )
+
+    classifier = DrawIOCellClassifier(xml, draw_io_parser.get_prefixes())
+    classification = classifier.classifications.get("literal")
+    assert classification is not None
+    assert getattr(classification.kind, "name", "") == "LITERAL"
+
+    tree = draw_io_parser.DrawIOXMLTree(xml, draw_io_parser.get_prefixes())
+    assert any(cell.attrib.get("id") == "literal" for cell, _ in tree.literal_cells)
 
 
 def test_decorations_serialise_to_skos_note(tmp_path: Path):


### PR DESCRIPTION
## Summary
- ensure the override classifier imports underscore-prefixed helpers and treats rounded DrawIO cells as literals when their prefix is unknown
- load the override classifier in the extraction override and add a regression test for rounded literals, documenting the change

## Testing
- pytest legacy/tests/test_cell_classifier.py::test_rounded_style_literals_remain_literals
- bun run check
- bun run test *(fails: baseline regeneration rejects invalid prefix IRIs and HTML preservation expectations; see console log)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d94c9ef4832d997c045b0dff0fcc