### PR TITLE
Handle legacy metadata envelopes for rdfexport flowchart

### DIFF
--- a/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20250220T120000Z.md
+++ b/src/main/webapp/plugins/rdfexport/docs/aicode/gpt-5-codex-report-20250220T120000Z.md
@@ -1,0 +1,20 @@
+# RDF Export Plugin – Bugfix Report (Flowchart Tweaked metadata regression)
+
+## Summary
+- Investigated pytest failure triggered by `test_generated_metadata_fixtures_round_trip` where Flowchart fixtures caused `ArrowWithoutIndividualAsSourceException`.
+- Determined root cause: legacy DrawIO fixtures still using `<object>` metadata envelope were ignored by `_extract_drawio_metadata`, so the `kb` prefix never reached the classifier, leaving decision nodes treated as literals. Metadata patcher also overwrote legacy prefixes when injecting modern metadata.
+- Added a new override (`legacy/overrides/metadata_extraction.py`) so `_extract_drawio_metadata` recognises both `<UserObject>` and legacy `<object>` wrappers and harvests existing preamble entries.
+- Updated `tests/utils/patchDrawioWithMetadata.ts` to merge any pre-existing preamble entries into the generated metadata, preserving legacy prefixes when the fixture already declared them.
+- Regenerated the parser via `python -m meta_builder -o legacy/draw_io_parser.py` and reformatted with Ruff & Prettier.
+
+## Commands Executed
+- Environment prep: `bun install`, `bun run setup:uv`, `bun run setup:pyodide`, `bun run test`, `bun run check` (with supporting lint/format subtasks), plus targeted `pytest legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip` during diagnosis.
+- Formatting: `ruff format`, `prettier --write .` (with CI log-level guard) to satisfy repository style gates.
+
+## Testing
+- Targeted pytest run for `legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip` confirmed the regression fix locally before rerunning the full suite.
+- `bun run test` (legacy + TypeScript + Pyodide integration) and `bun run check` executed cleanly with all existing skips unchanged.
+
+## Notes
+- No CHANGELOG entry provided for this focused bugfix per existing project cadence.
+- Flowchart fixtures continue to be skipped in baseline regeneration until dedicated `.nt` fixtures exist; behaviour unchanged by this patch.

--- a/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/draw_io_parser.py
@@ -829,33 +829,52 @@ class pipeline:
 
 class xml_metadata_pre:
     # BEGIN _extract_drawio_metadata
+    # override from metadata_extraction.py
     def _extract_drawio_metadata(
         raw_xml: str,
     ) -> tuple[dict[str, str], Optional[str], Optional[str], Optional[Element]]:
-        """Extracts CSV path, base URI, prefixes, and returns parsed XML root."""
+        """Extract CSV path, base URI, prefixes, and return the parsed XML root."""
         try:
             root = fromstring(raw_xml)
-        except Exception:  # pragma: no cover - defensive guard around XML parsing
-            return {}, None, None, None
-
+        except Exception:
+            return ({}, None, None, None)
         metadata_node = root.find(".//mxGraphModel/root/UserObject[@id='0']")
         if metadata_node is None:
-            return {}, None, None, root
-
-        csv_path_raw = metadata_node.attrib.get("csvPath", "")
-        base_uri_raw = metadata_node.attrib.get("baseUri", "")
-
-        csv_path = csv_path_raw.strip() or None
-        base_uri = base_uri_raw.strip() or None
-
+            graph_root = root.find(".//mxGraphModel/root")
+            if graph_root is not None:
+                for candidate in list(graph_root):
+                    tag_lower = candidate.tag.lower()
+                    if tag_lower not in {"userobject", "object"}:
+                        continue
+                    has_metadata_payload = bool(
+                        candidate.attrib.get("csvPath")
+                        or candidate.attrib.get("baseUri")
+                        or any(
+                            (
+                                child.tag
+                                in {
+                                    "userObjectPreambleElement",
+                                    "UserObjectPreambleElement",
+                                }
+                                for child in list(candidate)
+                            )
+                        )
+                    )
+                    if has_metadata_payload:
+                        metadata_node = candidate
+                        break
+        if metadata_node is None:
+            return ({}, None, None, root)
+        csv_path = (metadata_node.attrib.get("csvPath") or "").strip() or None
+        base_uri = (metadata_node.attrib.get("baseUri") or "").strip() or None
         prefixes: dict[str, str] = {}
-        for preamble in metadata_node.findall("userObjectPreambleElement"):
-            prefix = (preamble.attrib.get("rdfPrefix") or "").strip()
-            iri = (preamble.attrib.get("rdfIRI") or "").strip()
-            if prefix and iri:
-                prefixes[prefix] = iri
-
-        return prefixes, base_uri, csv_path, root
+        for tag in ("userObjectPreambleElement", "UserObjectPreambleElement"):
+            for preamble in metadata_node.findall(tag):
+                prefix = (preamble.attrib.get("rdfPrefix") or "").strip()
+                iri = (preamble.attrib.get("rdfIRI") or "").strip()
+                if prefix and iri:
+                    prefixes[prefix] = iri
+        return (prefixes, base_uri, csv_path, root)
 
     # END _extract_drawio_metadata
     # BEGIN _strip_metadata_user_object

--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/metadata_extraction.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/metadata_extraction.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from legacy.draw_io_parser import *  # type: ignore=imported-unused
+from meta_builder.drawio_meta_builder import override
+
+# ruff: noqa: F403, F405
+
+
+@override(phase="pre", type="xml", role="metadata")
+def _extract_drawio_metadata(
+    raw_xml: str,
+) -> tuple[dict[str, str], Optional[str], Optional[str], Optional[Element]]:
+    """Extract CSV path, base URI, prefixes, and return the parsed XML root."""
+    try:
+        root = fromstring(raw_xml)
+    except Exception:  # pragma: no cover - defensive guard around XML parsing
+        return {}, None, None, None
+
+    metadata_node = root.find(".//mxGraphModel/root/UserObject[@id='0']")
+
+    if metadata_node is None:
+        graph_root = root.find(".//mxGraphModel/root")
+        if graph_root is not None:
+            for candidate in list(graph_root):
+                tag_lower = candidate.tag.lower()
+                if tag_lower not in {"userobject", "object"}:
+                    continue
+                has_metadata_payload = bool(
+                    candidate.attrib.get("csvPath")
+                    or candidate.attrib.get("baseUri")
+                    or any(
+                        child.tag
+                        in {"userObjectPreambleElement", "UserObjectPreambleElement"}
+                        for child in list(candidate)
+                    )
+                )
+                if has_metadata_payload:
+                    metadata_node = candidate
+                    break
+
+    if metadata_node is None:
+        return {}, None, None, root
+
+    csv_path = (metadata_node.attrib.get("csvPath") or "").strip() or None
+    base_uri = (metadata_node.attrib.get("baseUri") or "").strip() or None
+
+    prefixes: dict[str, str] = {}
+    for tag in ("userObjectPreambleElement", "UserObjectPreambleElement"):
+        for preamble in metadata_node.findall(tag):
+            prefix = (preamble.attrib.get("rdfPrefix") or "").strip()
+            iri = (preamble.attrib.get("rdfIRI") or "").strip()
+            if prefix and iri:
+                prefixes[prefix] = iri
+
+    return prefixes, base_uri, csv_path, root

--- a/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts
+++ b/src/main/webapp/plugins/rdfexport/tests/utils/patchDrawioWithMetadata.ts
@@ -39,6 +39,44 @@ function createWhitespaceNode(document: Document, value: string): Text {
   return document.createTextNode(value);
 }
 
+function collectExistingPreambleElements(
+  rootElement: Element,
+): DrawioPreambleElement[] {
+  const entries = new Map<string, string>();
+
+  for (const child of collectChildElements(rootElement)) {
+    const tagName = child.tagName?.toLowerCase() ?? "";
+
+    if (tagName !== "userobject" && tagName !== "object") {
+      continue;
+    }
+
+    for (const preamble of collectChildElements(child)) {
+      const preambleTag = preamble.tagName?.toLowerCase() ?? "";
+
+      if (preambleTag !== "userobjectpreambleelement") {
+        continue;
+      }
+
+      const prefix = preamble.getAttribute("rdfPrefix")?.trim();
+      const iri = preamble.getAttribute("rdfIRI")?.trim();
+
+      if (!prefix || !iri) {
+        continue;
+      }
+
+      if (!entries.has(prefix)) {
+        entries.set(prefix, iri);
+      }
+    }
+  }
+
+  return Array.from(entries.entries()).map(([rdfPrefix, rdfIRI]) => ({
+    rdfPrefix,
+    rdfIRI,
+  }));
+}
+
 export function patchDrawioWithMetadata(
   source: string,
   options: DrawioMetadataPatchOptions,
@@ -100,10 +138,18 @@ export function patchDrawioWithMetadata(
 
   metadataNode.appendChild(createWhitespaceNode(document, innerWhitespace));
 
+  const mergedPreamble = new Map<string, string>();
+  for (const existing of collectExistingPreambleElements(rootElement)) {
+    mergedPreamble.set(existing.rdfPrefix, existing.rdfIRI);
+  }
   for (const preambleEntry of options.preamble) {
+    mergedPreamble.set(preambleEntry.rdfPrefix, preambleEntry.rdfIRI);
+  }
+
+  for (const [rdfPrefix, rdfIRI] of mergedPreamble) {
     const preambleNode = document.createElement("userObjectPreambleElement");
-    preambleNode.setAttribute("rdfPrefix", preambleEntry.rdfPrefix);
-    preambleNode.setAttribute("rdfIRI", preambleEntry.rdfIRI);
+    preambleNode.setAttribute("rdfPrefix", rdfPrefix);
+    preambleNode.setAttribute("rdfIRI", rdfIRI);
     metadataNode.appendChild(preambleNode);
     metadataNode.appendChild(createWhitespaceNode(document, innerWhitespace));
   }


### PR DESCRIPTION
## Summary
- add a metadata extraction override that recognises legacy `<object>` wrappers so the flowchart fixtures expose their `kb` prefix again
- merge pre-existing preamble entries when patching DrawIO metadata so regression fixtures keep their legacy namespace declarations
- document the investigation under docs/aicode with runbook notes

## Testing
- bun run test
- bun run check
- pytest legacy/tests/test_patched_parser.py::test_generated_metadata_fixtures_round_trip


------
https://chatgpt.com/codex/tasks/task_e_68fa8960d7b8832daf0a85ce8dce29df