### PR TITLE
Improve pipeline RML templating and preprocessing

### DIFF
--- a/src/main/webapp/plugins/rdfexport/legacy/overrides/serialisers.py
+++ b/src/main/webapp/plugins/rdfexport/legacy/overrides/serialisers.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from rdflib import BNode, SKOS
+import re
+import uuid
+import urllib.parse
+from typing import Any, Dict, Optional, Type
+
+from rdflib import BNode, Graph, Literal, Namespace, SKOS, URIRef
 
 from legacy.draw_io_parser import *  # type: ignore=imported-unused
 from meta_builder.drawio_meta_builder import override
@@ -11,6 +16,10 @@ from meta_builder.drawio_meta_builder import override
 @override(phase="core", type="rdf", role="control")
 class RDFSerializationHelper:
     """Shared helper methods for RDF and RML serialization."""
+
+    _RANGE_PLACEHOLDER_PATTERN = re.compile(
+        r"^(?P<base>[A-Za-z0-9:_-]+)_(?P<start>\d+)\.\.(?P<end>\d+)(?P<suffix>.*)$"
+    )
 
     def __init__(
         self,
@@ -38,6 +47,20 @@ class RDFSerializationHelper:
         self.explicit_overrides: dict[str, URIRef] = {}
 
     @staticmethod
+    def generate_uuid(entity_name: str, base_mapping_iri: str | None = None) -> str:
+        """Generate UUID v5 identical to map_schema implementation."""
+
+        if not entity_name or not entity_name.strip():
+            raise ValueError("entity_name must be a non-empty string")
+
+        base = (
+            base_mapping_iri
+            or "https://data.archives.gov.on.test.gbad.ca/Schema/Mapping"
+        )
+        namespace_source = f"{base}#{entity_name}"
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, namespace_source))
+
+    @staticmethod
     def _is_absolute_iri(candidate: str) -> bool:
         """Check if a string is an absolute IRI."""
         if not candidate or any(ch.isspace() for ch in candidate):
@@ -47,18 +70,50 @@ class RDFSerializationHelper:
         scheme, _, remainder = candidate.partition(":")
         return scheme.lower() in {"urn", "tag"} and bool(remainder.strip())
 
+    @staticmethod
+    def _is_relative_iri(candidate: str) -> bool:
+        """Detect if a string represents a relative IRI."""
+
+        if not candidate or any(ch.isspace() for ch in candidate):
+            return False
+        if candidate.startswith(("/", "#", "./", "../")):
+            return True
+        if ":" not in candidate:
+            return True
+        return False
+
+    def _resolve_iri(self, candidate: str) -> URIRef:
+        """Resolve absolute or relative IRI candidates."""
+
+        if self._is_absolute_iri(candidate):
+            return URIRef(candidate)
+
+        if self._is_relative_iri(candidate):
+            base = self.serialisation_config.prefix_iri or self.prefix_iri
+            if base:
+                return URIRef(urllib.parse.urljoin(f"{base.rstrip('/')}/", candidate))
+            if self.fallback_namespace is not None:
+                return self.fallback_namespace[candidate.lstrip("/#")]
+
+        return URIRef(candidate)
+
+    def _resolve_namespace_uri(self, raw_uri: str) -> Namespace:
+        if self._is_absolute_iri(raw_uri):
+            return Namespace(raw_uri)
+        if self._is_relative_iri(raw_uri) and self.prefix_iri:
+            resolved = urllib.parse.urljoin(f"{self.prefix_iri.rstrip('/')}/", raw_uri)
+            return Namespace(resolved)
+        if self.fallback_namespace is not None:
+            return self.fallback_namespace
+        raise ParseException(f"Prefix IRI '{raw_uri}' looks invalid")
+
     def setup_namespaces(self) -> None:
         """Bind namespaces to the graph."""
         if self.prefix_iri and self._is_absolute_iri(self.prefix_iri):
             self.fallback_namespace = Namespace(self.prefix_iri)
 
         for prefix_key, uri in self.prefixes.items():
-            if self._is_absolute_iri(uri):
-                namespace = Namespace(uri)
-            elif self.fallback_namespace is not None:
-                namespace = self.fallback_namespace
-            else:
-                raise ParseException(f"Prefix IRI '{uri}' looks invalid")
+            namespace = self._resolve_namespace_uri(uri)
 
             self.graph.bind(prefix_key, namespace, replace=True)
             self.namespace_map[prefix_key] = namespace
@@ -131,9 +186,58 @@ class RDFSerializationHelper:
         elif self.prefix and self.serialisation_config.prefix_iri:
             return Namespace(self.serialisation_config.prefix_iri)[individual_id]
         elif self.prefix_iri:
-            return URIRef(f"{self.prefix_iri}{individual_id}")
+            return self._resolve_iri(individual_id)
         else:
             return URIRef(individual_id)
+
+    @staticmethod
+    def _decode_value(value: str) -> str:
+        return urllib.parse.unquote(value)
+
+    def _canonicalize_placeholder(self, placeholder: str) -> str:
+        match = self._RANGE_PLACEHOLDER_PATTERN.match(placeholder)
+        if match:
+            base = match.group("base")
+            suffix = match.group("suffix")
+            return f"{base}{suffix}" if suffix else base
+
+        replacements = {
+            "REFD_FILE": "REF_FILE",
+        }
+        return replacements.get(placeholder, placeholder)
+
+    def _parse_template_value(self, raw: str) -> tuple[str, set[str]]:
+        placeholders: set[str] = set()
+        result: list[str] = []
+        idx = 0
+        length = len(raw)
+
+        while idx < length:
+            char = raw[idx]
+            if char == "{" and idx + 1 < length and raw[idx + 1] == "{":
+                result.append("{")
+                idx += 2
+                continue
+            if char == "}" and idx + 1 < length and raw[idx + 1] == "}":
+                result.append("}")
+                idx += 2
+                continue
+            if char == "{":
+                closing = raw.find("}", idx + 1)
+                if closing == -1:
+                    result.append(char)
+                    idx += 1
+                    continue
+                placeholder = raw[idx + 1 : closing]
+                canonical = self._canonicalize_placeholder(placeholder)
+                placeholders.add(canonical)
+                result.append("{" + canonical + "}")
+                idx = closing + 1
+                continue
+            result.append(char)
+            idx += 1
+
+        return "".join(result), placeholders
 
     def coerce_to_literal(self, value: Any) -> Literal:
         """Convert a value to a typed Literal."""
@@ -265,10 +369,15 @@ class RMLSerializer(RDFSerializationHelper):
         self.graph.bind("ql", self.ql, replace=False)
         self.graph.bind("rdfs", RDFS, replace=False)
 
-    def _add_constant_object_map(
-        self, predicate_map_owner: Any, predicate_uri: URIRef, constant: Any
+    def _add_object_map(
+        self,
+        predicate_map_owner: Any,
+        predicate_uri: URIRef,
+        value: Any,
+        *,
+        is_literal: bool,
     ) -> None:
-        """Add a constant object map to a predicate-object map."""
+        """Add an object map supporting constants and templates."""
         predicate_object_map = BNode()
         self.graph.add(
             (predicate_map_owner, self.rr.predicateObjectMap, predicate_object_map)
@@ -277,18 +386,32 @@ class RMLSerializer(RDFSerializationHelper):
 
         object_map = BNode()
         self.graph.add((predicate_object_map, self.rr.objectMap, object_map))
-        self.graph.add((object_map, self.rr.constant, constant))
+        term_type = self.rr.Literal if is_literal else self.rr.IRI
 
-        if isinstance(constant, URIRef):
-            self.graph.add((object_map, self.rr.termType, self.rr.IRI))
-        elif isinstance(constant, Literal):
-            self.graph.add((object_map, self.rr.termType, self.rr.Literal))
-            if constant.datatype:
-                self.graph.add((object_map, self.rr.datatype, constant.datatype))
-            if constant.language:
-                self.graph.add(
-                    (object_map, self.rr.language, Literal(constant.language))
-                )
+        if isinstance(value, Literal):
+            constant = value
+        elif isinstance(value, URIRef):
+            constant = value
+        else:
+            decoded = self._decode_value(str(value))
+            template, placeholders = self._parse_template_value(decoded)
+            if placeholders:
+                self.graph.add((object_map, self.rr.template, Literal(template)))
+                self.graph.add((object_map, self.rr.termType, term_type))
+                return
+
+            if is_literal:
+                constant = self.coerce_to_literal(decoded)
+            else:
+                constant = self._resolve_iri(decoded)
+
+        self.graph.add((object_map, self.rr.constant, constant))
+        self.graph.add((object_map, self.rr.termType, term_type))
+
+        if isinstance(constant, Literal) and constant.datatype:
+            self.graph.add((object_map, self.rr.datatype, constant.datatype))
+        if isinstance(constant, Literal) and constant.language:
+            self.graph.add((object_map, self.rr.language, Literal(constant.language)))
 
     def _get_logical_source_value(self) -> Literal:
         """Determine the logical source value for RML mappings."""
@@ -320,8 +443,16 @@ class RMLSerializer(RDFSerializationHelper):
         # Add subject map
         subject_map = BNode()
         self.graph.add((triples_map, self.rr.subjectMap, subject_map))
-        self.graph.add((subject_map, self.rr.termType, self.rr.IRI))
-        self.graph.add((subject_map, self.rr.constant, subject_uri))
+
+        subject_value = self._decode_value(str(subject_uri))
+        template, placeholders = self._parse_template_value(subject_value)
+        if placeholders:
+            self.graph.add((subject_map, self.rr.template, Literal(template)))
+            self.graph.add((subject_map, self.rr.termType, self.rr.IRI))
+        else:
+            resolved_subject = self._resolve_iri(subject_value)
+            self.graph.add((subject_map, self.rr.constant, resolved_subject))
+            self.graph.add((subject_map, self.rr.termType, self.rr.IRI))
 
         # Add RDF types as rr:class
         for rdf_type in sorted(types_and_facts.get("Types", set())):
@@ -331,8 +462,11 @@ class RMLSerializer(RDFSerializationHelper):
 
         # Add label if configured
         if self.serialisation_config.include_label:
-            self._add_constant_object_map(
-                triples_map, RDFS.label, Literal(individual_label)
+            self._add_object_map(
+                triples_map,
+                RDFS.label,
+                Literal(individual_label),
+                is_literal=True,
             )
 
         # Add properties
@@ -361,13 +495,16 @@ class RMLSerializer(RDFSerializationHelper):
                     )
 
                 if not is_literal:
-                    # Object property
-                    target_uri = self.resolve_individual_uri(str(value))
-                    self._add_constant_object_map(triples_map, prop_uri, target_uri)
+                    target_value = value
                 else:
-                    # Datatype property
-                    literal_value = self.coerce_to_literal(value)
-                    self._add_constant_object_map(triples_map, prop_uri, literal_value)
+                    target_value = value
+
+                self._add_object_map(
+                    triples_map,
+                    prop_uri,
+                    target_value,
+                    is_literal=is_literal,
+                )
 
     def serialize_all_individuals(self) -> None:
         """Serialize all individuals as RML mappings."""

--- a/src/main/webapp/plugins/rdfexport/rmlmapper_workflows/pipeline_workflow.py
+++ b/src/main/webapp/plugins/rdfexport/rmlmapper_workflows/pipeline_workflow.py
@@ -35,6 +35,9 @@ from .map_schema_workflow import (  # type: ignore  # noqa: E402
 )
 
 import legacy.map_schema as legacy_map_schema  # type: ignore  # noqa: E402
+from legacy.overrides.serialisers import (  # type: ignore  # noqa: E402
+    RDFSerializationHelper,
+)
 
 
 class PipelineCSVPreprocessor(SourceCSVPreprocessor):
@@ -43,7 +46,7 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
     INCREMENT_COLUMN = "INCREMENT_NUMBER"
     RICO_AUTHTP_CLASS_COLUMN = "RICO_AUTHTP_CLASS"
     RICO_AUTHTP_TERM_COLUMN = "RICO_AUTHTP_TERM"
-    
+
     _SUFFIX_PATTERN = re.compile(
         r"^(?P<prefix>.+?)_(?P<number>\d+)(?P<suffix>(?:_.+)?)$"
     )
@@ -52,7 +55,7 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
         self,
         source_csv_path: str,
         preprocessed_csv_path: str,
-        schema_code: Literal['add','auth'],
+        schema_code: Literal["add", "auth"],
         *,
         index_col: str | bool = False,
         **kwargs,
@@ -65,13 +68,17 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
         self._schema_code = schema_code
         self._rico_authtp_patterns = self._compile_rico_patterns()
         # Auth-specific
-        self._correct_dateex_path = kwargs.get('correct_dateex_path')
+        self._correct_dateex_path = kwargs.get("correct_dateex_path")
+        self._creation_relation_uuid = self._build_creation_relation_uuid_lookup()
+        self._instantiation_uuid = RDFSerializationHelper.generate_uuid(
+            "rr_template___KB_Instantiation__REFD__urn_uuid__UUID_INSTANTIATION_1__"
+        )
 
     def run(self) -> Path:
         """Execute preprocessing and return the path to the written CSV."""
-        if self._schema_code == 'auth':
+        if self._schema_code == "auth":
             self._auth_preprocess()
-        elif self._schema_code == 'add':
+        elif self._schema_code == "add":
             self._add_preprocess()
 
         processed = self._normalise_increment_columns(self.source_df.copy())
@@ -79,10 +86,10 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
             "Int64"
         )
         self.source_df = processed
-        
+
         super().dump()
         return Path(self.preprocessed_csv_path)
-    
+
     # Overrides original
     def column_split(self, split_method, joint_col, separate_cols_list):
         mask = self.source_df[joint_col].notna()
@@ -98,10 +105,12 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
             columns=separate_cols_list,
         )
         # Drop existing columns first to avoid duplicates
-        self.source_df = self.source_df.drop(columns=[col for col in separate_cols_list if col in self.source_df.columns])
+        self.source_df = self.source_df.drop(
+            columns=[col for col in separate_cols_list if col in self.source_df.columns]
+        )
         self.source_df = pd.concat([self.source_df, split_df], axis=1)
         print(f"Splitting column '{joint_col}' into {separate_cols_list}\n")
-    
+
     ### Auth-specific processing ###
     def _auth_preprocess(self):
         self._annotate_rico_authtp()
@@ -110,12 +119,14 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
     def _annotate_rico_authtp(self):
         """Annotate with RiC-O AUTHTP class and term based on AUTHTP column."""
         if "AUTHTP" not in self.source_df.columns:
-            self.add(self.RICO_AUTHTP_CLASS_COLUMN, pd.Series(
-                [None] * len(self.source_df), dtype="object"
-            ))
-            self.add(self.RICO_AUTHTP_TERM_COLUMN, pd.Series(
-                [None] * len(self.source_df), dtype="object"
-            ))
+            self.add(
+                self.RICO_AUTHTP_CLASS_COLUMN,
+                pd.Series([None] * len(self.source_df), dtype="object"),
+            )
+            self.add(
+                self.RICO_AUTHTP_TERM_COLUMN,
+                pd.Series([None] * len(self.source_df), dtype="object"),
+            )
             return
 
         def _resolve(value: object) -> tuple[str | None, str | None]:
@@ -134,56 +145,68 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
         results = self.get(["AUTHTP"]).map(_resolve)
         self.add(self.RICO_AUTHTP_CLASS_COLUMN, results.apply(lambda x: x[0]))
         self.add(self.RICO_AUTHTP_TERM_COLUMN, results.apply(lambda x: x[1]))
-    
+
     def _pull_correct_dateex(self):
-        DATEEX_COLS = ['DATEEX_BEGINNING', 'DATEEX_END']
+        DATEEX_COLS = ["DATEEX_BEGINNING", "DATEEX_END"]
         SISN = "SISN"
         correct_dateex_path = self._correct_dateex_path
         if correct_dateex_path is None:
             return
         try:
             correct_dateex_name = Path(correct_dateex_path).name
-            correct_dateex_df = pd.read_csv(correct_dateex_path, index_col=SISN, dtype='object')
+            correct_dateex_df = pd.read_csv(
+                correct_dateex_path, index_col=SISN, dtype="object"
+            )
             self.update(correct_dateex_df[DATEEX_COLS])
-            
-            print(f"Source preprocessed by updating {DATEEX_COLS} with values from '{correct_dateex_name}'\n")
+
+            print(
+                f"Source preprocessed by updating {DATEEX_COLS} with values from '{correct_dateex_name}'\n"
+            )
         except Exception as e:
             print(f"Failed to update Authority DATEEX with correct values: '{e}'")
 
     ### ADD-specific processing ###
     def _add_preprocess(self):
-        DATEOFF_COLNAME = 'DATEOFF'
-        DATE_BEGINNING_SUFFIX = '_BEGINNING'
-        DATE_END_SUFFIX = '_END'
+        DATEOFF_COLNAME = "DATEOFF"
+        DATE_BEGINNING_SUFFIX = "_BEGINNING"
+        DATE_END_SUFFIX = "_END"
 
         # Column split #1
-        joint_findaid_col = 'FINDAID:FINDAIDLINK:FINDAID_URL'
-        separate_findaid_cols = ['FINDAID', 'FINDAIDLINK', 'FINDAID_URL']
-        self.column_split(self._split_by_colon, joint_findaid_col, separate_findaid_cols)
+        joint_findaid_col = "FINDAID:FINDAIDLINK:FINDAID_URL"
+        separate_findaid_cols = ["FINDAID", "FINDAIDLINK", "FINDAID_URL"]
+        self.column_split(
+            self._split_by_colon, joint_findaid_col, separate_findaid_cols
+        )
 
         # Column split #2
-        joint_iil_col = 'IIL:IIL_URL'
-        separate_iil_cols = ['IIL', 'IIL_URL']
+        joint_iil_col = "IIL:IIL_URL"
+        separate_iil_cols = ["IIL", "IIL_URL"]
         self.column_split(self._split_by_colon, joint_iil_col, separate_iil_cols)
 
         # Column split #3
-        indexprov_col = 'INDEXPROV'
+        indexprov_col = "INDEXPROV"
         numbered_indexprov_cols = [f"{indexprov_col}_{i}" for i in range(1, 31)]
-        self.column_split(self._split_by_adjacent_case, indexprov_col, numbered_indexprov_cols)
+        self.column_split(
+            self._split_by_adjacent_case, indexprov_col, numbered_indexprov_cols
+        )
 
         # Column split #4
-        indexname_col = 'INDEXNAME'
+        indexname_col = "INDEXNAME"
         numbered_indexname_cols = [f"{indexname_col}_{i}" for i in range(1, 31)]
-        self.column_split(self._split_by_adjacent_case, indexname_col, numbered_indexname_cols)
+        self.column_split(
+            self._split_by_adjacent_case, indexname_col, numbered_indexname_cols
+        )
 
         # Column split #5
-        indexsub_col = 'INDEXSUB'
+        indexsub_col = "INDEXSUB"
         numbered_indexsub_cols = [f"{indexsub_col}_{i}" for i in range(1, 31)]
-        self.column_split(self._split_by_adjacent_case, indexsub_col, numbered_indexsub_cols)
+        self.column_split(
+            self._split_by_adjacent_case, indexsub_col, numbered_indexsub_cols
+        )
 
         # Column split #6
-        joint_office_col = 'DATEOFF:OFFICEAB:AB_REFA:OFFICEC:C_REFA'
-        separate_office_cols = ['DATEOFF', 'OFFICEAB', 'AB_REFA', 'OFFICEC', 'C_REFA']
+        joint_office_col = "DATEOFF:OFFICEAB:AB_REFA:OFFICEC:C_REFA"
+        separate_office_cols = ["DATEOFF", "OFFICEAB", "AB_REFA", "OFFICEC", "C_REFA"]
         numbered_office_cols = []
         for i in range(1, 21):
             numbered_office_cols.extend([f"{col}_{i}" for col in separate_office_cols])
@@ -191,66 +214,83 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
         self.column_split(self._split_by_colon, joint_office_col, numbered_office_cols)
 
         # Column split #7
-        joint_dateoff_colnames = [f'{DATEOFF_COLNAME}_{i}' for i in range(1, 21)]
+        joint_dateoff_colnames = [f"{DATEOFF_COLNAME}_{i}" for i in range(1, 21)]
         for col in joint_dateoff_colnames:
-            separate_dateoff_cols = [f"{col}{DATE_BEGINNING_SUFFIX}", f"{col}{DATE_END_SUFFIX}"]
+            separate_dateoff_cols = [
+                f"{col}{DATE_BEGINNING_SUFFIX}",
+                f"{col}{DATE_END_SUFFIX}",
+            ]
             self.column_split(self._split_by_hyphen, col, separate_dateoff_cols)
 
         # Column logic (not split) #8, co-created with Claude 3.7 Sonnet on 2025-04-21
         for i in range(1, 21):
             # REFA based (main) logic
-            ab_refa_colname = f'AB_REFA_{i}'
-            c_refa_colname = f'C_REFA_{i}'
-            abc_refa_colname = f'ABC_REFA_{i}'
+            ab_refa_colname = f"AB_REFA_{i}"
+            c_refa_colname = f"C_REFA_{i}"
+            abc_refa_colname = f"ABC_REFA_{i}"
             refa_df = self.get([ab_refa_colname, c_refa_colname])
-            abc_refa_series = refa_df[c_refa_colname].combine_first(refa_df[ab_refa_colname])
+            abc_refa_series = refa_df[c_refa_colname].combine_first(
+                refa_df[ab_refa_colname]
+            )
             self.add(abc_refa_colname, abc_refa_series)
 
             # 1. OFFICE_TYPE: determine by first character
-            office_type_colname = f'OFFICE_TYPE_{i}'
-            office_type_series = abc_refa_series.str[0].str.upper().map(
-                lambda x: x if x in {'A', 'B', 'C'} else None
+            office_type_colname = f"OFFICE_TYPE_{i}"
+            office_type_series = (
+                abc_refa_series.str[0]
+                .str.upper()
+                .map(lambda x: x if x in {"A", "B", "C"} else None)
             )
             self.add(office_type_colname, office_type_series)
 
             # 2. OFFICEABC: pick office_ab or office_c based on office type
-            officeab_colname = f'OFFICEAB_{i}'
-            officec_colname = f'OFFICEC_{i}'
-            officeabc_colname = f'OFFICEABC_{i}'
+            officeab_colname = f"OFFICEAB_{i}"
+            officec_colname = f"OFFICEC_{i}"
+            officeabc_colname = f"OFFICEABC_{i}"
             office_df = self.get([officeab_colname, officec_colname])
-            
+
             # Initialize the result series with None values (same index as other series)
-            officeabc_series = pd.Series(None, index=office_df.index, dtype='object')
-            
+            officeabc_series = pd.Series(None, index=office_df.index, dtype="object")
+
             # Fill in values based on office type
             # For A or B types, use OFFICEAB
-            officeabc_series.loc[office_type_series.isin(['A', 'B'])] = office_df.loc[office_type_series.isin(['A', 'B']), officeab_colname]
-            
+            officeabc_series.loc[office_type_series.isin(["A", "B"])] = office_df.loc[
+                office_type_series.isin(["A", "B"]), officeab_colname
+            ]
+
             # For C type, use OFFICEC
-            officeabc_series.loc[office_type_series == 'C'] = office_df.loc[office_type_series == 'C', officec_colname]
+            officeabc_series.loc[office_type_series == "C"] = office_df.loc[
+                office_type_series == "C", officec_colname
+            ]
 
             # Add the combined series to the preprocessor
             self.add(officeabc_colname, officeabc_series)
 
     def _split_by_colon(self, value: str, expect_num_cols: int):
-        SEP = ' : '
+        SEP = " : "
+
         def fix_colon_spacing(value: str) -> str:
-            while ': :' in value:
-                value = value.replace(': :', ':  :')
-            value = value[:-2] if value.endswith(' :') else value  # to fix any ending colon
-            value = value[2:] if value.startswith(': ') else value  # to fix any starting colon
+            while ": :" in value:
+                value = value.replace(": :", ":  :")
+            value = (
+                value[:-2] if value.endswith(" :") else value
+            )  # to fix any ending colon
+            value = (
+                value[2:] if value.startswith(": ") else value
+            )  # to fix any starting colon
             return value
+
         return self.separate_value(fix_colon_spacing(value), expect_num_cols, sep=SEP)
-    
+
     def _split_by_adjacent_case(self, value: str, expect_num_cols: int):
-        unique_separator = '<split-by-adjacent-case>'
-        value = re.sub(r'([^A-Z\s\(\[])([A-Z])', rf'\1{unique_separator}\2', value)
+        unique_separator = "<split-by-adjacent-case>"
+        value = re.sub(r"([^A-Z\s\(\[])([A-Z])", rf"\1{unique_separator}\2", value)
         return self.separate_value(value, expect_num_cols, sep=unique_separator)
-    
+
     def _split_by_hyphen(self, value: str, expect_num_cols: int):
-        if re.fullmatch(r'\d{4}-\d{4}', value) is None:
-            value = ''  # won't try to separate these for now
-        return self.separate_value(value, expect_num_cols, sep='-')
+        if re.fullmatch(r"\d{4}-\d{4}", value) is None:
+            value = ""  # won't try to separate these for now
+        return self.separate_value(value, expect_num_cols, sep="-")
 
     ### Shared Auth/ADD processing ###
     def _compile_rico_patterns(self) -> list[tuple[str, tuple[str, re.Pattern[str]]]]:
@@ -263,11 +303,21 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
             patterns.append((label, (term, re.compile(pythonic))))
         return patterns
 
+    def _build_creation_relation_uuid_lookup(self) -> dict[int, str]:
+        base_lookup: dict[int, str] = {}
+        for increment in range(1, 21):
+            entity_name = (
+                f"rr_template___KB_CreationRelation__REFD__OFFICEABC_{increment}__"
+                "urn_uuid__UUID_OFFICEABC__"
+            )
+            base_lookup[increment] = RDFSerializationHelper.generate_uuid(entity_name)
+        return base_lookup
+
     def _normalise_increment_columns(self, frame: pd.DataFrame) -> pd.DataFrame:
         """Normalise incremented columns by creating rows per increment number."""
         frame.reset_index(inplace=True)
         increment_groups = self._collect_increment_groups(frame.columns)
-        
+
         if not increment_groups:
             frame[self.INCREMENT_COLUMN] = pd.Series(
                 [pd.NA] * len(frame), dtype="Int64"
@@ -284,11 +334,11 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
         ]
 
         records: list[dict[str, object]] = []
-        
+
         for _, row in frame.iterrows():
             # Find max increment number with actual data in this row
             max_increment = self._get_max_increment_with_data(row, increment_groups)
-            
+
             if max_increment is None:
                 # No incremented data in this row, create single row with no increment
                 record: dict[str, object] = {
@@ -299,14 +349,18 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
                     record[base] = None
                 records.append(record)
                 continue
-            
+
             # Create rows for each increment number from 1 to max
             for increment_num in range(1, max_increment + 1):
                 record: dict[str, object] = {
                     column: row[column] for column in non_increment_columns
                 }
                 record[self.INCREMENT_COLUMN] = increment_num
-                
+                record["UUID_OFFICEABC"] = self._creation_relation_uuid.get(
+                    increment_num
+                )
+                record["UUID_INSTANTIATION_1"] = self._instantiation_uuid
+
                 # Check if this increment has any data
                 has_data = False
                 for base, mapping in increment_groups.items():
@@ -320,25 +374,67 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
                             record[base] = None
                     else:
                         record[base] = None
-                
+
                 # Only keep this row if it has at least one value from incremented columns
                 if has_data:
                     records.append(record)
 
         normalised = pd.DataFrame.from_records(records)
-        
+
+        if not normalised.empty:
+            normalised = self._augment_placeholder_columns(normalised)
+
         # Order columns: non-increment cols, INCREMENT_COLUMN, then base columns
         ordered_columns = non_increment_columns + [self.INCREMENT_COLUMN]
         for base in increment_groups.keys():
             if base not in ordered_columns:
                 ordered_columns.append(base)
+        for extra in [
+            "UUID_OFFICEABC",
+            "UUID_INSTANTIATION_1",
+        ]:
+            if extra not in ordered_columns and extra in normalised.columns:
+                ordered_columns.append(extra)
         for column in normalised.columns:
             if column not in ordered_columns:
                 ordered_columns.append(column)
-        
+
         normalised = normalised.reindex(columns=ordered_columns)
         normalised.set_index(self.index_col, inplace=True)
         return normalised
+
+    def _augment_placeholder_columns(self, frame: pd.DataFrame) -> pd.DataFrame:
+        frame = frame.copy()
+
+        if "REF_FILE" in frame.columns and "REFD_FILE" not in frame.columns:
+            frame["REFD_FILE"] = frame["REF_FILE"]
+
+        mirror_columns: dict[str, str] = {
+            "GMD_1..8": "GMD",
+            "INDEXPROV_1..20": "INDEXPROV",
+            "INDEXNAME_1..20": "INDEXNAME",
+            "INDEXSUB_1..20": "INDEXSUB",
+            "INDEXGEO_1..20": "INDEXGEO",
+            "OFFICEABC_1..20": "OFFICEABC",
+            "ABC_REFA_1..20": "ABC_REFA",
+            "DATEOFF_1..20": "DATEOFF",
+            "DATEOFF_1..20_BEGINNING": "DATEOFF_BEGINNING",
+            "DATEOFF_1..20_END": "DATEOFF_END",
+        }
+
+        for target, source in mirror_columns.items():
+            if source in frame.columns and target not in frame.columns:
+                frame[target] = frame[source]
+
+        if "UUID_INSTANTIATION_1" not in frame.columns:
+            frame["UUID_INSTANTIATION_1"] = self._instantiation_uuid
+
+        if "UUID_OFFICEABC" not in frame.columns:
+            frame["UUID_OFFICEABC"] = frame[self.INCREMENT_COLUMN].map(
+                self._creation_relation_uuid
+            )
+
+        return frame
 
     def _collect_increment_groups(
         self, columns: pd.Index | list[str]
@@ -371,6 +467,7 @@ class PipelineCSVPreprocessor(SourceCSVPreprocessor):
                     if max_increment is None or number > max_increment:
                         max_increment = number
         return max_increment
+
 
 @dataclass
 class PipelineWorkflowResult:

--- a/src/main/webapp/plugins/rdfexport/rmlmapper_workflows/tests/test_pipeline_preprocessor.py
+++ b/src/main/webapp/plugins/rdfexport/rmlmapper_workflows/tests/test_pipeline_preprocessor.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+if str(PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(PLUGIN_ROOT))
+
+import pandas as pd  # noqa: E402
+
+from rmlmapper_workflows.pipeline_workflow import (  # noqa: E402
+    PipelineCSVPreprocessor,
+)
+
+
+def test_normalise_increment_columns_populates_placeholder_columns(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source.csv"
+    destination = tmp_path / "dest.csv"
+
+    data = pd.DataFrame(
+        [
+            {
+                "SISN": "row-1",
+                "REF_FILE": "REF-A",
+                "INDEXPROV_1": "prov-a",
+                "INDEXNAME_1": "name-a",
+                "INDEXSUB_1": "sub-a",
+                "INDEXGEO_1": "geo-a",
+                "OFFICEABC_1": "office-a",
+                "ABC_REFA_1": "refa-a",
+                "DATEOFF_1": "1999-01-01 - 1999-12-31",
+                "DATEOFF_1_BEGINNING": "1999-01-01",
+                "DATEOFF_1_END": "1999-12-31",
+                "GMD_1": "Textual records",
+            },
+            {
+                "SISN": "row-2",
+                "REF_FILE": "REF-B",
+                "INDEXPROV_2": "prov-b",
+                "INDEXNAME_2": "name-b",
+                "INDEXSUB_2": "sub-b",
+                "INDEXGEO_2": "geo-b",
+                "OFFICEABC_2": "office-b",
+                "ABC_REFA_2": "refa-b",
+                "DATEOFF_2": "2000-01-01 - 2000-12-31",
+                "DATEOFF_2_BEGINNING": "2000-01-01",
+                "DATEOFF_2_END": "2000-12-31",
+                "GMD_2": "Microfilm",
+            },
+        ]
+    )
+    data.to_csv(source, index=False)
+
+    preprocessor = PipelineCSVPreprocessor(
+        str(source),
+        str(destination),
+        schema_code="add",
+        index_col="SISN",
+    )
+    preprocessor.source_df = data.copy()
+
+    normalised = preprocessor._normalise_increment_columns(data.copy())
+    normalised = normalised.reset_index()
+
+    assert "REFD_FILE" in normalised.columns
+    assert list(normalised["REFD_FILE"]) == ["REF-A", "REF-B"]
+
+    assert "INDEXPROV_1..20" in normalised.columns
+    assert normalised.loc[0, "INDEXPROV_1..20"] == "prov-a"
+    assert normalised.loc[1, "INDEXPROV_1..20"] == "prov-b"
+
+    assert "DATEOFF_1..20_BEGINNING" in normalised.columns
+    assert normalised.loc[0, "DATEOFF_1..20_BEGINNING"] == "1999-01-01"
+
+    assert "UUID_INSTANTIATION_1" in normalised.columns
+    assert normalised["UUID_INSTANTIATION_1"].nunique() == 1
+
+    assert "UUID_OFFICEABC" in normalised.columns
+    assert normalised.loc[0, "UUID_OFFICEABC"] != normalised.loc[1, "UUID_OFFICEABC"]

--- a/src/main/webapp/plugins/rdfexport/rmlmapper_workflows/tests/test_pipeline_workflow.py
+++ b/src/main/webapp/plugins/rdfexport/rmlmapper_workflows/tests/test_pipeline_workflow.py
@@ -150,8 +150,10 @@ def test_pipeline_workflow_general_authority(
     )
 
     pipeline_result = run_pipeline_workflow(
-        pipeline_config, rmlmapper_env, workspace_base=tmp_path,
-        correct_dateex_path='tmp/New-export-of-Government-authorities-with-correct-Dates-of-Existence-xlsx.csv',
+        pipeline_config,
+        rmlmapper_env,
+        workspace_base=tmp_path,
+        correct_dateex_path="tmp/New-export-of-Government-authorities-with-correct-Dates-of-Existence-xlsx.csv",
     )
     map_result = run_map_schema_workflow(
         map_schema_config, rmlmapper_env, workspace_base=tmp_path


### PR DESCRIPTION
## Summary
- add template-aware RML serialization utilities, including relative IRI handling and deterministic UUID helpers
- extend the pipeline CSV preprocessor to populate UUID and placeholder-friendly columns for normalized artifacts
- add pytest coverage to ensure the preprocessor generates the expected columns after normalization

## Testing
- pytest rmlmapper_workflows/tests/test_pipeline_preprocessor.py
- bun run check
- bun run test:log:linux *(fails: bun integration suite currently reports known failures)*
- bun run test:all:log:linux *(aborted: command was interrupted due to runtime)*

------
https://chatgpt.com/codex/tasks/task_e_69059992675c832d8854e33dab70075e